### PR TITLE
docs: correct getrandom version in Cargo.toml comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ prost-types = "0.12"
 [dev-dependencies]
 tokio-test = "0.4"
 mockito = "1.2"
-# tempfile 3.10 has issues with getrandom 0.4, use older version
+# tempfile 3.10 has issues with this project's pinned getrandom 0.2, use older version
 tempfile = ">=3.8, <3.10"
 
 [build-dependencies]


### PR DESCRIPTION
Fixes an inaccurate comment pointed out by Copilot in PR #37.

## Issue
The comment on line 69 mentioned 'getrandom 0.4' but the project actually
pins getrandom to version 0.2 (line 15).

## Changes
- Updated comment to say 'getrandom 0.2' instead of 'getrandom 0.4'
- Clarified that it's 'this project's pinned getrandom 0.2'
- This makes the documentation consistent with the actual dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>