### PR TITLE
feat(skill): add reusable uxc skill and validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate skills
+        run: bash skills/uxc/scripts/validate.sh
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,22 @@ Example: `feature/openapi-parser`
 
 8. Create a pull request
 
+### Updating Skills
+
+This repository includes a reusable Codex skill at `skills/uxc`.
+
+When CLI syntax, operation naming, or output envelope changes, update skill files in the same PR:
+
+- `skills/uxc/SKILL.md`
+- `skills/uxc/references/*`
+- `skills/uxc/agents/openai.yaml` (if prompt wording should change)
+
+Run validation before opening a PR:
+
+```bash
+bash skills/uxc/scripts/validate.sh
+```
+
 ## Commit Message Convention
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/):
@@ -213,6 +229,8 @@ git push origin vX.Y.Z
 ```
 
 See `docs/release.md` for full details, rollback, and troubleshooting.
+
+See `docs/skills.md` for skill install and maintenance details.
 
 ## Testing & Coverage
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ cd uxc
 cargo install --path .
 ```
 
+### Codex Skill (Reusable by Other Skills)
+
+Install the built-in `uxc` skill from this repository:
+
+```bash
+python ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo holon-run/uxc \
+  --path skills/uxc
+```
+
+After installation, restart Codex to load the skill.
+
 ## Example Usage
 
 ### Operation ID Conventions
@@ -485,6 +497,7 @@ The CLI works independently, but can transparently use the daemon for performanc
 * Dynamically call remote capabilities
 * Avoid injecting large tool schemas into context
 * Maintain deterministic execution boundaries
+* Reuse the repository skill at `skills/uxc` as the shared API execution layer
 
 ### Infrastructure & DevOps
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,32 @@
+# Skills In This Repository
+
+## Canonical Skill
+
+UXC exposes one canonical reusable skill:
+
+- `skills/uxc`
+
+This skill is the execution abstraction for remote schema-exposed interfaces. Other skills should reuse it when they need API/tool calls.
+
+## Install For Codex
+
+```bash
+python ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo holon-run/uxc \
+  --path skills/uxc
+```
+
+After installation, restart Codex to load the skill.
+
+## Maintenance Rules
+
+- Keep CLI examples in `skills/uxc` aligned with current UXC syntax.
+- If CLI semantics or output envelope changes, update:
+  - `skills/uxc/SKILL.md`
+  - files in `skills/uxc/references/`
+  - `skills/uxc/agents/openai.yaml` (if invocation wording changes)
+- Run validation:
+
+```bash
+bash skills/uxc/scripts/validate.sh
+```

--- a/skills/uxc/SKILL.md
+++ b/skills/uxc/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: uxc
+description: Discover and call remote schema-exposed interfaces with UXC. Use when an agent or skill needs to list operations, inspect operation schemas, and execute OpenAPI, GraphQL, gRPC, MCP, or JSON-RPC calls via one CLI contract.
+metadata:
+  short-description: Discover and call remote schema APIs via UXC
+---
+
+# UXC Skill
+
+Use this skill when a task requires calling a remote interface and the endpoint can expose machine-readable schema metadata.
+
+## When To Use
+
+- You need to call APIs/tools from another skill and want one consistent CLI workflow.
+- The interface may be OpenAPI, GraphQL, gRPC reflection, MCP, or JSON-RPC/OpenRPC.
+- You need deterministic, machine-readable output (`ok`, `kind`, `data`, `error`).
+
+Do not use this skill for pure local file operations with no remote interface.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- For gRPC runtime calls, `grpcurl` is installed and available in `PATH`.
+
+## Core Workflow
+
+1. Discover operations:
+   - `uxc <host> list`
+2. Inspect a specific operation:
+   - `uxc <host> describe <operation>`
+   - or `uxc <host> <operation> help`
+3. Execute with structured input:
+   - `uxc <host> <operation> --json '<payload-json>'`
+4. Parse result as JSON envelope:
+   - Success: `.ok == true`, consume `.data`
+   - Failure: `.ok == false`, inspect `.error.code` and `.error.message`
+5. If operation name conflicts with keywords such as `help`/`list`, use explicit form:
+   - `uxc <host> call <operation> --json '<payload-json>'`
+
+## Output Contract For Reuse
+
+Other skills should treat this skill as the interface execution layer and consume only the stable envelope:
+
+- Success fields: `ok`, `kind`, `protocol`, `endpoint`, `operation`, `data`, `meta`
+- Failure fields: `ok`, `error.code`, `error.message`, `meta`
+
+Default output is JSON. Do not use `--text` in agent automation paths.
+
+## Reuse Rule For Other Skills
+
+- If a skill needs remote API/tool execution, reuse this skill instead of embedding protocol-specific calling logic.
+- Upstream skill inputs should be limited to:
+  - target host
+  - operation id/name
+  - JSON payload
+  - required fields to extract from `.data`
+
+## Reference Files (Load On Demand)
+
+- Workflow details and progressive invocation patterns:
+  - `references/usage-patterns.md`
+- Protocol operation naming quick reference:
+  - `references/protocol-cheatsheet.md`
+- Public endpoint examples and availability notes:
+  - `references/public-endpoints.md`
+- Failure handling and retry strategy:
+  - `references/error-handling.md`

