### PR TITLE
ci: add rustfmt check and normalize formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
@@ -111,6 +111,9 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy -- -D warnings -A non_camel_case_types -A unused_variables -A unused_imports -A dead_code -A clippy::upper_case_acronyms -A clippy::enum_variant_names -A clippy::vec_init_then_push -A clippy::type_complexity
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
 
   test:
     name: Test (${{ matrix.rust }})

--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -25,7 +25,8 @@ impl McpStdioClient {
         args: &[String],
         executor: Arc<dyn StdioProcessExecutor>,
     ) -> Result<Self> {
-        let mut transport = McpStdioTransport::connect_with_executor(command, args, executor).await?;
+        let mut transport =
+            McpStdioTransport::connect_with_executor(command, args, executor).await?;
 
         // Initialize the session
         let client_info = ClientInfo {
@@ -260,10 +261,9 @@ mod tests {
             done
         "#;
 
-        let client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         assert!(!client.supports_tools());
     }
@@ -276,10 +276,9 @@ mod tests {
             while read line; do sleep 1; done
         "#;
 
-        let client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         assert!(client.supports_tools());
     }
@@ -292,10 +291,9 @@ mod tests {
             while read line; do sleep 1; done
         "#;
 
-        let client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         assert!(client.supports_resources());
     }
@@ -308,10 +306,9 @@ mod tests {
             while read line; do sleep 1; done
         "#;
 
-        let client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         assert!(client.supports_prompts());
     }
@@ -324,14 +321,16 @@ mod tests {
             echo '{"jsonrpc":"2.0","id":2,"result":{}}'
         "#;
 
-        let mut client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         let result = client.list_tools().await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("does not support tools"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("does not support tools"));
     }
 
     #[tokio::test]
@@ -343,10 +342,9 @@ mod tests {
             echo '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"test_tool","description":"A test tool","inputSchema":{"type":"object"}}]}}'
         "#;
 
-        let mut client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         let tools = client.list_tools().await.unwrap();
         assert_eq!(tools.len(), 1);
@@ -363,10 +361,9 @@ mod tests {
             echo '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Tool executed successfully"}]}}'
         "#;
 
-        let mut client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         let args = serde_json::json!({"param1": "value1"});
         let result = client.call_tool("test_tool", Some(args)).await.unwrap();
@@ -385,14 +382,16 @@ mod tests {
             echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"test","version":"1.0"}}}'
         "#;
 
-        let mut client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         let result = client.call_tool("test", None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("does not support tools"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("does not support tools"));
     }
 
     #[tokio::test]
@@ -402,14 +401,16 @@ mod tests {
             echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"test","version":"1.0"}}}'
         "#;
 
-        let mut client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         let result = client.list_resources().await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("does not support resources"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("does not support resources"));
     }
 
     #[tokio::test]
@@ -421,10 +422,9 @@ mod tests {
             echo '{"jsonrpc":"2.0","id":2,"result":{"resources":[{"name":"test_resource","uri":"test://resource","description":"A test resource"}]}}'
         "#;
 
-        let mut client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         let resources = client.list_resources().await.unwrap();
         assert_eq!(resources.len(), 1);
@@ -441,22 +441,27 @@ mod tests {
             echo '{"jsonrpc":"2.0","id":2,"result":{"contents":[{"uri":"test://resource"}]}}'
         "#;
 
-        let mut client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         // The response structure has a "contents" array, so we need to handle that
         let result = client
             .transport
-            .send_request("resources/read", Some(serde_json::json!({"uri": "test://resource"})))
+            .send_request(
+                "resources/read",
+                Some(serde_json::json!({"uri": "test://resource"})),
+            )
             .await
             .unwrap();
 
         // Parse the contents array
         let contents_array = result.get("contents").and_then(|v| v.as_array()).unwrap();
         let first_content = &contents_array[0];
-        assert_eq!(first_content.get("uri").unwrap().as_str().unwrap(), "test://resource");
+        assert_eq!(
+            first_content.get("uri").unwrap().as_str().unwrap(),
+            "test://resource"
+        );
     }
 
     #[tokio::test]
@@ -466,14 +471,16 @@ mod tests {
             echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"test","version":"1.0"}}}'
         "#;
 
-        let mut client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         let result = client.list_prompts().await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("does not support prompts"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("does not support prompts"));
     }
 
     #[tokio::test]
