### PR TITLE
feat(mcp): surface structuredContent in tools/call output

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ Success envelope shape:
 }
 ```
 
+For MCP `tools/call`, `data` may include `content`, optional `structuredContent`, and optional `isError`.
+
 Failure envelope shape:
 
 ```json

--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -374,7 +374,7 @@ mod tests {
             read line
             echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"test","version":"1.0"}}}'
             read line
-            echo '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Tool executed successfully"}]}}'
+            echo '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Tool executed successfully"}],"structuredContent":{"message":"Tool executed successfully"}}}'
         "#;
 
         let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
@@ -389,6 +389,10 @@ mod tests {
             ToolContent::Text { text } => assert_eq!(text, "Tool executed successfully"),
             _ => panic!("Expected text content"),
         }
+        assert_eq!(
+            result.structuredContent,
+            Some(serde_json::json!({ "message": "Tool executed successfully" }))
+        );
     }
 
     #[tokio::test]

--- a/src/adapters/mcp/http_transport.rs
+++ b/src/adapters/mcp/http_transport.rs
@@ -1499,6 +1499,38 @@ data: invalid json
         assert_eq!(tool_result.isError, Some(true));
     }
 
+    #[tokio::test]
+    async fn call_tool_parses_structured_content() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "jsonrpc":"2.0",
+                "id":1,
+                "result":{
+                    "content":[{"type":"text","text":"ok"}],
+                    "structuredContent":{"status":"ok","count":1}
+                }
+            }"#,
+            )
+            .create_async()
+            .await;
+
+        let transport = McpHttpTransport::new(server.url()).unwrap();
+
+        let result = transport.call_tool("test_tool", None).await;
+        assert!(result.is_ok());
+        let tool_result = result.unwrap();
+        assert_eq!(
+            tool_result.structuredContent,
+            Some(serde_json::json!({"status":"ok","count":1}))
+        );
+    }
+
     // ===== Resource Tests =====
 
     #[tokio::test]

