### PR TITLE
docs: fix TOML example to use auth_type instead of type

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -8,11 +8,11 @@
 //! ```toml
 //! [default]
 //! api_key = "sk-..."
-//! type = "bearer"
+//! auth_type = "bearer"
 //!
 //! [production]
 //! api_key = "sk-prod-..."
-//! type = "bearer"
+//! auth_type = "bearer"
 //! ```
 
 use anyhow::{Context, Result};


### PR DESCRIPTION
This fixes a documentation issue pointed out by Copilot in PR #37.

## Issue
The module documentation example showed `type = "bearer"` but the actual TOML field name is `auth_type` because the struct field is named `auth_type` without a `#[serde(rename = "type")]` attribute.

## Changes
- Updated documentation example to use `auth_type` instead of `type`
- This makes the documentation match the actual TOML serialization format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>