### PR TITLE
fix(daemon): restart on cli version mismatch

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -109,6 +109,7 @@ pub struct DaemonStatus {
     pub running: bool,
     pub pid: Option<u32>,
     pub socket: String,
+    pub version: Option<String>,
     pub started_at_unix: Option<u64>,
     pub request_count: u64,
     pub mcp_stdio_sessions: usize,
@@ -140,6 +141,13 @@ struct JsonRpcResponse {
 struct JsonRpcError {
     code: i32,
     message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnsureDaemonOutcome {
+    pub started_now: bool,
+    pub restarted_for_version_mismatch: bool,
+    pub previous_version: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -862,6 +870,7 @@ impl DaemonRuntime {
             running: true,
             pid: Some(std::process::id()),
             socket: socket_path().display().to_string(),
+            version: Some(env!("CARGO_PKG_VERSION").to_string()),
             started_at_unix: Some(state.started_at_unix),
             request_count: state.request_count,
             mcp_stdio_sessions: stdio_sessions,
@@ -1020,11 +1029,7 @@ pub async fn runtime_invoke_client(
 }
 
 #[cfg(unix)]
-pub async fn ensure_daemon_running() -> Result<bool> {
-    if daemon_status_client().await.is_ok() {
-        return Ok(false);
-    }
-
+async fn start_daemon_process() -> Result<()> {
     let dir = daemon_dir();
     ensure_private_dir(&dir)?;
     let lock_path = dir.join("start.lock");
@@ -1049,7 +1054,7 @@ pub async fn ensure_daemon_running() -> Result<bool> {
     for _ in 0..START_POLL_TRIES {
         tokio::time::sleep(Duration::from_millis(START_POLL_INTERVAL_MS)).await;
         if daemon_status_client().await.is_ok() {
-            return Ok(true);
+            return Ok(());
         }
     }
 
@@ -1058,7 +1063,66 @@ pub async fn ensure_daemon_running() -> Result<bool> {
 }
 
 #[cfg(not(unix))]
-pub async fn ensure_daemon_running() -> Result<bool> {
+async fn start_daemon_process() -> Result<()> {
+    bail!("uxcd daemon is not supported on this platform; run uxc inside WSL")
+}
+
+#[cfg(unix)]
+fn daemon_version_matches(status: &DaemonStatus) -> bool {
+    status.version.as_deref() == Some(env!("CARGO_PKG_VERSION"))
+}
+
+#[cfg(unix)]
+pub async fn ensure_compatible_daemon_running() -> Result<EnsureDaemonOutcome> {
+    match daemon_status_client().await {
+        Ok(status) => {
+            if daemon_version_matches(&status) {
+                return Ok(EnsureDaemonOutcome {
+                    started_now: false,
+                    restarted_for_version_mismatch: false,
+                    previous_version: None,
+                });
+            }
+
+            let previous_version = status.version.clone();
+            if let Err(err) = daemon_stop_local().await {
+                return Err(UxcError::DaemonVersionMismatch(format!(
+                    "Detected daemon version mismatch (daemon={}, cli={}) and failed to restart daemon automatically: {}. Run `uxc daemon restart`.",
+                    previous_version.as_deref().unwrap_or("unknown"),
+                    env!("CARGO_PKG_VERSION"),
+                    err
+                ))
+                .into());
+            }
+            if let Err(err) = start_daemon_process().await {
+                return Err(UxcError::DaemonVersionMismatch(format!(
+                    "Detected daemon version mismatch (daemon={}, cli={}) and failed to restart daemon automatically: {}. Run `uxc daemon restart`.",
+                    previous_version.as_deref().unwrap_or("unknown"),
+                    env!("CARGO_PKG_VERSION"),
+                    err
+                ))
+                .into());
+            }
+
+            Ok(EnsureDaemonOutcome {
+                started_now: true,
+                restarted_for_version_mismatch: true,
+                previous_version,
+            })
+        }
+        Err(_) => {
+            start_daemon_process().await?;
+            Ok(EnsureDaemonOutcome {
+                started_now: true,
+                restarted_for_version_mismatch: false,
+                previous_version: None,
+            })
+        }
+    }
+}
+
+#[cfg(not(unix))]
+pub async fn ensure_compatible_daemon_running() -> Result<EnsureDaemonOutcome> {
     bail!("uxcd daemon is not supported on this platform; run uxc inside WSL")
 }
 
@@ -1241,8 +1305,8 @@ pub async fn daemon_status_local() -> Result<DaemonStatus> {
     daemon_status_client().await
 }
 
-pub async fn daemon_start_local() -> Result<bool> {
-    ensure_daemon_running().await
+pub async fn daemon_start_local() -> Result<EnsureDaemonOutcome> {
+    ensure_compatible_daemon_running().await
 }
 
 pub async fn daemon_stop_local() -> Result<bool> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,9 @@ pub enum UxcError {
     #[error("OAuth scope insufficient: {0}")]
     OAuthScopeInsufficient(String),
 
+    #[error("Daemon version mismatch: {0}")]
+    DaemonVersionMismatch(String),
+
     #[error("Network error: {0}")]
     NetworkError(#[from] reqwest::Error),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1204,11 +1204,17 @@ async fn execute_endpoint_via_daemon(
     info!("UXC v{} - connecting to {}", env!("CARGO_PKG_VERSION"), url);
 
     let daemon_used = daemon::daemon_supported();
-    let daemon_autostarted = if daemon_used {
-        Some(daemon::ensure_daemon_running().await?)
+    let daemon_ensure = if daemon_used {
+        Some(daemon::ensure_compatible_daemon_running().await?)
     } else {
         None
     };
+    let daemon_autostarted = daemon_ensure
+        .as_ref()
+        .map(|outcome| outcome.started_now && !outcome.restarted_for_version_mismatch);
+    let daemon_restarted_for_version_mismatch = daemon_ensure
+        .as_ref()
+        .map(|outcome| outcome.restarted_for_version_mismatch);
     let (action, operation_id, args_map) = match endpoint_command {
         EndpointCommand::HostHelp => (daemon::RuntimeAction::HostHelp, None, None),
         EndpointCommand::Describe { operation_id } => (
@@ -1265,6 +1271,7 @@ async fn execute_endpoint_via_daemon(
     .with_daemon_meta(
         daemon_used,
         daemon_autostarted,
+        daemon_restarted_for_version_mismatch,
         response.meta.daemon_session_reused,
     );
 
@@ -1773,6 +1780,19 @@ fn render_text_output(envelope: &OutputEnvelope) -> Result<()> {
         Some("daemon_start_result") => {
             let data = envelope.data.clone().unwrap_or(Value::Null);
             if data
+                .get("restarted_for_version_mismatch")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                println!("Daemon restarted due to version mismatch.");
+                if let Some(previous_version) = data.get("previous_version").and_then(Value::as_str)
+                {
+                    println!("Previous Version: {}", previous_version);
+                }
+                if let Some(version) = data.get("version").and_then(Value::as_str) {
+                    println!("Version: {}", version);
+                }
+            } else if data
                 .get("autostarted")
                 .and_then(Value::as_bool)
                 .unwrap_or(false)
@@ -1818,6 +1838,15 @@ fn render_text_output(envelope: &OutputEnvelope) -> Result<()> {
             }
             if let Some(socket) = data.get("socket").and_then(Value::as_str) {
                 println!("Socket: {}", socket);
+            }
+            if let Some(version) = data.get("version").and_then(Value::as_str) {
+                println!("Daemon Version: {}", version);
+            }
+            if let Some(version) = data.get("client_version").and_then(Value::as_str) {
+                println!("CLI Version: {}", version);
+            }
+            if let Some(mismatch) = data.get("version_mismatch").and_then(Value::as_bool) {
+                println!("Version Mismatch: {}", mismatch);
             }
             if let Some(requests) = data.get("request_count").and_then(Value::as_u64) {
                 println!("Requests: {}", requests);
@@ -2887,6 +2916,7 @@ fn error_code(err: &anyhow::Error) -> &'static str {
                 UxcError::OAuthSessionExpired(_) => "OAUTH_SESSION_EXPIRED",
                 UxcError::OAuthRefreshFailed(_) => "OAUTH_REFRESH_FAILED",
                 UxcError::OAuthScopeInsufficient(_) => "OAUTH_SCOPE_INSUFFICIENT",
+                UxcError::DaemonVersionMismatch(_) => "DAEMON_VERSION_MISMATCH",
                 UxcError::ExecutionFailed(_)
                 | UxcError::SchemaRetrievalFailed(_)
                 | UxcError::NetworkError(_)
@@ -3003,12 +3033,15 @@ async fn handle_cache_command(
 async fn handle_daemon_command(command: &DaemonCommands) -> Result<OutputEnvelope> {
     match command {
         DaemonCommands::Start => {
-            let started_now = daemon::daemon_start_local().await?;
+            let outcome = daemon::daemon_start_local().await?;
             let data = json!({
-                "started": started_now,
-                "autostarted": started_now,
-                "started_now": started_now,
-                "already_running": !started_now,
+                "started": outcome.started_now,
+                "autostarted": outcome.started_now && !outcome.restarted_for_version_mismatch,
+                "started_now": outcome.started_now,
+                "already_running": !outcome.started_now,
+                "restarted_for_version_mismatch": outcome.restarted_for_version_mismatch,
+                "previous_version": outcome.previous_version,
+                "version": env!("CARGO_PKG_VERSION"),
                 "socket": daemon::socket_path().display().to_string()
             });
             Ok(OutputEnvelope::success(
@@ -3037,10 +3070,28 @@ async fn handle_daemon_command(command: &DaemonCommands) -> Result<OutputEnvelop
         }
         DaemonCommands::Status => {
             let status = match daemon::daemon_status_local().await {
-                Ok(status) => serde_json::to_value(status)?,
+                Ok(status) => {
+                    let running = status.running;
+                    let version_mismatch =
+                        running && status.version.as_deref() != Some(env!("CARGO_PKG_VERSION"));
+                    let mut value = serde_json::to_value(status)?;
+                    if let Some(obj) = value.as_object_mut() {
+                        obj.insert(
+                            "client_version".to_string(),
+                            Value::String(env!("CARGO_PKG_VERSION").to_string()),
+                        );
+                        obj.insert(
+                            "version_mismatch".to_string(),
+                            Value::Bool(version_mismatch),
+                        );
+                    }
+                    value
+                }
                 Err(err) => json!({
                     "running": false,
                     "socket": daemon::socket_path().display().to_string(),
+                    "client_version": env!("CARGO_PKG_VERSION"),
+                    "version_mismatch": false,
                     "error": {
                         "code": "DAEMON_UNREACHABLE",
                         "message": err.to_string()
@@ -3058,10 +3109,13 @@ async fn handle_daemon_command(command: &DaemonCommands) -> Result<OutputEnvelop
         }
         DaemonCommands::Restart => {
             let stopped = daemon::daemon_stop_local().await?;
-            let started_now = daemon::daemon_start_local().await?;
+            let outcome = daemon::daemon_start_local().await?;
             let data = json!({
                 "stopped": stopped,
-                "started_now": started_now,
+                "started_now": outcome.started_now,
+                "restarted_for_version_mismatch": outcome.restarted_for_version_mismatch,
+                "previous_version": outcome.previous_version,
+                "version": env!("CARGO_PKG_VERSION"),
                 "socket": daemon::socket_path().display().to_string()
             });
             Ok(OutputEnvelope::success(

--- a/src/output.rs
+++ b/src/output.rs
@@ -83,6 +83,10 @@ pub struct Metadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub daemon_autostarted: Option<bool>,
 
+    /// Whether daemon was restarted due to CLI/daemon version mismatch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daemon_restarted_for_version_mismatch: Option<bool>,
+
     /// Whether daemon session was reused.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub daemon_session_reused: Option<bool>,
@@ -116,6 +120,7 @@ impl OutputEnvelope {
                 cache_fallback: None,
                 daemon_used: None,
                 daemon_autostarted: None,
+                daemon_restarted_for_version_mismatch: None,
                 daemon_session_reused: None,
             },
         }
@@ -144,6 +149,7 @@ impl OutputEnvelope {
                 cache_fallback: None,
                 daemon_used: None,
                 daemon_autostarted: None,
+                daemon_restarted_for_version_mismatch: None,
                 daemon_session_reused: None,
             },
         }
@@ -170,10 +176,12 @@ impl OutputEnvelope {
         mut self,
         daemon_used: bool,
         daemon_autostarted: Option<bool>,
+        daemon_restarted_for_version_mismatch: Option<bool>,
         daemon_session_reused: Option<bool>,
     ) -> Self {
         self.meta.daemon_used = Some(daemon_used);
         self.meta.daemon_autostarted = daemon_autostarted;
+        self.meta.daemon_restarted_for_version_mismatch = daemon_restarted_for_version_mismatch;
         self.meta.daemon_session_reused = daemon_session_reused;
         self
     }

--- a/tests/daemon_cli_test.rs
+++ b/tests/daemon_cli_test.rs
@@ -31,6 +31,9 @@ fn daemon_start_status_stop_lifecycle() {
     assert_eq!(json["ok"], true);
     assert_eq!(json["kind"], "daemon_status");
     assert_eq!(json["data"]["running"], true);
+    assert_eq!(json["data"]["version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(json["data"]["client_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(json["data"]["version_mismatch"], false);
 
     let stop = uxc_command()
         .arg("daemon")
@@ -86,6 +89,7 @@ fn endpoint_host_help_autostarts_daemon_and_sets_meta() {
     assert_eq!(json["ok"], true);
     assert_eq!(json["meta"]["daemon_used"], true);
     assert_eq!(json["meta"]["daemon_autostarted"], true);
+    assert_eq!(json["meta"]["daemon_restarted_for_version_mismatch"], false);
 
     daemon_stop_best_effort();
 }
@@ -106,6 +110,8 @@ fn daemon_start_reports_started_now_and_already_running() {
     assert_eq!(first_json["kind"], "daemon_start_result");
     assert_eq!(first_json["data"]["started_now"], true);
     assert_eq!(first_json["data"]["already_running"], false);
+    assert_eq!(first_json["data"]["restarted_for_version_mismatch"], false);
+    assert_eq!(first_json["data"]["version"], env!("CARGO_PKG_VERSION"));
 
     let second = uxc_command()
         .arg("daemon")
@@ -119,6 +125,8 @@ fn daemon_start_reports_started_now_and_already_running() {
     assert_eq!(second_json["kind"], "daemon_start_result");
     assert_eq!(second_json["data"]["started_now"], false);
     assert_eq!(second_json["data"]["already_running"], true);
+    assert_eq!(second_json["data"]["restarted_for_version_mismatch"], false);
+    assert_eq!(second_json["data"]["version"], env!("CARGO_PKG_VERSION"));
 
     daemon_stop_best_effort();
 }

--- a/tests/daemon_version_mismatch_test.rs
+++ b/tests/daemon_version_mismatch_test.rs
@@ -1,0 +1,268 @@
+mod common;
+
+use serde_json::{json, Value};
+use serial_test::serial;
+use std::fs;
+use std::io::{Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+fn runtime_root(test_home: &Path) -> PathBuf {
+    test_home.join("runtime")
+}
+
+fn daemon_socket_path(test_home: &Path) -> PathBuf {
+    runtime_root(test_home).join("uxc").join("uxc.sock")
+}
+
+fn read_frame(stream: &mut UnixStream) -> Value {
+    let mut header = Vec::new();
+    let mut byte = [0_u8; 1];
+    loop {
+        let n = stream.read(&mut byte).expect("read frame header");
+        assert!(n > 0, "unexpected EOF while reading header");
+        header.push(byte[0]);
+        if header.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let header_str = String::from_utf8(header).expect("header utf8");
+    let len = header_str
+        .split("\r\n")
+        .find_map(|line| line.strip_prefix("Content-Length:"))
+        .map(|v| v.trim().parse::<usize>().expect("content length"))
+        .expect("content length header");
+    let mut body = vec![0_u8; len];
+    stream.read_exact(&mut body).expect("read frame body");
+    serde_json::from_slice(&body).expect("json body")
+}
+
+fn write_frame(stream: &mut UnixStream, value: &Value) {
+    let body = serde_json::to_vec(value).expect("serialize frame");
+    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+    stream
+        .write_all(header.as_bytes())
+        .expect("write frame header");
+    stream.write_all(&body).expect("write frame body");
+    stream.flush().expect("flush frame");
+}
+
+struct FakeOldDaemon {
+    socket_path: PathBuf,
+    stop: Arc<AtomicBool>,
+    done_rx: mpsc::Receiver<()>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl FakeOldDaemon {
+    fn start(test_home: &Path, version: Option<&str>, shutdown_fails: bool) -> Self {
+        let socket_path = daemon_socket_path(test_home);
+        if let Some(parent) = socket_path.parent() {
+            fs::create_dir_all(parent).expect("create fake daemon dir");
+        }
+        let _ = fs::remove_file(&socket_path);
+
+        let listener = UnixListener::bind(&socket_path).expect("bind fake daemon socket");
+        listener
+            .set_nonblocking(true)
+            .expect("set fake daemon listener nonblocking");
+        let version = version.map(|v| v.to_string());
+        let socket_path_for_thread = socket_path.clone();
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_thread = stop.clone();
+        let (done_tx, done_rx) = mpsc::channel();
+
+        let join = thread::spawn(move || loop {
+            if stop_for_thread.load(Ordering::SeqCst) {
+                break;
+            }
+            let mut stream = match listener.accept() {
+                Ok((stream, _)) => stream,
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(20));
+                    continue;
+                }
+                Err(_) => break,
+            };
+            if stop_for_thread.load(Ordering::SeqCst) {
+                break;
+            }
+            let req = read_frame(&mut stream);
+            let id = req.get("id").cloned().unwrap_or(Value::Null);
+            let method = req.get("method").and_then(Value::as_str).unwrap_or("");
+            let response = match method {
+                "daemon.status" => {
+                    let mut result = json!({
+                        "running": true,
+                        "pid": 99999,
+                        "socket": socket_path_for_thread.display().to_string(),
+                        "started_at_unix": 1,
+                        "request_count": 0,
+                        "mcp_stdio_sessions": 0,
+                        "mcp_http_sessions": 0,
+                        "mcp_reuse_hits": 0
+                    });
+                    if let Some(version) = &version {
+                        result["version"] = Value::String(version.clone());
+                    }
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": result
+                    })
+                }
+                "daemon.shutdown" if shutdown_fails => json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": { "code": -32000, "message": "shutdown refused" }
+                }),
+                "daemon.shutdown" => {
+                    let response = json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": { "ok": true }
+                    });
+                    write_frame(&mut stream, &response);
+                    let _ = done_tx.send(());
+                    let _ = fs::remove_file(&socket_path_for_thread);
+                    break;
+                }
+                _ => json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": { "code": -32601, "message": format!("Method not found: {}", method) }
+                }),
+            };
+            write_frame(&mut stream, &response);
+        });
+
+        Self {
+            socket_path,
+            stop,
+            done_rx,
+            join: Some(join),
+        }
+    }
+
+    fn wait_for_shutdown(&self) {
+        self.done_rx.recv().expect("fake daemon shutdown signal");
+    }
+}
+
+impl Drop for FakeOldDaemon {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        let _ = UnixStream::connect(&self.socket_path);
+        let _ = fs::remove_file(&self.socket_path);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn endpoint_request_restarts_old_daemon_before_invoke() {
+    let test_home = common::fresh_test_home_dir();
+    let fake = FakeOldDaemon::start(&test_home, Some("0.8.0"), false);
+
+    let mut server = mockito::Server::new();
+    let _schema = server
+        .mock("GET", "/openapi.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+  "openapi": "3.0.0",
+  "info": { "title": "test", "version": "1.0.0" },
+  "paths": { "/health": { "get": { "responses": { "200": { "description": "ok" } } } } }
+}"#,
+        )
+        .create();
+
+    let stdout = common::run_uxc_in_home(&[&server.url(), "--no-cache", "-h"], &test_home)
+        .expect("host help should succeed");
+    fake.wait_for_shutdown();
+
+    let json: Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["meta"]["daemon_used"], true);
+    assert_eq!(json["meta"]["daemon_autostarted"], false);
+    assert_eq!(json["meta"]["daemon_restarted_for_version_mismatch"], true);
+
+    let status_stdout =
+        common::run_uxc_in_home(&["daemon", "status"], &test_home).expect("status should succeed");
+    let status_json: Value = serde_json::from_str(&status_stdout).expect("valid status json");
+    assert_eq!(status_json["data"]["version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(status_json["data"]["version_mismatch"], false);
+
+    let _ = common::run_uxc_in_home(&["daemon", "stop"], &test_home);
+}
+
+#[test]
+#[serial]
+fn daemon_status_reports_version_mismatch_without_restarting() {
+    let test_home = common::fresh_test_home_dir();
+    let _fake = FakeOldDaemon::start(&test_home, Some("0.8.0"), false);
+
+    let stdout =
+        common::run_uxc_in_home(&["daemon", "status"], &test_home).expect("status should succeed");
+    let json: Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["running"], true);
+    assert_eq!(json["data"]["version"], "0.8.0");
+    assert_eq!(json["data"]["client_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(json["data"]["version_mismatch"], true);
+}
+
+#[test]
+#[serial]
+fn daemon_start_restarts_old_daemon_and_reports_previous_version() {
+    let test_home = common::fresh_test_home_dir();
+    let fake = FakeOldDaemon::start(&test_home, Some("0.8.0"), false);
+
+    let stdout =
+        common::run_uxc_in_home(&["daemon", "start"], &test_home).expect("start should succeed");
+    fake.wait_for_shutdown();
+
+    let json: Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["started_now"], true);
+    assert_eq!(json["data"]["already_running"], false);
+    assert_eq!(json["data"]["restarted_for_version_mismatch"], true);
+    assert_eq!(json["data"]["previous_version"], "0.8.0");
+    assert_eq!(json["data"]["version"], env!("CARGO_PKG_VERSION"));
+
+    let _ = common::run_uxc_in_home(&["daemon", "stop"], &test_home);
+}
+
+#[test]
+#[serial]
+fn daemon_start_reports_error_when_version_mismatch_restart_fails() {
+    let test_home = common::fresh_test_home_dir();
+    let _fake = FakeOldDaemon::start(&test_home, Some("0.8.0"), true);
+
+    let uxc = common::uxc_binary();
+    let output = std::process::Command::new(&uxc)
+        .args(["daemon", "start"])
+        .env("HOME", &test_home)
+        .env("USERPROFILE", &test_home)
+        .env("XDG_RUNTIME_DIR", runtime_root(&test_home))
+        .output()
+        .expect("daemon start should run");
+    assert!(!output.status.success(), "daemon start should fail");
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "DAEMON_VERSION_MISMATCH");
+    let message = json["error"]["message"].as_str().unwrap();
+    assert!(message.contains("daemon=0.8.0"));
+    assert!(message.contains(env!("CARGO_PKG_VERSION")));
+    assert!(message.contains("uxc daemon restart"));
+}


### PR DESCRIPTION
## What
- add daemon version reporting to `daemon status`
- detect CLI/daemon version mismatch before daemon-backed endpoint requests
- automatically restart daemon on version mismatch
- surface mismatch restart metadata in endpoint responses and daemon start output
- add regression tests for old-daemon replacement and failure handling

## Why
Upgrading the CLI while keeping an old daemon running can produce stale behavior, especially for protocol detection and MCP transports. The CLI version looked correct, but requests were still being served by outdated daemon logic until a manual restart.

## How
- extend daemon status payload with `version`
- compare daemon semver with `env!("CARGO_PKG_VERSION")`
- restart daemon automatically when mismatch is detected on endpoint requests or `uxc daemon start`
- keep `uxc daemon status` diagnostic-only and report `client_version` + `version_mismatch`
- add `DAEMON_VERSION_MISMATCH` for restart failures
- add fake old-daemon integration tests over the Unix socket protocol

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test --test daemon_cli_test --test daemon_version_mismatch_test -- --test-threads=1`
- `cargo test output::tests --lib -- --test-threads=1`

Closes #180
