### PR TITLE
test: remove duplicate test case for profile validation

### DIFF
--- a/tests/auth_integration_test.rs
+++ b/tests/auth_integration_test.rs
@@ -344,7 +344,7 @@ fn test_profile_name_validation_invalid_characters() {
     let result = profiles.set_profile("test/profile".to_string(), profile.clone());
     assert!(result.is_err());
 
-    let result = profiles.set_profile("test.profile".to_string(), profile.clone());
+    let result = profiles.set_profile("test+profile".to_string(), profile.clone());
     assert!(result.is_err());
 
     let result = profiles.set_profile("test@profile".to_string(), profile.clone());


### PR DESCRIPTION
Fixes a duplicate test case pointed out by Copilot in PR #37.

## Issue
The test `test_profile_name_validation_invalid_characters` was testing
"test.profile" twice (lines 326 and 332 in the old PR), which was redundant.

## Changes
- Changed the duplicate test from "test.profile" to "test+profile"
- This improves test coverage by testing an additional invalid character (+)
- All 5 tests now check different invalid characters:
  1. Space in "test profile"
  2. Dot in "test.profile"
  3. Slash in "test/profile"
  4. Plus sign in "test+profile" (changed from duplicate dot)
  5. At sign in "test@profile"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>