### PR TITLE
fix: ensure consistent AuthType serialization across all contexts

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -71,6 +71,7 @@ impl<'de> serde::Deserialize<'de> for AuthType {
 }
 
 impl Default for AuthType {
+    #[allow(clippy::derivable_impls)]
     fn default() -> Self {
         Self::Bearer
     }


### PR DESCRIPTION
Fixes AuthType serialization inconsistency pointed out by Copilot in PR #37.

## Problem
There was an inconsistency in AuthType serialization:
- `#[serde(rename_all = "lowercase")]` serialized `ApiKey` as "apikey"
- `Display` outputted "api_key" (with underscore)  
- `FromStr` accepted "api_key" (with underscore)

This meant TOML files would contain `auth_type = "apikey"` but the
CLI expected `auth_type = "api_key"`.

## Solution
- Removed `#[serde(rename_all = "lowercase")]` attribute
- Manually implemented `Serialize` and `Deserialize` traits
- Now consistently uses snake_case ("api_key") across all contexts

## Testing
All tests pass with `--test-threads=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>