--- a/skills/uxc/agents/openai.yaml
+++ b/skills/uxc/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "UXC"
+  short_description: "Discover and call remote schema APIs via UXC"
+  default_prompt: "Use $uxc to discover operations and call remote interfaces with the UXC CLI."

--- a/skills/uxc/references/error-handling.md
+++ b/skills/uxc/references/error-handling.md
@@ -1,0 +1,41 @@
+# Error Handling
+
+## Envelope-First Handling
+
+Always parse `ok` first.
+
+- `ok=true`: consume `data`
+- `ok=false`: branch by `error.code`
+
+## Common Failure Classes
+
+1. Discovery failure
+- Symptoms: `list` fails, protocol not detected, endpoint mismatch
+- Actions:
+  - verify host URL/scheme/port
+  - run with `RUST_LOG=debug`
+  - for OpenAPI schema separation, provide `--schema-url` or mapping if needed
+
+2. Operation not found
+- Symptoms: `describe` or call reports unknown operation
+- Actions:
+  - refresh with `list`
+  - check exact operation naming convention per protocol
+
+3. Input validation failure
+- Symptoms: invalid argument / missing field
+- Actions:
+  - inspect `describe` schema
+  - start from minimal required payload
+
+4. Runtime transport failure
+- Symptoms: timeout, connection reset, TLS error
+- Actions:
+  - retry with bounded attempts
+  - verify endpoint health with native tooling (`curl`, `grpcurl`)
+
+## Retry Guidance
+
+- Retry only idempotent read-like operations by default.
+- Suggested backoff: 1s, 2s, 4s (max 3 attempts).
+- Do not retry validation errors without payload change.

--- a/skills/uxc/references/protocol-cheatsheet.md
+++ b/skills/uxc/references/protocol-cheatsheet.md
@@ -1,0 +1,46 @@
+# Protocol Cheatsheet
+
+UXC operation names follow protocol-native conventions.
+
+## OpenAPI
+
+- Operation id format: `method:/path`
+- Example:
+  - `get:/users/{id}`
+  - `post:/pet`
+
+## gRPC
+
+- Operation id format: `Service/Method`
+- Example:
+  - `addsvc.Add/Sum`
+
+## GraphQL
+
+- Operation id format: `<operation_type>/<field>`
+- Example:
+  - `query/viewer`
+  - `mutation/addStar`
+  - `subscription/onEvent`
+
+## MCP
+
+- Operation id format: tool name
+- Example:
+  - `ask_question`
+  - `list_directory`
+
+## JSON-RPC (OpenRPC-driven)
+
+- Operation id format: method name
+- Example:
+  - `eth_getBalance`
+  - `net_version`
+
+## Generic Command Templates
+
+```bash
+uxc <host> list
+uxc <host> describe <operation>
+uxc <host> <operation> --json '<payload-json>'
+```