@@ -485,10 +492,9 @@ mod tests {
             echo '{"jsonrpc":"2.0","id":2,"result":{"prompts":[{"name":"test_prompt","description":"A test prompt"}]}}'
         "#;
 
-        let mut client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         let prompts = client.list_prompts().await.unwrap();
         assert_eq!(prompts.len(), 1);
@@ -504,10 +510,9 @@ mod tests {
             echo '{"jsonrpc":"2.0","id":2,"result":{"description":"Test prompt","messages":[{"role":"user","content":"Test content"}]}}'
         "#;
 
-        let mut client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         let result = client.get_prompt("test_prompt", None).await.unwrap();
         assert_eq!(result.description, "Test prompt");
@@ -524,10 +529,9 @@ mod tests {
             while read line; do sleep 1; done
         "#;
 
-        let client =
-            McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         assert!(client.supports_tools());
         assert!(client.supports_resources());

--- a/src/adapters/mcp/http_transport.rs
+++ b/src/adapters/mcp/http_transport.rs
@@ -1836,8 +1836,8 @@ data: {"jsonrpc":"2.0","id":1,"result":{}}
             access_token: Some("oauth-access-token".to_string()),
             ..Default::default()
         };
-        let profile = Profile::new("stale-api-key".to_string(), AuthType::OAuth)
-            .with_oauth(oauth_profile);
+        let profile =
+            Profile::new("stale-api-key".to_string(), AuthType::OAuth).with_oauth(oauth_profile);
         let transport = McpHttpTransport::with_auth(server.url(), Some(profile)).unwrap();
 
         let result = transport.send_request("test", None).await;
@@ -1860,8 +1860,8 @@ data: {"jsonrpc":"2.0","id":1,"result":{}}
             access_token: None,
             ..Default::default()
         };
-        let profile = Profile::new("stale-api-key".to_string(), AuthType::OAuth)
-            .with_oauth(oauth_profile);
+        let profile =
+            Profile::new("stale-api-key".to_string(), AuthType::OAuth).with_oauth(oauth_profile);
         let transport = McpHttpTransport::with_auth(server.url(), Some(profile)).unwrap();
 
         let result = transport.send_request("test", None).await;

--- a/src/adapters/mcp/mod.rs
+++ b/src/adapters/mcp/mod.rs
@@ -13,14 +13,14 @@ use anyhow::{bail, Result};
 use async_trait::async_trait;
 pub use client::McpStdioClient;
 pub use http_transport::McpHttpTransport;
-pub use transport::{DefaultStdioProcessExecutor, SpawnedProcess, StdioProcessExecutor};
-#[cfg(test)]
-pub use transport::MockStdioExecutor;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, info};
+#[cfg(test)]
+pub use transport::MockStdioExecutor;
+pub use transport::{DefaultStdioProcessExecutor, SpawnedProcess, StdioProcessExecutor};
 
 pub struct McpAdapter {
     cache: Option<Arc<dyn crate::cache::Cache>>,

--- a/src/adapters/mcp/transport.rs
+++ b/src/adapters/mcp/transport.rs
@@ -59,7 +59,11 @@ impl StdioProcessExecutor for DefaultStdioProcessExecutor {
         let stdin = child.stdin.take().context("Failed to get stdin handle")?;
         let stdout = child.stdout.take().context("Failed to get stdout handle")?;
 
-        Ok(SpawnedProcess { child, stdin, stdout })
+        Ok(SpawnedProcess {
+            child,
+            stdin,
+            stdout,
+        })
     }
 }
 
@@ -136,7 +140,11 @@ impl StdioProcessExecutor for MockStdioExecutor {
         let stdin = child.stdin.take().context("Failed to get stdin handle")?;
         let stdout = child.stdout.take().context("Failed to get stdout handle")?;
 
-        Ok(SpawnedProcess { child, stdin, stdout })
+        Ok(SpawnedProcess {
+            child,
+            stdin,
+            stdout,
+        })
     }
 }
 
