### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-02-28
+
 ### Changed
 - Endpoint CLI interaction is now single-path and help-first:
   - `uxc <host> -h`
@@ -142,7 +144,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/holon-run/uxc/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/holon-run/uxc/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/holon-run/uxc/releases/tag/v0.4.0
 [0.3.0]: https://github.com/holon-run/uxc/releases/tag/v0.3.0
 [0.2.0]: https://github.com/holon-run/uxc/releases/tag/v0.2.0
 [0.1.1]: https://github.com/holon-run/uxc/releases/tag/v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxc"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["UXC Contributors"]
 description = "Universal API calling CLI for URL-first schema discovery and invocation across OpenAPI, gRPC, GraphQL, MCP, and JSON-RPC"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ bash install-uxc.sh
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.3.0
+curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.4.0
 ```
 
 ### Cargo


### PR DESCRIPTION
## Summary
- bump crate version to 0.4.0 in Cargo.toml
- move current Unreleased notes into 0.4.0 release section dated 2026-02-28
- update changelog compare/release links for v0.4.0
- refresh install example in README to use v0.4.0

## Verification
- ./scripts/release-check.sh v0.4.0