--- a/skills/uxc/references/public-endpoints.md
+++ b/skills/uxc/references/public-endpoints.md
@@ -1,0 +1,52 @@
+# Public Endpoints
+
+The following endpoints are practical no-key baselines for smoke checks. Availability can change over time.
+
+## OpenAPI
+
+- Endpoint: `https://petstore3.swagger.io/api/v3`
+- Check:
+
+```bash
+uxc https://petstore3.swagger.io/api/v3 list
+uxc https://petstore3.swagger.io/api/v3 get:/store/inventory
+```
+
+## GraphQL
+
+- Endpoint: `https://countries.trevorblades.com/`
+- Check:
+
+```bash
+uxc https://countries.trevorblades.com/ list
+uxc https://countries.trevorblades.com/ query/country --json '{"code":"US"}'
+```
+
+## gRPC
+
+- Endpoint: `grpcb.in:9000` (plaintext), `grpcb.in:9001` (TLS)
+- Prerequisite: `grpcurl` installed
+- Check:
+
+```bash
+uxc grpcb.in:9000 list
+uxc grpcb.in:9000 addsvc.Add/Sum --json '{"a":1,"b":2}'
+```
+
+## MCP (HTTP)
+
+- Endpoint: `https://mcp.deepwiki.com/mcp`
+- Check:
+
+```bash
+uxc https://mcp.deepwiki.com/mcp list
+uxc https://mcp.deepwiki.com/mcp describe ask_question
+```
+
+## JSON-RPC
+
+- Constraint: UXC JSON-RPC discovery requires `openrpc.json`, `/.well-known/openrpc.json`, or `rpc.discover`.
+- Current status: no stable, keyless public endpoint is curated in this repository.
+- Recommended baseline for reliable tests:
+  - use a controlled endpoint that exposes OpenRPC/rpc.discover
+  - or run local/self-hosted JSON-RPC with OpenRPC enabled

--- a/skills/uxc/references/usage-patterns.md
+++ b/skills/uxc/references/usage-patterns.md
@@ -1,0 +1,49 @@
+# Usage Patterns
+
+## Progressive Flow (Default)
+
+1. Discover operations:
+
+```bash
+uxc <host> list
+```
+
+2. Inspect operation input/output shape:
+
+```bash
+uxc <host> describe <operation>
+```
+
+3. Execute with minimal valid payload:
+
+```bash
+uxc <host> <operation> --json '{"field":"value"}'
+```
+
+4. Parse success/failure envelope:
+
+```bash
+uxc <host> <operation> --json '{"field":"value"}' | jq '.ok, .kind, .data'
+```
+
+## Conflict-Safe Flow
+
+If operation name collides with CLI keywords (`help`, `list`, `describe`), use explicit `call`:
+
+```bash
+uxc <host> call <operation> --json '{"field":"value"}'
+```
+
+## Host-Level Help
+
+```bash
+uxc <host> help
+```
+
+Use this when you need quick discovery context before full `list` + `describe`.
+
+## Automation Safety Rules
+
+- Keep JSON as default output for machine parsing.
+- Treat stderr logs as diagnostic only; parse stdout JSON envelope.
+- Start with smallest valid payload before expanding optional fields.