@@ -185,7 +193,11 @@ impl McpStdioTransport {
         args: &[String],
         executor: Arc<dyn StdioProcessExecutor>,
     ) -> Result<Self> {
-        let SpawnedProcess { child, stdin, stdout } = executor.spawn(command, args).await?;
+        let SpawnedProcess {
+            child,
+            stdin,
+            stdout,
+        } = executor.spawn(command, args).await?;
 
         // Create channels for sending requests
         let (request_tx, mut request_rx) = mpsc::unbounded_channel::<OutboundMessage>();
@@ -479,7 +491,10 @@ mod tests {
     #[tokio::test]
     async fn parse_command_handles_command_with_args() {
         let parts = parse_command("npx @modelcontextprotocol/server-everything");
-        assert_eq!(parts, vec!["npx", "@modelcontextprotocol/server-everything"]);
+        assert_eq!(
+            parts,
+            vec!["npx", "@modelcontextprotocol/server-everything"]
+        );
     }
 
     #[tokio::test]
@@ -659,7 +674,8 @@ mod tests {
 
     #[tokio::test]
     async fn initialized_sends_notification() {
-        let script = "while read line; do echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}'; done";
+        let script =
+            "while read line; do echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}'; done";
         let mut transport =
             McpStdioTransport::connect("sh", &["-c".to_string(), script.to_string()])
                 .await
@@ -679,8 +695,7 @@ mod tests {
     #[tokio::test]
     async fn connect_with_mock_executor_succeeds() {
         let mock = Arc::new(MockStdioExecutor::new());
-        let result =
-            McpStdioTransport::connect_with_executor("test", &[], mock).await;
+        let result = McpStdioTransport::connect_with_executor("test", &[], mock).await;
         // The mock will spawn a real echo process, so this should succeed
         // but may fail on initialization - that's ok for this test
         // We're just testing that the executor is being used
@@ -690,19 +705,18 @@ mod tests {
     #[tokio::test]
     async fn connect_with_failing_mock_executor_fails() {
         let mock = Arc::new(MockStdioExecutor::with_spawn_failure());
-        let result =
-            McpStdioTransport::connect_with_executor("test", &[], mock).await;
+        let result = McpStdioTransport::connect_with_executor("test", &[], mock).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("failed to spawn"));
     }
 
     #[tokio::test]
     async fn request_id_increments_with_each_request() {
-        let script = "while read line; do echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}'; done";
-        let transport =
-            McpStdioTransport::connect("sh", &["-c".to_string(), script.to_string()])
-                .await
-                .unwrap();
+        let script =
+            "while read line; do echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}'; done";
+        let transport = McpStdioTransport::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
 
         // Check that ID counter starts at 1 and increments
         let id1 = {

--- a/tests/cli_error_output_test.rs
+++ b/tests/cli_error_output_test.rs
@@ -22,12 +22,15 @@ fn protocol_detection_failure_uses_error_envelope() {
 
     // Verify JSON error envelope structure
     let stdout = output.get_output().stdout.clone();
-    let json: serde_json::Value = serde_json::from_slice(&stdout)
-        .expect("stdout should be valid JSON");
+    let json: serde_json::Value =
+        serde_json::from_slice(&stdout).expect("stdout should be valid JSON");
 
     assert_eq!(json["ok"], false, "ok should be false");
     assert_eq!(json["error"]["code"], "PROTOCOL_DETECTION_FAILED");
-    assert!(json["error"]["message"].is_string(), "error.message should be a string");
+    assert!(
+        json["error"]["message"].is_string(),
+        "error.message should be a string"
+    );
 }
 
 #[test]
@@ -65,11 +68,17 @@ fn operation_execution_failure_uses_error_envelope() {
 
     // Verify JSON error envelope structure
     let stdout = output.get_output().stdout.clone();
-    let json: serde_json::Value = serde_json::from_slice(&stdout)
-        .expect("stdout should be valid JSON");
+    let json: serde_json::Value =
+        serde_json::from_slice(&stdout).expect("stdout should be valid JSON");
 
     assert_eq!(json["ok"], false, "ok should be false");
     assert!(json["error"].is_object(), "error should be an object");
-    assert!(json["error"]["code"].is_string(), "error.code should be a string");
-    assert!(json["error"]["message"].is_string(), "error.message should be a string");
+    assert!(
+        json["error"]["code"].is_string(),
+        "error.code should be a string"
+    );
+    assert!(
+        json["error"]["message"].is_string(),
+        "error.message should be a string"
+    );
 }

--- a/tests/graphql_contract_test.rs
+++ b/tests/graphql_contract_test.rs
@@ -52,7 +52,10 @@ fn test_graphql_introspection_detects_valid_endpoint() {
         let result = rt.block_on(async { adapter.can_handle(&server.url()).await });
 
         assert!(result.is_ok());
-        assert!(result.unwrap(), "Should detect GraphQL endpoint via introspection");
+        assert!(
+            result.unwrap(),
+            "Should detect GraphQL endpoint via introspection"
+        );
     });
 }
 
@@ -105,7 +108,10 @@ fn test_graphql_introspection_handles_errors_response() {
         let result = rt.block_on(async { adapter.can_handle(&server.url()).await });
 
         assert!(result.is_ok());
-        assert!(result.unwrap(), "GraphQL errors in response still indicate GraphQL endpoint");
+        assert!(
+            result.unwrap(),
+            "GraphQL errors in response still indicate GraphQL endpoint"
+        );
     });
 }
 
@@ -182,7 +188,10 @@ fn test_graphql_parses_query_fields() {
         assert!(operations.iter().any(|op| op.operation_id == "query/user"));
         assert!(operations.iter().any(|op| op.operation_id == "query/users"));
 
-        let user_op = operations.iter().find(|op| op.operation_id == "query/user").unwrap();
+        let user_op = operations
+            .iter()
+            .find(|op| op.operation_id == "query/user")
+            .unwrap();
         assert_eq!(user_op.description.as_ref().unwrap(), "Get a user by ID");
         assert_eq!(user_op.parameters.len(), 1);
         assert_eq!(user_op.parameters[0].name, "id");
@@ -242,7 +251,10 @@ fn test_graphql_parses_mutation_fields() {
 
         assert_eq!(operations.len(), 1);
         assert_eq!(operations[0].operation_id, "mutation/createUser");
-        assert_eq!(operations[0].description.as_ref().unwrap(), "Create a new user");
+        assert_eq!(
+            operations[0].description.as_ref().unwrap(),
+            "Create a new user"
+        );
         assert_eq!(operations[0].parameters.len(), 2);
         assert!(operations[0].parameters[0].required);
         assert!(!operations[0].parameters[1].required);
@@ -296,7 +308,10 @@ fn test_graphql_parses_subscription_fields() {
 
         assert_eq!(operations.len(), 1);
         assert_eq!(operations[0].operation_id, "subscription/userUpdated");
-        assert_eq!(operations[0].description.as_ref().unwrap(), "Subscribe to user updates");
+        assert_eq!(
+            operations[0].description.as_ref().unwrap(),
+            "Subscribe to user updates"
+        );
     });
 }
 
@@ -361,19 +376,34 @@ fn test_graphql_parses_scalar_types() {
             .unwrap();
 
         assert_eq!(operations.len(), 5);
-        let int_op = operations.iter().find(|op| op.operation_id == "query/intField").unwrap();
+        let int_op = operations
+            .iter()
+            .find(|op| op.operation_id == "query/intField")
+            .unwrap();
         assert_eq!(int_op.parameters[0].param_type, "Int");
 
-        let float_op = operations.iter().find(|op| op.operation_id == "query/floatField").unwrap();
+        let float_op = operations
+            .iter()
+            .find(|op| op.operation_id == "query/floatField")
+            .unwrap();
         assert_eq!(float_op.parameters[0].param_type, "Float");
 
-        let string_op = operations.iter().find(|op| op.operation_id == "query/stringField").unwrap();
+        let string_op = operations
+            .iter()
+            .find(|op| op.operation_id == "query/stringField")
+            .unwrap();
         assert_eq!(string_op.parameters[0].param_type, "String");
 
-        let bool_op = operations.iter().find(|op| op.operation_id == "query/boolField").unwrap();
+        let bool_op = operations
+            .iter()
+            .find(|op| op.operation_id == "query/boolField")
+            .unwrap();
         assert_eq!(bool_op.parameters[0].param_type, "Boolean");
 
-        let id_op = operations.iter().find(|op| op.operation_id == "query/idField").unwrap();
+        let id_op = operations
+            .iter()
+            .find(|op| op.operation_id == "query/idField")
+            .unwrap();
         assert_eq!(id_op.parameters[0].param_type, "ID");
     });
 }
@@ -576,7 +606,11 @@ fn test_graphql_builds_input_schema_for_query() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = GraphQLAdapter::new();
         let detail = rt
-            .block_on(async { adapter.describe_operation(&server.url(), "query/user").await })
+            .block_on(async {
+                adapter
+                    .describe_operation(&server.url(), "query/user")
+                    .await
+            })
             .unwrap();
 
         assert!(detail.input_schema.is_some());
@@ -645,15 +679,28 @@ fn test_graphql_builds_input_schema_with_input_object() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = GraphQLAdapter::new();
         let detail = rt
-            .block_on(async { adapter.describe_operation(&server.url(), "query/search").await })
+            .block_on(async {
+                adapter
+                    .describe_operation(&server.url(), "query/search")
+                    .await
+            })
             .unwrap();
 
         assert!(detail.input_schema.is_some());
         let schema = detail.input_schema.unwrap();
         assert!(schema["properties"]["filter"]["properties"]["limit"].is_object());
-        assert_eq!(schema["properties"]["filter"]["properties"]["limit"]["type"], "integer");
-        assert_eq!(schema["properties"]["filter"]["properties"]["limit"]["description"], "Max results");
-        assert_eq!(schema["properties"]["filter"]["properties"]["query"]["type"], "string");
+        assert_eq!(
+            schema["properties"]["filter"]["properties"]["limit"]["type"],
+            "integer"
+        );
+        assert_eq!(
+            schema["properties"]["filter"]["properties"]["limit"]["description"],
+            "Max results"
+        );
+        assert_eq!(
+            schema["properties"]["filter"]["properties"]["query"]["type"],
+            "string"
+        );
     });
 }
 