--- a/src/adapters/mcp/mod.rs
+++ b/src/adapters/mcp/mod.rs
@@ -475,8 +475,7 @@ impl Adapter for McpAdapter {
 
             let result = client.call_tool(operation, arguments).await?;
 
-            // Convert tool content to a simple JSON output
-            let output = convert_tool_content_to_value(&result.content);
+            let output = convert_tool_result_to_value(&result);
 
             return Ok(ExecutionResult {
                 data: output,
@@ -504,8 +503,7 @@ impl Adapter for McpAdapter {
 
             let result = transport.call_tool(operation, arguments).await?;
 
-            // Convert tool content to a simple JSON output
-            let output = convert_tool_content_to_value(&result.content);
+            let output = convert_tool_result_to_value(&result);
 
             return Ok(ExecutionResult {
                 data: output,
@@ -561,8 +559,23 @@ fn parse_schema_to_parameters(schema: &Value) -> Vec<super::Parameter> {
     parameters
 }
 
-/// Convert tool content to a JSON value for output
-fn convert_tool_content_to_value(content: &[types::ToolContent]) -> Value {
+/// Convert MCP tool call result to a JSON value for output.
+pub(crate) fn convert_tool_result_to_value(result: &types::ToolCallResult) -> Value {
+    let mut output = serde_json::json!({
+        "content": convert_tool_content_to_json(&result.content)
+    });
+
+    if let Some(is_error) = result.isError {
+        output["isError"] = serde_json::json!(is_error);
+    }
+    if let Some(structured) = &result.structuredContent {
+        output["structuredContent"] = structured.clone();
+    }
+
+    output
+}
+
+fn convert_tool_content_to_json(content: &[types::ToolContent]) -> Value {
     let mut results = Vec::new();
 
     for item in content {
@@ -601,12 +614,31 @@ fn convert_tool_content_to_value(content: &[types::ToolContent]) -> Value {
         results.push(value);
     }
 
-    serde_json::json!({ "content": results })
+    Value::Array(results)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn convert_tool_result_includes_structured_content_and_error_flag() {
+        let result = types::ToolCallResult {
+            content: vec![types::ToolContent::Text {
+                text: "hello".to_string(),
+            }],
+            isError: Some(true),
+            structuredContent: Some(json!({ "message": "hello", "count": 1 })),
+        };
+
+        let output = convert_tool_result_to_value(&result);
+        assert_eq!(output["content"][0]["type"], "text");
+        assert_eq!(output["content"][0]["text"], "hello");
+        assert_eq!(output["isError"], true);
+        assert_eq!(output["structuredContent"]["message"], "hello");
+        assert_eq!(output["structuredContent"]["count"], 1);
+    }
 
     fn initialize_response() -> &'static str {
         r#"{

--- a/src/adapters/mcp/types.rs
+++ b/src/adapters/mcp/types.rs
@@ -163,6 +163,8 @@ pub struct CallToolResult {
     pub content: Vec<ToolContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub isError: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub structuredContent: Option<JsonValue>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -895,7 +895,7 @@ impl DaemonRuntime {
             Ok((
                 "call_result".to_string(),
                 Some(op.clone()),
-                convert_tool_content_to_value(&result.content),
+                adapters::mcp::convert_tool_result_to_value(&result),
                 reused,
             ))
         } else {
@@ -915,7 +915,7 @@ impl DaemonRuntime {
             Ok((
                 "call_result".to_string(),
                 Some(op.clone()),
-                convert_tool_content_to_value(&result.content),
+                adapters::mcp::convert_tool_result_to_value(&result),
                 reused,
             ))
         }
@@ -1833,48 +1833,6 @@ impl Drop for SchemaMappingEnvGuard {
             None => std::env::remove_var("UXC_SCHEMA_MAPPINGS_FILE"),
         }
     }
-}
-
-fn convert_tool_content_to_value(content: &[adapters::mcp::types::ToolContent]) -> Value {
-    let mut results = Vec::new();
-
-    for item in content {
-        let value = match item {
-            adapters::mcp::types::ToolContent::Text { text } => serde_json::json!({
-                "type": "text",
-                "text": text
-            }),
-            adapters::mcp::types::ToolContent::Image { data, mimeType } => serde_json::json!({
-                "type": "image",
-                "data": data,
-                "mimeType": mimeType
-            }),
-            adapters::mcp::types::ToolContent::Resource {
-                uri,
-                mimeType,
-                text,
-                blob,
-            } => {
-                let mut obj = serde_json::json!({
-                    "type": "resource",
-                    "uri": uri
-                });
-                if let Some(mt) = mimeType {
-                    obj["mimeType"] = serde_json::json!(mt);
-                }
-                if let Some(t) = text {
-                    obj["text"] = serde_json::json!(t);
-                }
-                if let Some(b) = blob {
-                    obj["blob"] = serde_json::json!(b);
-                }
-                obj
-            }
-        };
-        results.push(value);
-    }
-
-    serde_json::json!({ "content": results })
 }
 
 fn normalize_http_url(url: &str) -> String {

--- a/src/test_server/common.rs
+++ b/src/test_server/common.rs
@@ -19,6 +19,8 @@ pub enum Scenario {
     ToolCallTimeout,
     /// tools/list succeeds once, then fails (used to verify cache-first help behavior)
     ToolsListFailAfterFirst,
+    /// tools/call returns content + structuredContent payload
+    StructuredContent,
 }
 
 impl Scenario {
@@ -31,8 +33,9 @@ impl Scenario {
             "timeout" => Ok(Self::Timeout),
             "tool_call_timeout" => Ok(Self::ToolCallTimeout),
             "tools_list_fail_after_first" => Ok(Self::ToolsListFailAfterFirst),
+            "structured_content" => Ok(Self::StructuredContent),
             _ => anyhow::bail!(
-                "Unknown scenario: {}. Use: ok, auth_required, malformed, timeout, tool_call_timeout, tools_list_fail_after_first",
+                "Unknown scenario: {}. Use: ok, auth_required, malformed, timeout, tool_call_timeout, tools_list_fail_after_first, structured_content",
                 s
             ),
         }

--- a/src/test_server/graphql.rs
+++ b/src/test_server/graphql.rs
@@ -235,7 +235,8 @@ async fn execute_query(
         Scenario::Ok
         | Scenario::AuthRequired
         | Scenario::ToolsListFailAfterFirst
-        | Scenario::ToolCallTimeout => {
+        | Scenario::ToolCallTimeout
+        | Scenario::StructuredContent => {
             // Introspection query
             if query.contains("__schema") || query.contains("__type(") {
                 return Ok(GraphQLResponse {

--- a/src/test_server/grpc.rs
+++ b/src/test_server/grpc.rs
@@ -24,7 +24,10 @@ impl addsvc::add_server::Add for AddService {
         request: Request<addsvc::SumRequest>,
     ) -> std::result::Result<Response<addsvc::SumReply>, Status> {
         match self.scenario {
-            Scenario::Ok | Scenario::ToolsListFailAfterFirst | Scenario::ToolCallTimeout => {
+            Scenario::Ok
+            | Scenario::ToolsListFailAfterFirst
+            | Scenario::ToolCallTimeout
+            | Scenario::StructuredContent => {
                 let req = request.into_inner();
                 Ok(Response::new(addsvc::SumReply { v: req.a + req.b }))
             }

--- a/src/test_server/jsonrpc.rs
+++ b/src/test_server/jsonrpc.rs
@@ -155,7 +155,10 @@ async fn execute_method(
     state: ServerState,
 ) -> Result<JsonRpcResponse, StatusCode> {
     match state.scenario {
-        Scenario::Ok | Scenario::ToolsListFailAfterFirst | Scenario::ToolCallTimeout => {
+        Scenario::Ok
+        | Scenario::ToolsListFailAfterFirst
+        | Scenario::ToolCallTimeout
+        | Scenario::StructuredContent => {
             let result = match method {
                 "rpc.discover" => schema_value(),
                 "health" => json!({"status": "ok"}),

--- a/src/test_server/mcp_http.rs
+++ b/src/test_server/mcp_http.rs
@@ -124,11 +124,19 @@ async fn mcp_handler(
                 }))
                 .into_response());
             }
-            json!({
+            let mut result = json!({
                 "content": [
                     {"type": "text", "text": message}
                 ]
-            })
+            });
+            if matches!(state.scenario, Scenario::StructuredContent) {
+                result["structuredContent"] = json!({
+                    "message": message,
+                    "source": "mcp-http",
+                    "length": message.len()
+                });
+            }
+            result
         }
         _ => {
             return Ok(Json(json!({

--- a/src/test_server/mcp_stdio.rs
+++ b/src/test_server/mcp_stdio.rs
@@ -136,16 +136,25 @@ pub fn run(scenario: Scenario) -> Result<()> {
                     .and_then(Value::as_str)
                     .unwrap_or("hello");
 
+                let mut result = json!({
+                    "content": [
+                        {"type": "text", "text": message}
+                    ]
+                });
+                if matches!(scenario, Scenario::StructuredContent) {
+                    result["structuredContent"] = json!({
+                        "message": message,
+                        "source": "mcp-stdio",
+                        "length": message.len()
+                    });
+                }
+
                 respond(
                     &mut out,
                     json!({
                         "jsonrpc": "2.0",
                         "id": id,
-                        "result": {
-                            "content": [
-                                {"type": "text", "text": message}
-                            ]
-                        }
+                        "result": result
                     }),
                 )?;
             }

--- a/src/test_server/openapi.rs
+++ b/src/test_server/openapi.rs
@@ -150,9 +150,10 @@ fn create_router(state: ServerState) -> Router {
     // Health check endpoint
     async fn health_check(State(state): State<ServerState>) -> Result<Response, StatusCode> {
         match state.scenario {
-            Scenario::Ok | Scenario::ToolsListFailAfterFirst | Scenario::ToolCallTimeout => {
-                Ok(Json(json!({"status": "ok"})).into_response())
-            }
+            Scenario::Ok
+            | Scenario::ToolsListFailAfterFirst
+            | Scenario::ToolCallTimeout
+            | Scenario::StructuredContent => Ok(Json(json!({"status": "ok"})).into_response()),
             Scenario::AuthRequired => Err(StatusCode::UNAUTHORIZED),
             Scenario::Malformed => {
                 // Return invalid JSON
@@ -171,7 +172,10 @@ fn create_router(state: ServerState) -> Router {
     // List users endpoint
     async fn list_users(State(state): State<ServerState>) -> Result<Response, StatusCode> {
         match state.scenario {
-            Scenario::Ok | Scenario::ToolsListFailAfterFirst | Scenario::ToolCallTimeout => {
+            Scenario::Ok
+            | Scenario::ToolsListFailAfterFirst
+            | Scenario::ToolCallTimeout
+            | Scenario::StructuredContent => {
                 let users = vec![
                     json!({"id": 1, "name": "Alice", "email": "alice@example.com"}),
                     json!({"id": 2, "name": "Bob", "email": "bob@example.com"}),
@@ -196,7 +200,10 @@ fn create_router(state: ServerState) -> Router {
         Json(payload): Json<serde_json::Value>,
     ) -> Result<Response, StatusCode> {
         match state.scenario {
-            Scenario::Ok | Scenario::ToolsListFailAfterFirst | Scenario::ToolCallTimeout => {
+            Scenario::Ok
+            | Scenario::ToolsListFailAfterFirst
+            | Scenario::ToolCallTimeout
+            | Scenario::StructuredContent => {
                 let name = payload
                     .get("name")
                     .and_then(|v| v.as_str())
@@ -229,7 +236,10 @@ fn create_router(state: ServerState) -> Router {
         AxumPath(id): AxumPath<u32>,
     ) -> Result<Response, StatusCode> {
         match state.scenario {
-            Scenario::Ok | Scenario::ToolsListFailAfterFirst | Scenario::ToolCallTimeout => {
+            Scenario::Ok
+            | Scenario::ToolsListFailAfterFirst
+            | Scenario::ToolCallTimeout
+            | Scenario::StructuredContent => {
                 if id == 1 {
                     Ok(
                         Json(json!({"id": 1, "name": "Alice", "email": "alice@example.com"}))

--- a/tests/daemon_reuse_test.rs
+++ b/tests/daemon_reuse_test.rs
@@ -327,6 +327,48 @@ fn mcp_stdio_execute_does_not_relist_tools_on_reused_session() {
 
 #[test]
 #[serial]
+fn mcp_stdio_execute_includes_structured_content_via_daemon() {
+    daemon_stop_best_effort();
+
+    let bin = test_server_binary("mcp-stdio");
+    let endpoint = format!("{} structured_content", bin.display());
+
+    let start = uxc_command()
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("daemon start should run");
+    assert!(start.status.success());
+
+    let call = uxc_command()
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"daemon structured"}"#)
+        .output()
+        .expect("call should run");
+    assert!(
+        call.status.success(),
+        "call should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&call.stdout),
+        String::from_utf8_lossy(&call.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&call.stdout).expect("valid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["protocol"], "mcp");
+    assert_eq!(json["data"]["content"][0]["text"], "daemon structured");
+    assert_eq!(
+        json["data"]["structuredContent"]["message"],
+        "daemon structured"
+    );
+    assert_eq!(json["data"]["structuredContent"]["source"], "mcp-stdio");
+
+    daemon_stop_best_effort();
+}
+
+#[test]
+#[serial]
 fn mcp_stdio_exclusive_key_allows_switching_endpoints_without_daemon_restart() {
     daemon_stop_best_effort();
 

--- a/tests/local_e2e_test.rs
+++ b/tests/local_e2e_test.rs
@@ -552,6 +552,34 @@ fn test_mcp_http_call_tool() {
 
 #[test]
 #[serial_test::serial]
+fn test_mcp_http_call_tool_includes_structured_content() {
+    let _server = start_test_server("mcp-http", "structured_content");
+
+    let result = run_uxc(&[
+        &format!("http://{}", _server.addr),
+        "echo",
+        "--input-json",
+        r#"{"message":"hello structured"}"#,
+    ]);
+
+    assert!(result.is_ok(), "Failed to call MCP HTTP tool: {:?}", result);
+
+    let output = result.unwrap();
+    let json: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["protocol"], "mcp");
+    assert_eq!(json["data"]["content"][0]["text"], "hello structured");
+    assert_eq!(
+        json["data"]["structuredContent"]["message"],
+        "hello structured"
+    );
+    assert_eq!(json["data"]["structuredContent"]["source"], "mcp-http");
+    assert_eq!(json["data"]["structuredContent"]["length"], 16);
+}
+
+#[test]
+#[serial_test::serial]
 fn test_mcp_http_auth_required() {
     let _server = start_test_server("mcp-http", "auth_required");
 
@@ -709,6 +737,39 @@ fn test_mcp_stdio_call_tool() {
     assert_eq!(json["ok"], true);
     assert_eq!(json["protocol"], "mcp");
     assert_eq!(json["data"]["content"][0]["text"], "from stdio");
+}
+
+#[test]
+#[serial_test::serial]
+fn test_mcp_stdio_call_tool_includes_structured_content() {
+    let bin = test_server_binary("mcp-stdio");
+    let endpoint = format!("{} structured_content", bin.display());
+
+    let result = run_uxc(&[
+        &endpoint,
+        "echo",
+        "--input-json",
+        r#"{"message":"stdio structured"}"#,
+    ]);
+
+    assert!(
+        result.is_ok(),
+        "Failed to call MCP stdio tool: {:?}",
+        result
+    );
+
+    let output = result.unwrap();
+    let json: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["protocol"], "mcp");
+    assert_eq!(json["data"]["content"][0]["text"], "stdio structured");
+    assert_eq!(
+        json["data"]["structuredContent"]["message"],
+        "stdio structured"
+    );
+    assert_eq!(json["data"]["structuredContent"]["source"], "mcp-stdio");
+    assert_eq!(json["data"]["structuredContent"]["length"], 16);
 }
 
 #[test]


### PR DESCRIPTION
## What
- include MCP `structuredContent` and `isError` in `call_result.data` output alongside `content`
- add `structuredContent` to MCP `CallToolResult` parsing for both stdio and HTTP transports
- unify daemon MCP output conversion with adapter conversion to avoid divergence
- add MCP structured-content test scenarios in test servers and E2E/daemon tests

## Why
`uxc` currently drops MCP `structuredContent`, which makes valid tool results look empty when servers return data primarily in structured form.

Closes #147

## How
- `src/adapters/mcp/types.rs`: extend `CallToolResult` with optional `structuredContent`
- `src/adapters/mcp/mod.rs`: add `convert_tool_result_to_value` and output `{content,isError?,structuredContent?}`
- `src/daemon.rs`: reuse MCP adapter conversion function
- test servers: add `structured_content` scenario for MCP stdio/http
- tests: add coverage for parsing and output via direct call + daemon path

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test --lib convert_tool_result_includes_structured_content_and_error_flag -- --test-threads=1`
- `cargo test --lib call_tool_parses_structured_content -- --test-threads=1`
- `cargo test --lib call_tool_executes_tool_with_arguments -- --test-threads=1`
- `cargo test --test local_e2e_test --features test-server test_mcp_http_call_tool_includes_structured_content -- --test-threads=1`
- `cargo test --test local_e2e_test --features test-server test_mcp_stdio_call_tool_includes_structured_content -- --test-threads=1`
- `cargo test --test daemon_reuse_test --features test-server mcp_stdio_execute_includes_structured_content_via_daemon -- --test-threads=1`