### PR TITLE
feat: support OpenAPI schema-separated services with mapping + --schema-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ UXC uses protocol-native, machine-friendly `operation_id` values:
 # List available operations
 uxc https://api.example.com list
 
+# Schema-separated service: runtime endpoint and schema URL are different
+uxc https://api.github.com list \
+  --schema-url https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
+
 # Get operation help
 uxc https://api.example.com describe get:/users/{id}
 uxc https://api.example.com get:/users/{id} help
@@ -345,12 +349,43 @@ UXC determines the protocol via lightweight probing:
 
 1. Attempt MCP stdio/HTTP discovery
 2. Attempt GraphQL introspection
-3. Check OpenAPI endpoints
+3. Check OpenAPI schema sources:
+   - `--schema-url` override
+   - user/builtin schema mappings
+   - default well-known OpenAPI endpoints (`/openapi.json`, `/swagger.json`, etc.)
 4. Attempt JSON-RPC OpenRPC discovery
 5. Attempt gRPC reflection
 6. Fallback or fail gracefully
 
 Each protocol is handled by a dedicated adapter.
+
+### OpenAPI Schema Mapping
+
+For services where the OpenAPI document is hosted separately from the runtime endpoint
+(for example `api.github.com`), UXC supports:
+
+1. Explicit override via `--schema-url`
+2. Builtin mappings for known services
+3. User mappings in `~/.uxc/schema_mappings.json`
+
+Example user mapping file:
+
+```json
+{
+  "version": 1,
+  "openapi": [
+    {
+      "host": "api.github.com",
+      "path_prefix": "/",
+      "schema_url": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
+      "priority": 100
+    }
+  ]
+}
+```
+
+For tests or custom environments, the mapping file path can be overridden via:
+`UXC_SCHEMA_MAPPINGS_FILE=/path/to/schema_mappings.json`.
 
 ---
 