@@ -706,7 +753,11 @@ fn test_graphql_builds_input_schema_with_enum() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = GraphQLAdapter::new();
         let detail = rt
-            .block_on(async { adapter.describe_operation(&server.url(), "query/items").await })
+            .block_on(async {
+                adapter
+                    .describe_operation(&server.url(), "query/items")
+                    .await
+            })
             .unwrap();
 
         assert!(detail.input_schema.is_some());
@@ -751,7 +802,9 @@ fn test_graphql_handles_missing_operation() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = GraphQLAdapter::new();
         let result = rt.block_on(async {
-            adapter.describe_operation(&server.url(), "query/nonexistent").await
+            adapter
+                .describe_operation(&server.url(), "query/nonexistent")
+                .await
         });
 
         assert!(result.is_err());
@@ -788,7 +841,11 @@ fn test_graphql_handles_invalid_operation_format() {
         assert!(result.is_err(), "Should fail for operation without prefix");
 
         // Invalid prefix - should fail with format error
-        let result = rt.block_on(async { adapter.describe_operation(&server.url(), "invalid/user").await });
+        let result = rt.block_on(async {
+            adapter
+                .describe_operation(&server.url(), "invalid/user")
+                .await
+        });
         assert!(result.is_err(), "Should fail for invalid operation type");
         let err_msg = result.unwrap_err().to_string();
         // Check that error message mentions the invalid operation
@@ -821,7 +878,10 @@ fn test_graphql_handles_introspection_errors() {
         let result = rt.block_on(async { adapter.fetch_schema(&server.url()).await });
 
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("GraphQL introspection failed"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("GraphQL introspection failed"));
     });
 }
 
