### PR TITLE
feat(skills): add playwright mcp wrapper skill

### DIFF
--- a/skills/playwright-mcp-skill/SKILL.md
+++ b/skills/playwright-mcp-skill/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: playwright-mcp-skill
+description: Run browser automation through @playwright/mcp over UXC stdio MCP, with daemon-friendly session reuse and safe action guardrails. Use when tasks need deterministic page navigation, DOM snapshots, and scripted browser interaction from CLI.
+---
+
+# Playwright MCP Skill
+
+Use this skill to run Playwright MCP operations through `uxc` using a fixed stdio endpoint.
+
+Reuse the `uxc` skill for generic protocol discovery, auth/error handling, and envelope parsing rules.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- `npx` is available in `PATH` (Node.js installed).
+- Network access for first-time `@playwright/mcp` package fetch.
+- Browser runtime can start locally (headless mode is default in this skill).
+
+## Core Workflow (Playwright-Specific)
+
+Endpoint candidate inputs before finalizing:
+- Raw package form from docs: `npx @playwright/mcp@latest`
+- Reliable non-interactive form: `npx -y @playwright/mcp@latest`
+- Isolated/headless stable form (default for this skill):
+  - `npx -y @playwright/mcp@latest --headless --isolated`
+
+1. Verify protocol/path from official source and probe:
+   - Official source: `https://github.com/microsoft/playwright-mcp`
+   - probe candidate endpoints with:
+     - `uxc "npx -y @playwright/mcp@latest --headless --isolated" -h`
+   - Confirm protocol is MCP stdio (`protocol == "mcp"` in envelope).
+2. Detect auth requirement explicitly:
+   - Run host help or a minimal read call and inspect envelope.
+   - `@playwright/mcp` default flow is no OAuth/API key for local stdio use.
+3. Use fixed link command by default:
+   - `command -v playwright-mcp-cli`
+   - If missing, create it:
+     - `uxc link playwright-mcp-cli "npx -y @playwright/mcp@latest --headless --isolated"`
+   - `playwright-mcp-cli -h`
+   - If command conflict is detected and cannot be safely reused, stop and ask skill maintainers to pick another fixed command name.
+4. Inspect operation schema before execution:
+   - `playwright-mcp-cli browser_navigate -h`
+   - `playwright-mcp-cli browser_snapshot -h`
+   - `playwright-mcp-cli browser_click -h`
+5. Prefer read-first interaction:
+   - Start with navigation/snapshot before mutating page state.
+6. Execute actions with explicit confirmation when impact is high:
+   - Confirm before form submission, checkout, delete/destructive actions, or irreversible multi-step flows.
+
+## Guardrails
+
+- Keep automation on JSON output envelope; do not rely on `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- Use `playwright-mcp-cli` as default command path.
+- `playwright-mcp-cli <operation> ...` is equivalent to `uxc "npx -y @playwright/mcp@latest --headless --isolated" <operation> ...`.
+- Use direct `uxc "<endpoint>" ...` only as temporary fallback when link setup is unavailable.
+- If browser profile conflict appears, keep `--isolated` in endpoint and retry via the same fixed link command.
+- Prefer `browser_snapshot` over screenshots for model-action loops.
+
+## References
+
+- Invocation patterns:
+  - `references/usage-patterns.md`

--- a/skills/playwright-mcp-skill/agents/openai.yaml
+++ b/skills/playwright-mcp-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Playwright MCP"
+  short_description: "Automate browser tasks via @playwright/mcp over UXC stdio"
+  default_prompt: "Use $playwright-mcp-skill to navigate pages, inspect snapshots, and run browser actions through @playwright/mcp with UXC."

--- a/skills/playwright-mcp-skill/references/usage-patterns.md
+++ b/skills/playwright-mcp-skill/references/usage-patterns.md
@@ -1,0 +1,65 @@
+# Usage Patterns
+
+All commands in this skill use the fixed stdio endpoint:
+`npx -y @playwright/mcp@latest --headless --isolated`
+
+This skill defaults to fixed link command `playwright-mcp-cli`.
+Create it when missing:
+
+```bash
+command -v playwright-mcp-cli
+uxc link playwright-mcp-cli "npx -y @playwright/mcp@latest --headless --isolated"
+```
+
+## Discover And Inspect
+
+```bash
+playwright-mcp-cli -h
+playwright-mcp-cli browser_navigate -h
+playwright-mcp-cli browser_snapshot -h
+```
+
+## Read-First Flow
+
+Navigate first:
+
+```bash
+playwright-mcp-cli browser_navigate url=https://example.com
+```
+
+Capture accessibility snapshot:
+
+```bash
+playwright-mcp-cli browser_snapshot
+```
+
+## Action Flow (Confirm High-Impact Actions First)
+
+Click by snapshot reference:
+
+```bash
+playwright-mcp-cli browser_click ref=e6
+```
+
+Run custom script:
+
+```bash
+playwright-mcp-cli browser_run_code code='await page.waitForTimeout(1000)'
+```
+
+## Bare JSON Positional Example
+
+```bash
+playwright-mcp-cli browser_navigate '{"url":"https://example.com"}'
+```
+
+## Output Parsing
+
+Rely on envelope fields:
+- Success: `ok == true`, consume `data`
+- Failure: `ok == false`, inspect `error.code` and `error.message`
+
+## Fallback Equivalence
+
+- `playwright-mcp-cli <operation> ...` is equivalent to `uxc "npx -y @playwright/mcp@latest --headless --isolated" <operation> ...`.
+- If link setup is temporarily unavailable, use the direct `uxc "<endpoint>" ...` form as fallback.

--- a/skills/playwright-mcp-skill/scripts/validate.sh
+++ b/skills/playwright-mcp-skill/scripts/validate.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/playwright-mcp-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd rg
+
+required_files=(
+  "${SKILL_FILE}"
+  "${OPENAI_FILE}"
+  "${SKILL_DIR}/references/usage-patterns.md"
+)
+
+for file in "${required_files[@]}"; do
+  [[ -f "${file}" ]] || fail "missing required file: ${file}"
+done
+
+if ! head -n 1 "${SKILL_FILE}" | rg -q '^---$'; then
+  fail "SKILL.md must include YAML frontmatter"
+fi
+
+if ! tail -n +2 "${SKILL_FILE}" | rg -q '^---$'; then
+  fail "SKILL.md must include YAML frontmatter"
+fi
+
+if ! rg -q '^name:\s*playwright-mcp-skill\s*$' "${SKILL_FILE}"; then
+  fail "SKILL.md frontmatter must define: name: playwright-mcp-skill"
+fi
+
+if ! rg -q '^description:\s*.+' "${SKILL_FILE}"; then
+  fail "SKILL.md frontmatter must define a description"
+fi
+
+if ! rg -q 'npx -y @playwright/mcp@latest --headless --isolated' "${SKILL_FILE}"; then
+  fail "SKILL.md must document fixed Playwright MCP stdio endpoint"
+fi
+
+if ! rg -q 'command -v playwright-mcp-cli' "${SKILL_FILE}"; then
+  fail "SKILL.md must include link command existence check"
+fi
+
+if ! rg -q 'uxc link playwright-mcp-cli "npx -y @playwright/mcp@latest --headless --isolated"' "${SKILL_FILE}"; then
+  fail "SKILL.md must include fixed link creation command"
+fi
+
+if ! rg -q 'playwright-mcp-cli -h' "${SKILL_FILE}"; then
+  fail "SKILL.md must use playwright-mcp-cli help-first discovery"
+fi
+
+if ! rg -q 'playwright-mcp-cli browser_navigate -h' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "docs must include operation-level help via playwright-mcp-cli <operation> -h"
+fi
+
+if ! rg -q 'browser_navigate url=' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "docs must include key=value example"
+fi
+
+if ! rg -q "browser_navigate .*'\\{.*\\}'" "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "docs must include bare JSON positional example"
+fi
+
+if ! rg -q 'official source' "${SKILL_FILE}"; then
+  fail "SKILL.md must mention official-source discovery step"
+fi
+
+if ! rg -q 'probe candidate endpoints with' "${SKILL_FILE}"; then
+  fail "SKILL.md must include probe step before finalizing endpoint"
+fi
+
+if ! rg -q 'no OAuth/API key' "${SKILL_FILE}"; then
+  fail "SKILL.md must explicitly document auth detection result"
+fi
+
+if rg -q -- 'playwright-mcp-cli (list|describe|call)|--input-json|--args .*\{' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "docs must not use legacy list/describe/call/--input-json/--args JSON forms"
+fi
+
+if rg -qi 'retry with .*suffix|append.*suffix|dynamic rename|auto-rename' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "docs must not include dynamic command renaming guidance"
+fi
+
+if ! rg -q 'references/usage-patterns.md' "${SKILL_FILE}"; then
+  fail "SKILL.md must reference usage-patterns.md"
+fi
+
+if ! rg -q 'equivalent to `uxc "npx -y @playwright/mcp@latest --headless --isolated"' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "docs must include fallback equivalence guidance"
+fi
+
+if ! rg -q '^\s*display_name:\s*"Playwright MCP"\s*$' "${OPENAI_FILE}"; then
+  fail "agents/openai.yaml must define interface.display_name"
+fi
+
+if ! rg -q '^\s*short_description:\s*".+"\s*$' "${OPENAI_FILE}"; then
+  fail "agents/openai.yaml must define interface.short_description"
+fi
+
+if ! rg -q '^\s*default_prompt:\s*".*\$playwright-mcp-skill.*"\s*$' "${OPENAI_FILE}"; then
+  fail 'agents/openai.yaml default_prompt must mention $playwright-mcp-skill'
+fi
+
+echo "skills/playwright-mcp-skill validation passed"


### PR DESCRIPTION
## What
- add new wrapper skill `skills/playwright-mcp-skill` for `@playwright/mcp` via UXC stdio MCP
- include required skill artifacts:
  - `SKILL.md`
  - `agents/openai.yaml`
  - `references/usage-patterns.md`
  - `scripts/validate.sh`

## Why
- we now support daemon-based stdio MCP process reuse
- Playwright MCP is a practical high-value target and needs a first-class skill for consistent link-first/help-first execution

## How
- fixed link command: `playwright-mcp-cli`
- fixed endpoint: `npx -y @playwright/mcp@latest --headless --isolated`
- documented read-first flow and high-impact action confirmation guardrails
- added validation rules to enforce `uxc-skill-creator` constraints and ban legacy invocation patterns

## Testing
- `bash skills/playwright-mcp-skill/scripts/validate.sh`
- `uxc link playwright-mcp-cli "npx -y @playwright/mcp@latest --headless --isolated"`
- `playwright-mcp-cli -h` (22 operations discovered)
- `playwright-mcp-cli browser_navigate url=https://example.com` (succeeds)