--- a/docs/schema-mapping.md
+++ b/docs/schema-mapping.md
@@ -1,0 +1,67 @@
+# OpenAPI Schema Mapping
+
+Some services expose runtime APIs and OpenAPI schemas at different URLs.
+
+- Runtime endpoint: where requests are executed (`uxc <url> ...`)
+- Schema URL: where operation metadata is discovered
+
+UXC supports this with a layered strategy:
+
+1. `--schema-url` CLI override (highest priority)
+2. User mapping file (`~/.uxc/schema_mappings.json`)
+3. Builtin mappings (for known services)
+4. Default OpenAPI probing (`/openapi.json`, `/swagger.json`, ...)
+
+## CLI Override
+
+```bash
+uxc https://api.github.com list \
+  --schema-url https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
+```
+
+`uxc <url>` stays the execution target. `--schema-url` only changes schema discovery.
+
+## User Mapping File
+
+Path: `~/.uxc/schema_mappings.json`
+
+Example:
+
+```json
+{
+  "version": 1,
+  "openapi": [
+    {
+      "host": "api.github.com",
+      "path_prefix": "/",
+      "schema_url": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
+      "priority": 100
+    }
+  ]
+}
+```
+
+Field notes:
+
+- `host`: exact host match (required)
+- `path_prefix`: optional path prefix filter (default all paths)
+- `schema_url`: OpenAPI document URL (required)
+- `priority`: higher wins when multiple rules match (default `0`)
+- `enabled`: optional, defaults to `true`
+
+## Matching Rules
+
+- Host matching is exact (case-insensitive).
+- Path prefix must match the target URL path.
+- If multiple rules match:
+  1. user mapping beats builtin mapping
+  2. higher `priority` wins
+  3. longer `path_prefix` wins
+
+## Override Mapping File Path
+
+For CI or testing:
+
+```bash
+UXC_SCHEMA_MAPPINGS_FILE=/tmp/schema_mappings.json uxc https://service.example.com list
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cache;
 pub mod error;
 pub mod output;
 pub mod protocol;
+pub mod schema_mapping;
 
 pub use adapters::{Adapter, ProtocolType};
 pub use cache::{create_cache, create_default_cache, Cache, CacheConfig, CacheResult};

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,6 +1,6 @@
 //! Protocol detection and routing
 
-use crate::adapters::{Adapter, AdapterEnum, ProtocolDetector, ProtocolType};
+use crate::adapters::{Adapter, AdapterEnum, DetectionOptions, ProtocolDetector, ProtocolType};
 use crate::error::{Result, UxcError};
 
 /// Protocol detector and router
@@ -29,6 +29,18 @@ impl ProtocolRouter {
     pub async fn get_adapter_for_url(&self, url: &str) -> Result<AdapterEnum> {
         self.detector
             .detect_adapter(url)
+            .await
+            .map_err(UxcError::GenericError)
+    }
+
+    /// Get adapter for a URL with explicit detection options.
+    pub async fn get_adapter_for_url_with_options(
+        &self,
+        url: &str,
+        options: &DetectionOptions,
+    ) -> Result<AdapterEnum> {
+        self.detector
+            .detect_adapter_with_options(url, options)
             .await
             .map_err(UxcError::GenericError)
     }

--- a/src/schema_mapping/mod.rs
+++ b/src/schema_mapping/mod.rs
@@ -1,0 +1,289 @@
+//! Schema mapping for services whose runtime endpoint and schema URL differ.
+
+use serde::Deserialize;
+use std::fs;
+use std::path::PathBuf;
+use tracing::warn;
+use url::Url;
+
+const DEFAULT_MAPPINGS_DIR: &str = ".uxc";
+const DEFAULT_MAPPINGS_FILE: &str = "schema_mappings.json";
+const SCHEMA_MAPPINGS_ENV: &str = "UXC_SCHEMA_MAPPINGS_FILE";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MappingSource {
+    Builtin,
+    UserConfig,
+}
+
+impl MappingSource {
+    fn rank(&self) -> i32 {
+        match self {
+            Self::Builtin => 0,
+            Self::UserConfig => 1,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Builtin => "builtin_mapping",
+            Self::UserConfig => "user_mapping",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedSchemaMapping {
+    pub schema_url: String,
+    pub source: MappingSource,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SchemaMappingsConfig {
+    #[allow(dead_code)]
+    #[serde(default)]
+    version: Option<u32>,
+    #[serde(default)]
+    openapi: Vec<OpenApiMappingRule>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct OpenApiMappingRule {
+    host: String,
+    #[serde(default)]
+    path_prefix: Option<String>,
+    schema_url: String,
+    #[serde(default = "default_true")]
+    enabled: bool,
+    #[serde(default)]
+    priority: i32,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone)]
+struct CandidateRule {
+    source: MappingSource,
+    rule: OpenApiMappingRule,
+}
+
+impl OpenApiMappingRule {
+    fn normalized_host(&self) -> String {
+        self.host.trim().to_ascii_lowercase()
+    }
+
+    fn normalized_path_prefix(&self) -> Option<String> {
+        self.path_prefix
+            .as_ref()
+            .map(|p| p.trim())
+            .filter(|p| !p.is_empty())
+            .map(|prefix| {
+                if prefix.starts_with('/') {
+                    prefix.to_string()
+                } else {
+                    format!("/{}", prefix)
+                }
+            })
+    }
+
+    fn matches(&self, target: &Url) -> bool {
+        let Some(host) = target.host_str() else {
+            return false;
+        };
+
+        if self.normalized_host() != host.to_ascii_lowercase() {
+            return false;
+        }
+
+        if let Some(prefix) = self.normalized_path_prefix() {
+            target.path().starts_with(&prefix)
+        } else {
+            true
+        }
+    }
+}
+
+fn builtin_openapi_rules() -> Vec<OpenApiMappingRule> {
+    vec![OpenApiMappingRule {
+        host: "api.github.com".to_string(),
+        path_prefix: Some("/".to_string()),
+        schema_url: "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json".to_string(),
+        enabled: true,
+        priority: 1000,
+    }]
+}
+
+fn resolve_user_mappings_path() -> Option<PathBuf> {
+    if let Some(override_path) = std::env::var_os(SCHEMA_MAPPINGS_ENV) {
+        return Some(PathBuf::from(override_path));
+    }
+
+    home_dir().map(|home| home.join(DEFAULT_MAPPINGS_DIR).join(DEFAULT_MAPPINGS_FILE))
+}
+
+fn load_user_openapi_rules() -> Vec<OpenApiMappingRule> {
+    let Some(path) = resolve_user_mappings_path() else {
+        return Vec::new();
+    };
+
+    if !path.exists() {
+        return Vec::new();
+    }
+
+    let raw = match fs::read_to_string(&path) {
+        Ok(value) => value,
+        Err(err) => {
+            warn!("Failed to read schema mappings file {:?}: {}", path, err);
+            return Vec::new();
+        }
+    };
+
+    let parsed: SchemaMappingsConfig = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(err) => {
+            warn!("Failed to parse schema mappings file {:?}: {}", path, err);
+            return Vec::new();
+        }
+    };
+
+    parsed.openapi
+}
+
+fn resolve_from_rules(
+    target_url: &str,
+    user_rules: Vec<OpenApiMappingRule>,
+    builtin_rules: Vec<OpenApiMappingRule>,
+) -> Option<ResolvedSchemaMapping> {
+    let target = Url::parse(target_url).ok()?;
+    let mut candidates = Vec::new();
+    candidates.extend(user_rules.into_iter().map(|rule| CandidateRule {
+        source: MappingSource::UserConfig,
+        rule,
+    }));
+    candidates.extend(builtin_rules.into_iter().map(|rule| CandidateRule {
+        source: MappingSource::Builtin,
+        rule,
+    }));
+
+    candidates
+        .into_iter()
+        .filter(|candidate| candidate.rule.enabled && candidate.rule.matches(&target))
+        .max_by_key(|candidate| {
+            (
+                candidate.source.rank(),
+                candidate.rule.priority,
+                candidate
+                    .rule
+                    .normalized_path_prefix()
+                    .map_or(0usize, |prefix| prefix.len()),
+            )
+        })
+        .map(|candidate| ResolvedSchemaMapping {
+            schema_url: candidate.rule.schema_url,
+            source: candidate.source,
+        })
+}
+
+pub fn resolve_openapi_schema_mapping(target_url: &str) -> Option<ResolvedSchemaMapping> {
+    resolve_from_rules(
+        target_url,
+        load_user_openapi_rules(),
+        builtin_openapi_rules(),
+    )
+}
+
+fn home_dir() -> Option<PathBuf> {
+    if let Some(home) = std::env::var_os("HOME") {
+        return Some(PathBuf::from(home));
+    }
+
+    #[cfg(windows)]
+    {
+        if let Some(user_profile) = std::env::var_os("USERPROFILE") {
+            return Some(PathBuf::from(user_profile));
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(
+        host: &str,
+        path_prefix: Option<&str>,
+        schema_url: &str,
+        priority: i32,
+    ) -> OpenApiMappingRule {
+        OpenApiMappingRule {
+            host: host.to_string(),
+            path_prefix: path_prefix.map(|value| value.to_string()),
+            schema_url: schema_url.to_string(),
+            enabled: true,
+            priority,
+        }
+    }
+
+    #[test]
+    fn builtin_mapping_matches_github() {
+        let resolved = resolve_from_rules(
+            "https://api.github.com",
+            Vec::new(),
+            builtin_openapi_rules(),
+        )
+        .expect("should resolve github mapping");
+
+        assert_eq!(resolved.source, MappingSource::Builtin);
+        assert!(resolved.schema_url.contains("api.github.com.json"));
+    }
+
+    #[test]
+    fn user_mapping_overrides_builtin() {
+        let resolved = resolve_from_rules(
+            "https://api.github.com",
+            vec![rule(
+                "api.github.com",
+                Some("/"),
+                "https://example.com/custom-github-openapi.json",
+                1,
+            )],
+            builtin_openapi_rules(),
+        )
+        .expect("should resolve mapping");
+
+        assert_eq!(resolved.source, MappingSource::UserConfig);
+        assert_eq!(
+            resolved.schema_url,
+            "https://example.com/custom-github-openapi.json"
+        );
+    }
+
+    #[test]
+    fn path_prefix_picks_more_specific_mapping() {
+        let resolved = resolve_from_rules(
+            "https://api.example.com/admin/users",
+            vec![
+                rule(
+                    "api.example.com",
+                    Some("/"),
+                    "https://example.com/root.json",
+                    10,
+                ),
+                rule(
+                    "api.example.com",
+                    Some("/admin"),
+                    "https://example.com/admin.json",
+                    10,
+                ),
+            ],
+            Vec::new(),
+        )
+        .expect("should resolve mapping");
+
+        assert_eq!(resolved.schema_url, "https://example.com/admin.json");
+    }
+}


### PR DESCRIPTION
## Summary\n- add global `--schema-url` override for OpenAPI discovery\n- add extensible schema mapping module (builtin + user config)\n- include builtin mapping for `api.github.com`\n- make OpenAPI cache key include resolved schema URL to avoid schema mix-ups\n- add docs for mapping and schema-separated usage\n- add CLI regression tests for override and user mapping config\n\n## Verification\n- `cargo test`\n- manual check: `uxc https://api.github.com --no-cache list` now detects `openapi` and lists operations