@@ -949,13 +1009,22 @@ fn test_graphql_return_type_display_names() {
             .block_on(async { adapter.list_operations(&server.url()).await })
             .unwrap();
 
-        let simple = operations.iter().find(|op| op.operation_id == "query/simple").unwrap();
+        let simple = operations
+            .iter()
+            .find(|op| op.operation_id == "query/simple")
+            .unwrap();
         assert_eq!(simple.return_type.as_ref().unwrap(), "String");
 
-        let required = operations.iter().find(|op| op.operation_id == "query/required").unwrap();
+        let required = operations
+            .iter()
+            .find(|op| op.operation_id == "query/required")
+            .unwrap();
         assert_eq!(required.return_type.as_ref().unwrap(), "String!");
 
-        let list = operations.iter().find(|op| op.operation_id == "query/listOfRequired").unwrap();
+        let list = operations
+            .iter()
+            .find(|op| op.operation_id == "query/listOfRequired")
+            .unwrap();
         assert_eq!(list.return_type.as_ref().unwrap(), "[Int!]");
     });
 }
@@ -1003,10 +1072,16 @@ fn test_graphql_description_optional_fields() {
             .unwrap();
 
         assert_eq!(operations.len(), 2);
-        let with_desc = operations.iter().find(|op| op.operation_id == "query/withDescription").unwrap();
+        let with_desc = operations
+            .iter()
+            .find(|op| op.operation_id == "query/withDescription")
+            .unwrap();
         assert_eq!(with_desc.description.as_ref().unwrap(), "Has description");
 
-        let without_desc = operations.iter().find(|op| op.operation_id == "query/withoutDescription").unwrap();
+        let without_desc = operations
+            .iter()
+            .find(|op| op.operation_id == "query/withoutDescription")
+            .unwrap();
         assert!(without_desc.description.is_none());
     });
 }
@@ -1061,7 +1136,11 @@ fn test_graphql_handles_circular_type_references() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = GraphQLAdapter::new();
         let detail = rt
-            .block_on(async { adapter.describe_operation(&server.url(), "query/node").await })
+            .block_on(async {
+                adapter
+                    .describe_operation(&server.url(), "query/node")
+                    .await
+            })
             .unwrap();
 
         // Should handle circular references without infinite recursion

--- a/tests/jsonrpc_contract_test.rs
+++ b/tests/jsonrpc_contract_test.rs
@@ -267,7 +267,10 @@ fn test_jsonrpc_method_parsing_parameters() {
 
         assert_eq!(method.parameters[0].name, "query");
         assert!(method.parameters[0].required);
-        assert_eq!(method.parameters[0].description.as_ref().unwrap(), "Search query string");
+        assert_eq!(
+            method.parameters[0].description.as_ref().unwrap(),
+            "Search query string"
+        );
 
         assert_eq!(method.parameters[1].name, "limit");
         assert!(!method.parameters[1].required);
@@ -317,10 +320,16 @@ fn test_jsonrpc_method_return_type() {
             .unwrap();
 
         assert_eq!(operations.len(), 2);
-        let data_method = operations.iter().find(|op| op.operation_id == "getData").unwrap();
+        let data_method = operations
+            .iter()
+            .find(|op| op.operation_id == "getData")
+            .unwrap();
         assert_eq!(data_method.return_type.as_ref().unwrap(), "object");
 
-        let string_method = operations.iter().find(|op| op.operation_id == "getString").unwrap();
+        let string_method = operations
+            .iter()
+            .find(|op| op.operation_id == "getString")
+            .unwrap();
         assert_eq!(string_method.return_type.as_ref().unwrap(), "string");
     });
 }
@@ -432,7 +441,11 @@ fn test_jsonrpc_param_structure_either_default() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = JsonRpcAdapter::new();
         let detail = rt
-            .block_on(async { adapter.describe_operation(&server.url(), "methodWithEither").await })
+            .block_on(async {
+                adapter
+                    .describe_operation(&server.url(), "methodWithEither")
+                    .await
+            })
             .unwrap();
 
         assert!(detail.input_schema.is_some());
