### PR TITLE
docs: simplify endpoint examples and remove https prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ Schema becomes execution.
 UXC does not require registering server aliases.
 
 ```bash
-uxc https://api.example.com list
-uxc https://api.example.com get:/users/42
+uxc petstore3.swagger.io/api/v3 list
+uxc petstore3.swagger.io/api/v3 get:/pet/{petId} --json '{"petId":1}'
 ```
 
 Any compliant endpoint can be called directly.
+For common HTTP targets, UXC infers `https://` when the scheme is omitted.
 
 This makes UXC safe to use inside:
 
@@ -102,8 +103,8 @@ The CLI interface remains consistent across protocols.
   "ok": true,
   "kind": "call_result",
   "protocol": "openapi",
-  "endpoint": "https://api.example.com",
-  "operation": "get:/users/{id}",
+  "endpoint": "https://petstore3.swagger.io/api/v3",
+  "operation": "get:/pet/{petId}",
   "data": { ... },
   "meta": {
     "version": "v1",
@@ -164,16 +165,16 @@ This makes UXC ideal for:
 uxc cache stats
 
 # Clear cache for specific endpoint
-uxc cache clear https://api.example.com
+uxc cache clear petstore3.swagger.io/api/v3
 
 # Clear all cache
 uxc cache clear --all
 
 # Disable cache for this operation
-uxc https://api.example.com list --no-cache
+uxc petstore3.swagger.io/api/v3 list --no-cache
 
 # Use custom TTL (in seconds)
-uxc https://api.example.com list --cache-ttl 3600
+uxc petstore3.swagger.io/api/v3 list --cache-ttl 3600
 ```
 
 ## Debugging and Logging
@@ -182,19 +183,19 @@ UXC uses structured logging with the `tracing` crate. By default, only warnings 
 
 ```bash
 # Default: warnings and errors only
-uxc https://api.example.com list
+uxc petstore3.swagger.io/api/v3 list
 
 # Enable info logs (HTTP requests, responses, etc.)
-RUST_LOG=info uxc https://api.example.com list
+RUST_LOG=info uxc petstore3.swagger.io/api/v3 list
 
 # Enable debug logs (detailed debugging information)
-RUST_LOG=debug uxc https://api.example.com list
+RUST_LOG=debug uxc petstore3.swagger.io/api/v3 list
 
 # Enable trace logs (maximum verbosity)
-RUST_LOG=trace uxc https://api.example.com list
+RUST_LOG=trace uxc petstore3.swagger.io/api/v3 list
 
 # Enable logs for specific modules only
-RUST_LOG=uxc::adapters::openapi=debug uxc https://api.example.com list
+RUST_LOG=uxc::adapters::openapi=debug uxc petstore3.swagger.io/api/v3 list
 ```
 
 **Log Levels:**
@@ -263,6 +264,8 @@ After installation, restart Codex to load the skill.
 
 ## Example Usage
 
+Most HTTP examples omit the scheme for brevity. Add `https://` explicitly if you prefer strictness.
+
 ### Operation ID Conventions
 
 UXC uses protocol-native, machine-friendly `operation_id` values:
@@ -277,32 +280,31 @@ UXC uses protocol-native, machine-friendly `operation_id` values:
 
 ```bash
 # List available operations
-uxc https://api.example.com list
-uxc petstore3.swagger.io/api/v3 list  # scheme can be omitted for common HTTP targets
+uxc petstore3.swagger.io/api/v3 list
 
 # Schema-separated service: runtime endpoint and schema URL are different
-uxc https://api.github.com list \
+uxc api.github.com list \
   --schema-url https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
 
 # Get operation help
-uxc https://api.example.com describe get:/users/{id}
-uxc https://api.example.com get:/users/{id} help
+uxc petstore3.swagger.io/api/v3 describe get:/pet/{petId}
+uxc petstore3.swagger.io/api/v3 get:/pet/{petId} help
 
 # Execute with parameters
-uxc https://api.example.com get:/users/{id} --json '{"id":42}'
+uxc petstore3.swagger.io/api/v3 get:/pet/{petId} --json '{"petId":1}'
 
 # Execute with JSON input
-uxc https://api.example.com call post:/users --json '{"name":"Alice","email":"alice@example.com"}'
+uxc petstore3.swagger.io/api/v3 call post:/pet --json '{"id":10001,"name":"codex-dog","photoUrls":["https://petstore3.swagger.io/favicon-32x32.png"],"status":"available"}'
 ```
 
 ### gRPC Services
 
 ```bash
 # List all services via reflection
-uxc grpc.example.com:9000 list
+uxc grpcb.in:9000 list
 
 # Call a unary RPC
-uxc grpc.example.com:9000 addsvc.Add/Sum --json '{"a":1,"b":2}'
+uxc grpcb.in:9000 addsvc.Add/Sum --json '{"a":1,"b":2}'
 ```
 
 Note: gRPC unary invocation uses the `grpcurl` binary at runtime.
@@ -311,27 +313,24 @@ Note: gRPC unary invocation uses the `grpcurl` binary at runtime.
 
 ```bash
 # List available queries/mutations/subscriptions
-uxc https://graphql.example.com list
+uxc countries.trevorblades.com list
 
 # Execute a query
-uxc https://graphql.example.com query/viewer
+uxc countries.trevorblades.com query/continents
 
 # Execute with parameters
-uxc https://graphql.example.com query/user --json '{"id":"42"}'
-
-# Execute a mutation
-uxc https://graphql.example.com mutation/addStar --json '{"starredId":"123"}'
+uxc countries.trevorblades.com query/country --json '{"code":"US"}'
 ```
 
 ### MCP (Model Context Protocol)
 
 ```bash
 # HTTP transport (recommended for production)
-uxc https://mcp-server.example.com list
-uxc https://mcp-server.example.com tool_name --json '{"param1":"value1"}'
+uxc mcp.deepwiki.com/mcp list
+uxc mcp.deepwiki.com/mcp ask_question --json '{"repoName":"holon-run/uxc","question":"What does this project do?"}'
 
 # If a tool name conflicts with CLI subcommands, use explicit call
-uxc https://mcp-server.example.com call help --json '{}'
+uxc mcp.deepwiki.com/mcp call <tool_name> --json '{...}'
 
 # stdio transport (for local development)
 uxc "npx -y @modelcontextprotocol/server-filesystem /tmp" list
@@ -342,13 +341,13 @@ uxc "npx -y @modelcontextprotocol/server-filesystem /tmp" list_directory --json 
 
 ```bash
 # Discover methods (requires rpc.discover or openrpc.json)
-uxc https://rpc.example.com list
+uxc fullnode.mainnet.sui.io list
 
 # Describe one method
-uxc https://rpc.example.com describe eth_getBalance
+uxc fullnode.mainnet.sui.io describe sui_getLatestCheckpointSequenceNumber
 
 # Execute a method
-uxc https://rpc.example.com eth_getBalance --json '{"address":"0xabc...","block":"latest"}'
+uxc fullnode.mainnet.sui.io sui_getLatestCheckpointSequenceNumber
 ```
 
 Note: JSON-RPC support is OpenRPC-driven for predictable `list/describe` discovery.
@@ -356,7 +355,7 @@ Note: JSON-RPC support is OpenRPC-driven for predictable `list/describe` discove
 ## Public Test Endpoints (No API Key)
 
 These endpoints are useful for protocol availability checks without API keys.
-Verified on 2026-02-23.
+Verified on 2026-02-25.
 
 ### OpenAPI
 

--- a/skills/deepwiki/SKILL.md
+++ b/skills/deepwiki/SKILL.md
@@ -12,7 +12,7 @@ Use this skill to query GitHub repository documentation and ask questions about 
 ## Prerequisites
 
 - `uxc` is installed and available in `PATH`.
-- Network access to `https://mcp.deepwiki.com/mcp`
+- Network access to `mcp.deepwiki.com/mcp`
 
 Note: Repositories must be indexed on DeepWiki first. Visit https://deepwiki.com to index a repository.
 
@@ -41,16 +41,16 @@ cargo install uxc
 ## Core Workflow
 
 1. List available tools:
-   - `uxc https://mcp.deepwiki.com/mcp list`
+   - `uxc mcp.deepwiki.com/mcp list`
 
 2. Ask a question about a repository:
-   - `uxc https://mcp.deepwiki.com/mcp ask_question --json '{"repoName":"owner/repo","question":"your question"}'`
+   - `uxc mcp.deepwiki.com/mcp ask_question --json '{"repoName":"owner/repo","question":"your question"}'`
 
 3. Read wiki structure:
-   - `uxc https://mcp.deepwiki.com/mcp read_wiki_structure --json '{"repoName":"owner/repo"}'`
+   - `uxc mcp.deepwiki.com/mcp read_wiki_structure --json '{"repoName":"owner/repo"}'`
 
 4. Read wiki contents:
-   - `uxc https://mcp.deepwiki.com/mcp read_wiki_contents --json '{"repoName":"owner/repo"}'`
+   - `uxc mcp.deepwiki.com/mcp read_wiki_contents --json '{"repoName":"owner/repo"}'`
 
 ## Available Tools
 
@@ -63,19 +63,19 @@ cargo install uxc
 ### Ask about a codebase
 
 ```bash
-uxc https://mcp.deepwiki.com/mcp ask_question --json '{"repoName":"facebook/react","question":"How does useState work?"}'
+uxc mcp.deepwiki.com/mcp ask_question --json '{"repoName":"facebook/react","question":"How does useState work?"}'
 ```
 
 ### Explore repository structure
 
 ```bash
-uxc https://mcp.deepwiki.com/mcp read_wiki_structure --json '{"repoName":"facebook/react"}'
+uxc mcp.deepwiki.com/mcp read_wiki_structure --json '{"repoName":"facebook/react"}'
 ```
 
 ### Read documentation
 
 ```bash
-uxc https://mcp.deepwiki.com/mcp read_wiki_contents --json '{"repoName":"facebook/react"}'
+uxc mcp.deepwiki.com/mcp read_wiki_contents --json '{"repoName":"facebook/react"}'
 ```
 
 ## Output Parsing

--- a/skills/deepwiki/references/usage-patterns.md
+++ b/skills/deepwiki/references/usage-patterns.md
@@ -5,7 +5,7 @@
 1. Ensure the repository is indexed on DeepWiki (visit https://deepwiki.com)
 2. Ask a question using `ask_question` tool:
    ```bash
-   uxc https://mcp.deepwiki.com/mcp ask_question --json '{"repoName":"owner/repo","question":"your question"}'
+   uxc mcp.deepwiki.com/mcp ask_question --json '{"repoName":"owner/repo","question":"your question"}'
    ```
 
 ## Common Use Cases
@@ -13,19 +13,19 @@
 ### Understand a function or API
 
 ```bash
-uxc https://mcp.deepwiki.com/mcp ask_question --json '{"repoName":"facebook/react","question":"How does useState work?"}'
+uxc mcp.deepwiki.com/mcp ask_question --json '{"repoName":"facebook/react","question":"How does useState work?"}'
 ```
 
 ### Find relevant code
 
 ```bash
-uxc https://mcp.deepwiki.com/mcp ask_question --json '{"repoName":"owner/repo","question":"Where is the authentication logic?"}'
+uxc mcp.deepwiki.com/mcp ask_question --json '{"repoName":"owner/repo","question":"Where is the authentication logic?"}'
 ```
 
 ### Get code review context
 
 ```bash
-uxc https://mcp.deepwiki.com/mcp ask_question --json '{"repoName":"owner/repo","question":"Explain the architecture of this project"}'
+uxc mcp.deepwiki.com/mcp ask_question --json '{"repoName":"owner/repo","question":"Explain the architecture of this project"}'
 ```
 
 ## Output Handling
@@ -34,7 +34,7 @@ Parse the response:
 
 ```bash
 # Extract the answer text
-uxc https://mcp.deepwiki.com/mcp ask_question --json '{"repoName":"facebook/react","question":"What is React?"}' | jq -r '.data.content[].text'
+uxc mcp.deepwiki.com/mcp ask_question --json '{"repoName":"facebook/react","question":"What is React?"}' | jq -r '.data.content[].text'
 ```
 
 ## Limitations

--- a/skills/uxc/references/public-endpoints.md
+++ b/skills/uxc/references/public-endpoints.md
@@ -4,22 +4,22 @@ The following endpoints are practical no-key baselines for smoke checks. Availab
 
 ## OpenAPI
 
-- Endpoint: `https://petstore3.swagger.io/api/v3`
+- Endpoint: `petstore3.swagger.io/api/v3`
 - Check:
 
 ```bash
-uxc https://petstore3.swagger.io/api/v3 list
-uxc https://petstore3.swagger.io/api/v3 get:/store/inventory
+uxc petstore3.swagger.io/api/v3 list
+uxc petstore3.swagger.io/api/v3 get:/store/inventory
 ```
 
 ## GraphQL
 
-- Endpoint: `https://countries.trevorblades.com/`
+- Endpoint: `countries.trevorblades.com`
 - Check:
 
 ```bash
-uxc https://countries.trevorblades.com/ list
-uxc https://countries.trevorblades.com/ query/country --json '{"code":"US"}'
+uxc countries.trevorblades.com list
+uxc countries.trevorblades.com query/country --json '{"code":"US"}'
 ```
 
 ## gRPC
@@ -35,12 +35,12 @@ uxc grpcb.in:9000 addsvc.Add/Sum --json '{"a":1,"b":2}'
 
 ## MCP (HTTP)
 
-- Endpoint: `https://mcp.deepwiki.com/mcp`
+- Endpoint: `mcp.deepwiki.com/mcp`
 - Check:
 
 ```bash
-uxc https://mcp.deepwiki.com/mcp list
-uxc https://mcp.deepwiki.com/mcp describe ask_question
+uxc mcp.deepwiki.com/mcp list
+uxc mcp.deepwiki.com/mcp describe ask_question
 ```
 
 ## JSON-RPC


### PR DESCRIPTION
## What
- update README endpoint examples to prefer concise, scheme-less host input where supported
- replace `example.com` command placeholders with real public endpoints that users can run directly
- simplify Sui JSON-RPC examples to `fullnode.mainnet.sui.io` form (omit explicit `https://` and default `:443`)
- align skill docs (`skills/uxc` and `skills/deepwiki`) with the same `uxc <host> ...` style

## Why
- reduce command verbosity for common usage paths
- make docs easier to copy/paste and verify against real endpoints
- keep README and skill examples consistent so users and agents follow one invocation pattern

## How
- edited README command blocks for OpenAPI/GraphQL/MCP/JSON-RPC examples
- refreshed endpoint references in skill docs and usage pattern references
- kept non-UXC URLs (install scripts, external links) unchanged

## Testing
- bash skills/uxc/scripts/validate.sh
- bash skills/deepwiki/scripts/validate.sh