--- a/skills/uxc/scripts/validate.sh
+++ b/skills/uxc/scripts/validate.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/uxc"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+
+required_files=(
+  "${SKILL_FILE}"
+  "${OPENAI_FILE}"
+  "${SKILL_DIR}/references/usage-patterns.md"
+  "${SKILL_DIR}/references/protocol-cheatsheet.md"
+  "${SKILL_DIR}/references/public-endpoints.md"
+  "${SKILL_DIR}/references/error-handling.md"
+)
+
+for file in "${required_files[@]}"; do
+  if [[ ! -f "${file}" ]]; then
+    echo "missing required file: ${file}"
+    exit 1
+  fi
+done
+
+# Validate SKILL frontmatter minimum fields.
+if ! rg -q '^---$' "${SKILL_FILE}"; then
+  echo "SKILL.md must include YAML frontmatter"
+  exit 1
+fi
+
+if ! rg -q '^name:\s*uxc\s*$' "${SKILL_FILE}"; then
+  echo "SKILL.md frontmatter must define: name: uxc"
+  exit 1
+fi
+
+if ! rg -q '^description:\s*.+' "${SKILL_FILE}"; then
+  echo "SKILL.md frontmatter must define a description"
+  exit 1
+fi
+
+# Validate required invocation contract appears in SKILL text.
+if ! rg -q 'uxc <host> list' "${SKILL_FILE}"; then
+  echo "SKILL.md must document list workflow"
+  exit 1
+fi
+
+if ! rg -q 'uxc <host> describe <operation>' "${SKILL_FILE}"; then
+  echo "SKILL.md must document describe workflow"
+  exit 1
+fi
+
+if ! rg -q "uxc <host> <operation> --json '<payload-json>'" "${SKILL_FILE}"; then
+  echo "SKILL.md must document execute workflow"
+  exit 1
+fi
+
+# Validate references linked from SKILL body.
+for rel in \
+  "references/usage-patterns.md" \
+  "references/protocol-cheatsheet.md" \
+  "references/public-endpoints.md" \
+  "references/error-handling.md"; do
+  if ! rg -q "${rel}" "${SKILL_FILE}"; then
+    echo "SKILL.md must reference ${rel}"
+    exit 1
+  fi
+done
+
+# Validate openai.yaml minimum fields.
+if ! rg -q '^\s*display_name:\s*"UXC"\s*$' "${OPENAI_FILE}"; then
+  echo "agents/openai.yaml must define interface.display_name"
+  exit 1
+fi
+
+if ! rg -q '^\s*short_description:\s*".+"\s*$' "${OPENAI_FILE}"; then
+  echo "agents/openai.yaml must define interface.short_description"
+  exit 1
+fi
+
+if ! rg -q '^\s*default_prompt:\s*".*\$uxc.*"\s*$' "${OPENAI_FILE}"; then
+  echo 'agents/openai.yaml default_prompt must mention $uxc'
+  exit 1
+fi
+
+echo "skills/uxc validation passed"


### PR DESCRIPTION
## What
Add a built-in reusable `uxc` skill under `skills/uxc` so agents/skills can consistently discover and call remote interfaces through UXC.

## Why
We need a canonical skill that documents and standardizes `list -> describe/help -> call` usage, and lets other skills reuse one execution contract instead of re-implementing protocol-specific calling logic.

## How
Implemented an in-repo skill package with frontmatter metadata, references, and agent UI metadata; added a validation script and wired it into CI lint.

## Changes
- [x] Add `skills/uxc/SKILL.md` as the canonical reusable skill.
- [x] Add references for usage patterns, protocol naming, public endpoints, and error handling.
- [x] Add `skills/uxc/agents/openai.yaml` metadata.
- [x] Add `skills/uxc/scripts/validate.sh` for structural/content validation.
- [x] Add `docs/skills.md` for install + maintenance guidance.
- [x] Update `README.md` with skill installation and reuse notes.
- [x] Update `CONTRIBUTING.md` with skill update policy.
- [x] Run skill validation in CI (`.github/workflows/ci.yml`).

## Testing

### Unit Tests
- [ ] All existing tests pass
- [ ] New tests added (if applicable)
- [ ] `cargo test` passes

### Manual Testing
- [x] Tested against real APIs
- [x] Tested edge cases
- [x] Tested error conditions

### Test Results
```bash
bash skills/uxc/scripts/validate.sh
# skills/uxc validation passed
```

## Checklist

- [ ] Code formatted with `cargo fmt`
- [ ] No clippy warnings (`cargo clippy -- -D warnings`)
- [ ] All tests pass (`cargo test`)
- [x] Documentation updated
- [x] Commit messages follow convention
- [x] PR title follows convention (e.g., `feat: add GraphQL support`)

## Breaking Changes
None.

## Additional Notes
- `public-endpoints.md` explicitly documents JSON-RPC discovery constraints (`openrpc.json` / `/.well-known/openrpc.json` / `rpc.discover`) and does not claim a stable no-key public JSON-RPC endpoint for this repo at the moment.