@@ -601,7 +614,9 @@ fn test_jsonrpc_standard_error_codes() {
         let adapter = JsonRpcAdapter::new();
 
         let result = rt.block_on(async {
-            adapter.execute(&url, "nonexistent", std::collections::HashMap::new()).await
+            adapter
+                .execute(&url, "nonexistent", std::collections::HashMap::new())
+                .await
         });
 
         // Should fail with an error
@@ -656,7 +671,9 @@ fn test_jsonrpc_error_with_data() {
         let adapter = JsonRpcAdapter::new();
 
         let result = rt.block_on(async {
-            adapter.execute(&url, "failingMethod", std::collections::HashMap::new()).await
+            adapter
+                .execute(&url, "failingMethod", std::collections::HashMap::new())
+                .await
         });
 
         assert!(result.is_err());
@@ -697,7 +714,13 @@ fn test_jsonrpc_missing_required_parameter() {
 
         // Call without required parameter
         let result = rt.block_on(async {
-            adapter.execute(&url, "methodWithRequiredParam", std::collections::HashMap::new()).await
+            adapter
+                .execute(
+                    &url,
+                    "methodWithRequiredParam",
+                    std::collections::HashMap::new(),
+                )
+                .await
         });
 
         assert!(result.is_err());
@@ -786,7 +809,9 @@ fn test_jsonrpc_missing_result_field() {
         let adapter = JsonRpcAdapter::new();
 
         let result = rt.block_on(async {
-            adapter.execute(&url, "noResult", std::collections::HashMap::new()).await
+            adapter
+                .execute(&url, "noResult", std::collections::HashMap::new())
+                .await
         });
 
         assert!(result.is_err());
@@ -814,7 +839,11 @@ fn test_jsonrpc_handles_missing_operation() {
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = JsonRpcAdapter::new();
-        let result = rt.block_on(async { adapter.describe_operation(&server.url(), "nonexistent").await });
+        let result = rt.block_on(async {
+            adapter
+                .describe_operation(&server.url(), "nonexistent")
+                .await
+        });
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
@@ -901,7 +930,9 @@ fn test_jsonrpc_url_resolution_from_servers_field() {
         let adapter = JsonRpcAdapter::new();
 
         let result = rt.block_on(async {
-            adapter.execute(&url, "test", std::collections::HashMap::new()).await
+            adapter
+                .execute(&url, "test", std::collections::HashMap::new())
+                .await
         });
 
         assert!(result.is_ok());
@@ -944,10 +975,16 @@ fn test_jsonrpc_description_fallback_to_summary() {
             .unwrap();
 
         assert_eq!(operations.len(), 2);
-        let m1 = operations.iter().find(|op| op.operation_id == "method1").unwrap();
+        let m1 = operations
+            .iter()
+            .find(|op| op.operation_id == "method1")
+            .unwrap();
         assert_eq!(m1.description.as_ref().unwrap(), "Has description");
 
-        let m2 = operations.iter().find(|op| op.operation_id == "method2").unwrap();
+        let m2 = operations
+            .iter()
+            .find(|op| op.operation_id == "method2")
+            .unwrap();
         assert_eq!(m2.description.as_ref().unwrap(), "Has summary");
     });
 }
@@ -1050,11 +1087,14 @@ fn test_jsonrpc_request_id_generation() {
             })))
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "result": "success"
-            }).to_string())
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": "success"
+                })
+                .to_string(),
+            )
             .create();
 
         let url = server.url();
@@ -1062,7 +1102,9 @@ fn test_jsonrpc_request_id_generation() {
         let adapter = JsonRpcAdapter::new();
 
         let result = rt.block_on(async {
-            adapter.execute(&url, "test", std::collections::HashMap::new()).await
+            adapter
+                .execute(&url, "test", std::collections::HashMap::new())
+                .await
         });
 
         assert!(result.is_ok());

--- a/tests/link_cli_test.rs
+++ b/tests/link_cli_test.rs
@@ -239,11 +239,8 @@ fn link_shortcut_is_runnable_and_forwards_args() {
         .expect("uxc link should run");
     assert!(create.status.success(), "link creation should succeed");
 
-    fs::write(
-        &fake_uxc_path,
-        "#!/usr/bin/env sh\nprintf '%s\\n' \"$@\"\n",
-    )
-    .expect("fake uxc should be written");
+    fs::write(&fake_uxc_path, "#!/usr/bin/env sh\nprintf '%s\\n' \"$@\"\n")
+        .expect("fake uxc should be written");
     let mut perms = fs::metadata(&fake_uxc_path)
         .expect("fake uxc metadata should be readable")
         .permissions();

--- a/tests/openapi_contract_test.rs
+++ b/tests/openapi_contract_test.rs
@@ -148,7 +148,10 @@ fn test_openapi_tries_multiple_schema_endpoints() {
         let result = rt.block_on(async { adapter.can_handle(&server.url()).await });
 
         assert!(result.is_ok());
-        assert!(result.unwrap(), "Should try multiple endpoints and find schema");
+        assert!(
+            result.unwrap(),
+            "Should try multiple endpoints and find schema"
+        );
     });
 }
 
