### PR TITLE
fix: improve MCP OAuth discovery compatibility with GitHub

### DIFF
--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -171,7 +171,7 @@ pub async fn discover_provider_metadata(
         .or_else(|| openid.as_ref().map(|config| config.token_endpoint.clone()))
         .ok_or_else(|| {
             UxcError::OAuthDiscoveryFailed(
-                "Could not determine token_endpoint from authorization server metadata".to_string(),
+                "Could not determine token_endpoint from provider metadata".to_string(),
             )
         })?;
 


### PR DESCRIPTION
## What
Improve MCP OAuth discovery and token flow compatibility for GitHub authorization server metadata.

## Why
Current discovery expected only OIDC-style metadata and failed for GitHub MCP OAuth issuer formats, leading to `OAUTH_DISCOVERY_FAILED`.

## How
Use RFC 8414 path-aware metadata candidates, fallback between authorization-server metadata and OIDC metadata, and add GitHub device endpoint fallback.

## Changes
- [x] Add RFC 8414 path-aware candidate generation for `.well-known/oauth-authorization-server` and `.well-known/openid-configuration`
- [x] Discover token endpoint from authorization server metadata first, fallback to OIDC
- [x] Add GitHub-specific fallback for device endpoint (`/login/device/code`) when metadata omits it
- [x] Add `Accept: application/json` to OAuth token/device requests for GitHub compatibility
- [x] Add unit tests for path-aware metadata candidate generation and GitHub device endpoint inference

## Testing
### Unit Tests
- [x] `cargo test auth::oauth --lib`

### Manual Testing
- [x] `uxc auth oauth login ... --endpoint https://api.githubcopilot.com/mcp --flow device_code ...`
- [x] Verified discovery no longer fails with `OAUTH_DISCOVERY_FAILED` (now reaches device code request stage)

### Test Results
```bash
cargo test auth::oauth --lib
running 4 tests
... ok
```

## Checklist
- [x] Code formatted with `cargo fmt`
- [ ] No clippy warnings (`cargo clippy -- -D warnings`)
- [ ] All tests pass (`cargo test`)
- [ ] Documentation updated
- [x] Commit messages follow convention
- [x] PR title follows convention

## Breaking Changes
None.

## Additional Notes
This PR focuses on discovery/compatibility improvements needed for GitHub MCP OAuth issuer behavior.