### PR TITLE
fix(mcp): make HTTP probe robust and surface detection diagnostics

### DIFF
--- a/src/adapters/mcp/http_transport.rs
+++ b/src/adapters/mcp/http_transport.rs
@@ -315,10 +315,11 @@ impl McpHttpTransport {
     fn summarize_body(body: &str) -> String {
         const MAX_CHARS: usize = 240;
         let compact = body.split_whitespace().collect::<Vec<_>>().join(" ");
-        if compact.len() <= MAX_CHARS {
+        if compact.chars().count() <= MAX_CHARS {
             compact
         } else {
-            format!("{}...", &compact[..MAX_CHARS])
+            let truncated: String = compact.chars().take(MAX_CHARS).collect();
+            format!("{}...", truncated)
         }
     }
 

--- a/src/adapters/mcp/mod.rs
+++ b/src/adapters/mcp/mod.rs
@@ -26,6 +26,7 @@ pub struct McpAdapter {
     cache: Option<Arc<dyn crate::cache::Cache>>,
     auth_profile: Option<Profile>,
     discovered_http_endpoints: Arc<RwLock<HashMap<String, String>>>,
+    last_probe_diagnostics: Arc<RwLock<Option<String>>>,
 }
 
 impl McpAdapter {
@@ -34,6 +35,7 @@ impl McpAdapter {
             cache: None,
             auth_profile: None,
             discovered_http_endpoints: Arc::new(RwLock::new(HashMap::new())),
+            last_probe_diagnostics: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -119,12 +121,17 @@ impl McpAdapter {
     async fn resolve_http_endpoint(&self, url: &str) -> Option<String> {
         let normalized = Self::normalize_http_url(url);
         {
+            let mut diag = self.last_probe_diagnostics.write().await;
+            *diag = None;
+        }
+        {
             let cache = self.discovered_http_endpoints.read().await;
             if let Some(endpoint) = cache.get(&normalized) {
                 return Some(endpoint.clone());
             }
         }
 
+        let mut reasons = Vec::new();
         for candidate in Self::http_endpoint_candidates(url) {
             match McpHttpTransport::probe_initialize_with_reason(
                 &candidate,
@@ -137,29 +144,6 @@ impl McpAdapter {
                     cache.insert(normalized, candidate.clone());
                     return Some(candidate);
                 }
-                Ok(http_transport::ProbeInitializeOutcome::NotMcp(_)) => {}
-                Err(_) => {}
-            }
-        }
-
-        None
-    }
-
-    pub async fn diagnose_http_endpoint(
-        url: &str,
-        auth_profile: Option<Profile>,
-    ) -> Option<String> {
-        if !Self::is_http_url(url) {
-            return None;
-        }
-
-        let mut reasons = Vec::new();
-        for candidate in Self::http_endpoint_candidates(url) {
-            let outcome =
-                McpHttpTransport::probe_initialize_with_reason(&candidate, auth_profile.clone())
-                    .await;
-            match outcome {
-                Ok(http_transport::ProbeInitializeOutcome::Success) => return None,
                 Ok(http_transport::ProbeInitializeOutcome::NotMcp(reason)) => {
                     reasons.push(format!("{} => {}", candidate, reason));
                 }
@@ -167,11 +151,16 @@ impl McpAdapter {
             }
         }
 
-        if reasons.is_empty() {
-            None
-        } else {
-            Some(reasons.join("; "))
+        if !reasons.is_empty() {
+            let mut diag = self.last_probe_diagnostics.write().await;
+            *diag = Some(reasons.join("; "));
         }
+
+        None
+    }
+
+    pub async fn latest_probe_diagnostics(&self) -> Option<String> {
+        self.last_probe_diagnostics.read().await.clone()
     }
 }
 

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -255,9 +255,7 @@ impl ProtocolDetector {
         }
 
         let mut message = format!("No adapter found for URL: {}", url);
-        if let Some(diag) =
-            mcp::McpAdapter::diagnose_http_endpoint(url, options.auth_profile.clone()).await
-        {
+        if let Some(diag) = mcp_adapter.latest_probe_diagnostics().await {
             message.push_str(&format!(". MCP probe diagnostics: {}", diag));
         }
 


### PR DESCRIPTION
## What
- make MCP HTTP probe more robust for real-world endpoints (including GitHub MCP)
- add probe diagnostics so protocol detection failures include actionable MCP failure reasons
- keep probe behavior backward compatible via `probe_initialize`, backed by the new detailed probe path

## Why
`uxc --profile <bearer> https://api.githubcopilot.com/mcp list` could fail with `PROTOCOL_DETECTION_FAILED` even when the endpoint is reachable and token is valid. Also, detection failures hid underlying MCP probe errors, making triage difficult.

## How
- in `src/adapters/mcp/http_transport.rs`:
  - increase probe timeout from 3s to 10s
  - add `ProbeInitializeOutcome` and `probe_initialize_with_reason(...)`
  - preserve existing `probe_initialize(...)` API by delegating to the detailed probe
- in `src/adapters/mcp/mod.rs`:
  - use detailed probe in endpoint resolution
  - add `diagnose_http_endpoint(...)` to collect candidate endpoint probe failures
- in `src/adapters/mod.rs`:
  - append MCP diagnostics to `PROTOCOL_DETECTION_FAILED` when applicable

## Testing
- `cargo fmt`
- `cargo test --lib parse_token_endpoint_response -- --test-threads=1`
- `cargo test --lib detector_ -- --test-threads=1`
- manual:
  - `target/debug/uxc --profile gh_bearer https://api.githubcopilot.com/mcp list` succeeds
  - `target/debug/uxc https://api.githubcopilot.com/mcp list` now includes diagnostics like `HTTP 401 Unauthorized: missing required Authorization header`