@@ -202,11 +205,21 @@ fn test_openapi_lists_all_http_methods() {
             .unwrap();
 
         assert_eq!(operations.len(), 5);
-        assert!(operations.iter().any(|op| op.operation_id == "get:/resource"));
-        assert!(operations.iter().any(|op| op.operation_id == "post:/resource"));
-        assert!(operations.iter().any(|op| op.operation_id == "put:/resource"));
-        assert!(operations.iter().any(|op| op.operation_id == "patch:/resource"));
-        assert!(operations.iter().any(|op| op.operation_id == "delete:/resource"));
+        assert!(operations
+            .iter()
+            .any(|op| op.operation_id == "get:/resource"));
+        assert!(operations
+            .iter()
+            .any(|op| op.operation_id == "post:/resource"));
+        assert!(operations
+            .iter()
+            .any(|op| op.operation_id == "put:/resource"));
+        assert!(operations
+            .iter()
+            .any(|op| op.operation_id == "patch:/resource"));
+        assert!(operations
+            .iter()
+            .any(|op| op.operation_id == "delete:/resource"));
     });
 }
 
@@ -497,7 +510,11 @@ fn test_openapi_parses_request_body_schema() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = OpenAPIAdapter::new();
         let detail = rt
-            .block_on(async { adapter.describe_operation(&server.url(), "post:/users").await })
+            .block_on(async {
+                adapter
+                    .describe_operation(&server.url(), "post:/users")
+                    .await
+            })
             .unwrap();
 
         assert!(detail.input_schema.is_some());
@@ -544,7 +561,11 @@ fn test_openapi_request_body_with_multiple_content_types() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = OpenAPIAdapter::new();
         let detail = rt
-            .block_on(async { adapter.describe_operation(&server.url(), "post:/upload").await })
+            .block_on(async {
+                adapter
+                    .describe_operation(&server.url(), "post:/upload")
+                    .await
+            })
             .unwrap();
 
         assert!(detail.input_schema.is_some());
@@ -602,7 +623,11 @@ fn test_openapi_resolves_local_refs() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = OpenAPIAdapter::new();
         let detail = rt
-            .block_on(async { adapter.describe_operation(&server.url(), "post:/users").await })
+            .block_on(async {
+                adapter
+                    .describe_operation(&server.url(), "post:/users")
+                    .await
+            })
             .unwrap();
 
         assert!(detail.input_schema.is_some());
@@ -664,7 +689,11 @@ fn test_openapi_handles_nested_refs() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = OpenAPIAdapter::new();
         let detail = rt
-            .block_on(async { adapter.describe_operation(&server.url(), "post:/users").await })
+            .block_on(async {
+                adapter
+                    .describe_operation(&server.url(), "post:/users")
+                    .await
+            })
             .unwrap();
 
         assert!(detail.input_schema.is_some());
@@ -672,7 +701,10 @@ fn test_openapi_handles_nested_refs() {
         let expanded = &schema["content"]["application/json"]["schema"];
         // Nested refs should be expanded
         assert_eq!(expanded["properties"]["user"]["type"], "object");
-        assert_eq!(expanded["properties"]["user"]["properties"]["id"]["type"], "integer");
+        assert_eq!(
+            expanded["properties"]["user"]["properties"]["id"]["type"],
+            "integer"
+        );
     });
 }
 
@@ -706,7 +738,9 @@ fn test_openapi_handles_missing_operation() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = OpenAPIAdapter::new();
         let result = rt.block_on(async {
-            adapter.describe_operation(&server.url(), "get:/nonexistent").await
+            adapter
+                .describe_operation(&server.url(), "get:/nonexistent")
+                .await
         });
 
         assert!(result.is_err());
@@ -738,7 +772,11 @@ fn test_openapi_handles_invalid_operation_id_format() {
         assert!(result.is_err());
 
         // Invalid: wrong format
-        let result = rt.block_on(async { adapter.describe_operation(&server.url(), "GET /users").await });
+        let result = rt.block_on(async {
+            adapter
+                .describe_operation(&server.url(), "GET /users")
+                .await
+        });
         assert!(result.is_err());
     });
 }
@@ -761,10 +799,17 @@ fn test_openapi_handles_unsupported_http_method() {
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         let adapter = OpenAPIAdapter::new();
-        let result = rt.block_on(async { adapter.describe_operation(&server.url(), "invalid:/path").await });
+        let result = rt.block_on(async {
+            adapter
+                .describe_operation(&server.url(), "invalid:/path")
+                .await
+        });
 
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Unsupported HTTP method"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported HTTP method"));
     });
 }
 
@@ -868,10 +913,16 @@ fn test_openapi_descriptions_fallback_to_summary() {
             .unwrap();
 
         assert_eq!(operations.len(), 2);
-        let get_op = operations.iter().find(|op| op.operation_id == "get:/users").unwrap();
+        let get_op = operations
+            .iter()
+            .find(|op| op.operation_id == "get:/users")
+            .unwrap();
         assert_eq!(get_op.description.as_ref().unwrap(), "List all users");
 
-        let post_op = operations.iter().find(|op| op.operation_id == "post:/users").unwrap();
+        let post_op = operations
+            .iter()
+            .find(|op| op.operation_id == "post:/users")
+            .unwrap();
         assert_eq!(post_op.description.as_ref().unwrap(), "Create a new user");
     });
 }

--- a/tests/protocol_test.rs
+++ b/tests/protocol_test.rs
@@ -9,13 +9,11 @@
 //! Note: Due to mockito 1.2 compatibility issues with tokio::test,
 //! HTTP-based tests use a manual runtime pattern.
 
-use uxc::adapters::{
-    Adapter, AdapterEnum, DetectionOptions, ProtocolDetector, ProtocolType,
-};
 use uxc::adapters::graphql::GraphQLAdapter;
-use uxc::adapters::openapi::OpenAPIAdapter;
 use uxc::adapters::jsonrpc::JsonRpcAdapter;
 use uxc::adapters::mcp::McpAdapter;
+use uxc::adapters::openapi::OpenAPIAdapter;
+use uxc::adapters::{Adapter, AdapterEnum, DetectionOptions, ProtocolDetector, ProtocolType};
 use uxc::protocol::ProtocolRouter;
 
 /// Helper to run async code with a mock server
@@ -172,7 +170,9 @@ fn test_protocol_router_detect_mcp_stdio() {
     // Test npx command
     let result = rt.block_on(async {
         let router = ProtocolRouter::new();
-        router.detect_protocol("npx @modelcontextprotocol/server-everything").await
+        router
+            .detect_protocol("npx @modelcontextprotocol/server-everything")
+            .await
     });
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), ProtocolType::Mcp);
@@ -397,7 +397,9 @@ fn test_protocol_router_get_adapter_with_schema_url_override() {
         let options = DetectionOptions {
             schema_url: Some(schema_url),
         };
-        router.get_adapter_for_url_with_options(&base_url, &options).await
+        router
+            .get_adapter_for_url_with_options(&base_url, &options)
+            .await
     });
 
     assert!(result.is_ok());
@@ -470,12 +472,8 @@ fn test_protocol_detector_http_vs_stdio() {
     let detector = ProtocolDetector::new();
 
     // These should not be detected as MCP stdio
-    let http_result = rt.block_on(async {
-        detector.detect_adapter(http_url).await
-    });
-    let https_result = rt.block_on(async {
-        detector.detect_adapter(https_url).await
-    });
+    let http_result = rt.block_on(async { detector.detect_adapter(http_url).await });
+    let https_result = rt.block_on(async { detector.detect_adapter(https_url).await });
 
     // Both should fail (no actual server), but not because of stdio detection
     assert!(http_result.is_err() || https_result.is_err());
@@ -770,7 +768,9 @@ fn test_detection_options_schema_url_some() {
         let options = DetectionOptions {
             schema_url: Some(schema_url),
         };
-        detector.detect_adapter_with_options(&base_url, &options).await
+        detector
+            .detect_adapter_with_options(&base_url, &options)
+            .await
     });
 
     assert!(result.is_ok());
@@ -919,12 +919,7 @@ fn test_empty_url() {
 fn test_invalid_url_format() {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    let invalid_urls = vec![
-        "not-a-url",
-        "://invalid",
-        "http://",
-        "://example.com",
-    ];
+    let invalid_urls = vec!["not-a-url", "://invalid", "http://", "://example.com"];
 
     for url in invalid_urls {
         let result = rt.block_on(async {
@@ -999,7 +994,10 @@ fn test_graphql_adapter_can_handle() {
     });
 
     assert!(result.is_ok());
-    assert!(result.unwrap(), "GraphQL adapter should handle GraphQL endpoint");
+    assert!(
+        result.unwrap(),
+        "GraphQL adapter should handle GraphQL endpoint"
+    );
 }
 
 #[test]
@@ -1098,7 +1096,9 @@ fn test_jsonrpc_adapter_can_handle() {
 #[test]
 fn test_mcp_adapter_is_stdio_command() {
     // Test various stdio command patterns
-    assert!(McpAdapter::is_stdio_command("npx @modelcontextprotocol/server"));
+    assert!(McpAdapter::is_stdio_command(
+        "npx @modelcontextprotocol/server"
+    ));
     assert!(McpAdapter::is_stdio_command("node server.js"));
     assert!(McpAdapter::is_stdio_command("python3 server.py"));
     assert!(McpAdapter::is_stdio_command("./my-server"));


### PR DESCRIPTION
## What
- add rustfmt check to CI (`cargo fmt --all -- --check`) in `rust-quality`
- install `rustfmt` component for the CI quality job
- commit the current rustfmt normalization changes so CI format check is green and stable

## Why
We observed local formatting drift and no fmt gate in CI. This PR adds a deterministic formatter check and aligns current files with rustfmt output.

## How
- update `.github/workflows/ci.yml` to include rustfmt component and fmt check step
- keep clippy check intact
- include rustfmt-produced updates in affected `src/adapters/mcp/*` and `tests/*` files

## Testing
- `cargo fmt --all -- --check`