### PR TITLE
feat(binance): add spot OpenAPI skill and Ed25519 signer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0"
 
 # Base64 encoding for basic auth
 base64 = "0.21"
+ed25519-dalek = { version = "2.1", features = ["pkcs8", "pem"] }
 hmac = "0.12"
 percent-encoding = "2.3"
 sha2 = "0.10"

--- a/skills/binance-spot-openapi-skill/SKILL.md
+++ b/skills/binance-spot-openapi-skill/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: binance-spot-openapi-skill
+description: Operate Binance Spot market, account, and order APIs through UXC with a curated OpenAPI schema, Binance query signing, and separate mainnet/testnet link flows.
+---
+
+# Binance Spot API Skill
+
+Use this skill to run Binance Spot REST operations through `uxc` + OpenAPI.
+
+Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- Network access to:
+  - `https://api.binance.com`
+  - `https://testnet.binance.vision`
+- Access to the curated OpenAPI schema URL:
+  - `https://raw.githubusercontent.com/holon-run/uxc/main/skills/binance-spot-openapi-skill/references/binance-spot.openapi.json`
+
+## Scope
+
+This skill covers curated Binance Spot REST endpoints for:
+
+- public market reads
+- signed account reads
+- signed order queries
+- test orders
+- order placement and cancellation
+
+This skill does **not** cover:
+
+- OCO, OTO, OTOCO, OPO, OPOCO, or other `orderList/*` endpoints
+- `order/cancelReplace`
+- `order/amend/*`
+- `historicalTrades`
+- `uiKlines`
+- `ticker/tradingDay`
+- SOR endpoints
+- Wallet, Margin, Earn, or `/sapi/*` endpoints
+- RSA request signing
+- `https://demo-api.binance.com`
+
+## Authentication
+
+Public market endpoints do not require credentials.
+
+Signed Spot endpoints require:
+
+- `api_key` field for `X-MBX-APIKEY`
+- `private_key` field for Ed25519 PKCS#8 PEM signing, or `secret_key` for deprecated HMAC SHA256 signing
+
+### Testnet API Key Setup
+
+Binance Spot testnet uses a separate host and separate API key records from mainnet:
+
+- base URL: `https://testnet.binance.vision`
+- testnet API keys do not work on mainnet
+- mainnet API keys do not work on testnet
+
+There are two practical testnet flows:
+
+1. `Ed25519` (recommended by Binance)
+   - Generate an Ed25519 keypair locally.
+   - Register the public key in the Spot testnet API management UI.
+   - After registration, Binance shows a distinct `API key` for that Ed25519 key record.
+   - Use that displayed `API key` in `X-MBX-APIKEY`, and use the matching private key PEM for signing.
+
+2. `HMAC` (legacy compatibility)
+   - Create an HMAC key in the Spot testnet API management UI.
+   - Binance shows both `API key` and `Secret key`.
+   - Use `API key` in `X-MBX-APIKEY`, and use `Secret key` for HMAC SHA256 signing.
+
+Important:
+
+- The Ed25519 public key you upload is **not** the `API key`.
+- Each Binance key record has its own `API key`.
+- Do not mix an HMAC `API key` with an Ed25519 private key, or an Ed25519 `API key` with an HMAC secret.
+- If you do, Binance returns `-1022 Signature for this request is not valid.`
+
+### Recommended Credential Setup
+
+Binance recommends `Ed25519`. Store the private key PEM text in an environment variable, or source it from 1Password.
+
+```bash
+export BINANCE_TESTNET_ED25519_PRIVATE_KEY="$(cat /absolute/path/to/binance_testnet_ed25519_private.pem)"
+export BINANCE_MAINNET_ED25519_PRIVATE_KEY="$(cat /absolute/path/to/binance_mainnet_ed25519_private.pem)"
+```
+
+Create one credential per environment so mainnet and testnet keys are never mixed:
+
+```bash
+uxc auth credential set binance-spot-mainnet \
+  --auth-type api_key \
+  --field api_key=env:BINANCE_MAINNET_API_KEY \
+  --field private_key=env:BINANCE_MAINNET_ED25519_PRIVATE_KEY
+
+uxc auth credential set binance-spot-testnet \
+  --auth-type api_key \
+  --field api_key=env:BINANCE_TESTNET_API_KEY \
+  --field private_key=env:BINANCE_TESTNET_ED25519_PRIVATE_KEY
+```
+
+Add one signer binding per environment:
+
+```bash
+uxc auth binding add \
+  --id binance-spot-mainnet \
+  --host api.binance.com \
+  --path-prefix /api/v3 \
+  --scheme https \
+  --credential binance-spot-mainnet \
+  --signer-json '{"kind":"ed25519_query_v1","algorithm":"ed25519","signing_field":"private_key","key_field":"api_key","key_placement":"header","key_name":"X-MBX-APIKEY","signature_param":"signature","signature_encoding":"base64","timestamp_param":"timestamp","timestamp_unit":"milliseconds","canonicalization":{"mode":"preserve_order"}}' \
+  --priority 100
+
+uxc auth binding add \
+  --id binance-spot-testnet \
+  --host testnet.binance.vision \
+  --path-prefix /api/v3 \
+  --scheme https \
+  --credential binance-spot-testnet \
+  --signer-json '{"kind":"ed25519_query_v1","algorithm":"ed25519","signing_field":"private_key","key_field":"api_key","key_placement":"header","key_name":"X-MBX-APIKEY","signature_param":"signature","signature_encoding":"base64","timestamp_param":"timestamp","timestamp_unit":"milliseconds","canonicalization":{"mode":"preserve_order"}}' \
+  --priority 100
+```
+
+### HMAC Fallback
+
+If you already have legacy HMAC keys, `uxc` still supports them:
+
+```bash
+uxc auth credential set binance-spot-mainnet-hmac \
+  --auth-type api_key \
+  --field api_key=env:BINANCE_MAINNET_API_KEY \
+  --field secret_key=env:BINANCE_MAINNET_SECRET_KEY
+
+uxc auth credential set binance-spot-testnet-hmac \
+  --auth-type api_key \
+  --field api_key=env:BINANCE_TESTNET_API_KEY \
+  --field secret_key=env:BINANCE_TESTNET_SECRET_KEY
+
+uxc auth binding add \
+  --id binance-spot-mainnet-hmac \
+  --host api.binance.com \
+  --path-prefix /api/v3 \
+  --scheme https \
+  --credential binance-spot-mainnet-hmac \
+  --signer-json '{"kind":"hmac_query_v1","algorithm":"hmac_sha256","signing_field":"secret_key","key_field":"api_key","key_placement":"header","key_name":"X-MBX-APIKEY","signature_param":"signature","signature_encoding":"hex","timestamp_param":"timestamp","timestamp_unit":"milliseconds","canonicalization":{"mode":"preserve_order"}}' \
+  --priority 100
+
+uxc auth binding add \
+  --id binance-spot-testnet-hmac \
+  --host testnet.binance.vision \
+  --path-prefix /api/v3 \
+  --scheme https \
+  --credential binance-spot-testnet-hmac \
+  --signer-json '{"kind":"hmac_query_v1","algorithm":"hmac_sha256","signing_field":"secret_key","key_field":"api_key","key_placement":"header","key_name":"X-MBX-APIKEY","signature_param":"signature","signature_encoding":"hex","timestamp_param":"timestamp","timestamp_unit":"milliseconds","canonicalization":{"mode":"preserve_order"}}' \
+  --priority 100
+```
+
+## Core Workflow
+
+1. Use fixed link commands by default:
+   - `command -v binance-spot-mainnet-openapi-cli`
+   - If missing, create it:
+     `uxc link binance-spot-mainnet-openapi-cli https://api.binance.com --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/binance-spot-openapi-skill/references/binance-spot.openapi.json`
+   - `command -v binance-spot-testnet-openapi-cli`
+   - If missing, create it:
+     `uxc link binance-spot-testnet-openapi-cli https://testnet.binance.vision --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/binance-spot-openapi-skill/references/binance-spot.openapi.json`
+
+2. Discover operations with help-first flow:
+   - `binance-spot-mainnet-openapi-cli -h`
+   - `binance-spot-testnet-openapi-cli -h`
+   - `binance-spot-testnet-openapi-cli post:/api/v3/order/test -h`
+   - `binance-spot-testnet-openapi-cli get:/api/v3/account -h`
+
+3. Execute reads first:
+   - public read:
+     `binance-spot-mainnet-openapi-cli get:/api/v3/ticker/price symbol=BTCUSDT`
+   - signed read:
+     `binance-spot-testnet-openapi-cli get:/api/v3/account omitZeroBalances=true recvWindow=5000`
+
+4. Use `order/test` before real writes:
+   - `binance-spot-testnet-openapi-cli post:/api/v3/order/test symbol=BTCUSDT side=BUY type=MARKET quoteOrderQty=100 recvWindow=5000`
+
+## Operation Groups
+
+### Public Market
+
+- `get:/api/v3/ping`
+- `get:/api/v3/time`
+- `get:/api/v3/exchangeInfo`
+- `get:/api/v3/avgPrice`
+- `get:/api/v3/depth`
+- `get:/api/v3/klines`
+- `get:/api/v3/ticker/24hr`
+- `get:/api/v3/ticker/price`
+- `get:/api/v3/trades`
+
+### Signed Reads
+
+- `get:/api/v3/account`
+- `get:/api/v3/openOrders`
+- `get:/api/v3/order`
+- `get:/api/v3/allOrders`
+- `get:/api/v3/myTrades`
+- `get:/api/v3/rateLimit/order`
+
+### Signed Writes
+
+- `post:/api/v3/order/test`
+- `post:/api/v3/order`
+- `delete:/api/v3/order`
+- `delete:/api/v3/openOrders`
+
+## Guardrails
+
+- Keep automation on the JSON output envelope; do not use `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- Treat `order/test` as the default validation path before any real order placement.
+- Treat all mainnet write operations as high-risk and require explicit user confirmation before execution.
+- Prefer testnet for all signed examples unless the user explicitly asks for mainnet.
+- Before placing orders, query `exchangeInfo` for symbol filters and `ticker/price` or `depth` for current market context.
+- If Binance returns `-1021`, call `get:/api/v3/time`, then retry with a fresh timestamp and, if needed, a larger `recvWindow`.
+- If Binance returns `-1022`, first verify you are using the `API key` from the same Binance key record as the signing material:
+  - Ed25519: displayed `API key` + matching private key PEM
+  - HMAC: displayed `API key` + matching `Secret key`
+- Use `--path-prefix /api/v3` on auth bindings. `uxc` now resolves OpenAPI auth against the final operation URL, so this narrower binding works for signed Spot requests and avoids over-broad host-level matching.
+- `timestamp` and `signature` are injected by the signer binding; users normally provide business parameters plus optional `recvWindow`.
+- `binance-spot-*-openapi-cli <operation> ...` is equivalent to `uxc <host> --schema-url <binance_spot_openapi_schema> <operation> ...`.
+
+## References
+
+- Usage patterns: `references/usage-patterns.md`
+- Curated OpenAPI schema: `references/binance-spot.openapi.json`
+- Binance Spot skill source material: https://github.com/binance/binance-skills-hub/tree/main/skills/binance/spot
+- Official Binance Spot API docs: https://github.com/binance/binance-spot-api-docs

--- a/skills/binance-spot-openapi-skill/agents/openai.yaml
+++ b/skills/binance-spot-openapi-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Binance Spot API"
+  short_description: "Operate Binance Spot public market, signed account, and order endpoints via UXC with curated OpenAPI mapping and Ed25519 (recommended) and HMAC query signing"
+  default_prompt: "Use $binance-spot-openapi-skill to discover and execute Binance Spot REST operations through UXC with separate mainnet/testnet link flows, Ed25519 (recommended) and HMAC signer bindings, and testnet-first write guardrails."

--- a/skills/binance-spot-openapi-skill/references/binance-spot.openapi.json
+++ b/skills/binance-spot-openapi-skill/references/binance-spot.openapi.json
@@ -1,0 +1,1482 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Binance Spot API",
+    "version": "1.0.0",
+    "description": "Curated OpenAPI schema for high-value Binance Spot market, account, and order endpoints."
+  },
+  "servers": [
+    {
+      "url": "https://api.binance.com"
+    },
+    {
+      "url": "https://testnet.binance.vision"
+    }
+  ],
+  "paths": {
+    "/api/v3/ping": {
+      "get": {
+        "operationId": "ping",
+        "summary": "Test connectivity",
+        "responses": {
+          "200": {
+            "description": "Connectivity check response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/time": {
+      "get": {
+        "operationId": "getServerTime",
+        "summary": "Check server time",
+        "responses": {
+          "200": {
+            "description": "Server time",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "serverTime": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "serverTime"
+                  ],
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/exchangeInfo": {
+      "get": {
+        "operationId": "getExchangeInfo",
+        "summary": "Exchange information",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "symbols",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "JSON-style symbols array accepted by Binance."
+            }
+          },
+          {
+            "name": "permissions",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "showPermissionSets",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "symbolStatus",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SymbolStatus"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Exchange information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExchangeInfo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/avgPrice": {
+      "get": {
+        "operationId": "getAveragePrice",
+        "summary": "Current average price",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Average price",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "mins": {
+                      "type": "integer"
+                    },
+                    "price": {
+                      "type": "string"
+                    },
+                    "closeTime": {
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/depth": {
+      "get": {
+        "operationId": "getOrderBook",
+        "summary": "Order book",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 100
+            }
+          },
+          {
+            "name": "symbolStatus",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SymbolStatus"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order book",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "lastUpdateId": {
+                      "type": "integer"
+                    },
+                    "bids": {
+                      "$ref": "#/components/schemas/PriceLevelArray"
+                    },
+                    "asks": {
+                      "$ref": "#/components/schemas/PriceLevelArray"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/klines": {
+      "get": {
+        "operationId": "getKlines",
+        "summary": "Kline candlestick data",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/KlineInterval"
+            }
+          },
+          {
+            "name": "startTime",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "endTime",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "timeZone",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 500
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Kline rows",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/KlineRow"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/ticker/24hr": {
+      "get": {
+        "operationId": "getTicker24hr",
+        "summary": "24hr ticker price change statistics",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "symbols",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/TickerType"
+            }
+          },
+          {
+            "name": "symbolStatus",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SymbolStatus"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "24hr ticker stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Ticker24hr"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Ticker24hr"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/ticker/price": {
+      "get": {
+        "operationId": "getTickerPrice",
+        "summary": "Symbol price ticker",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "symbols",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "symbolStatus",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SymbolStatus"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ticker price result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TickerPrice"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/TickerPrice"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/trades": {
+      "get": {
+        "operationId": "getRecentTrades",
+        "summary": "Recent trades list",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 500
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recent trades",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RecentTrade"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/account": {
+      "get": {
+        "operationId": "getAccount",
+        "summary": "Account information",
+        "parameters": [
+          {
+            "name": "omitZeroBalances",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "recvWindow",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/RecvWindow"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountInfo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/openOrders": {
+      "get": {
+        "operationId": "getOpenOrders",
+        "summary": "Current open orders",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "recvWindow",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/RecvWindow"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Open orders",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Order"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "cancelOpenOrders",
+        "summary": "Cancel all open orders on a symbol",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "recvWindow",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/RecvWindow"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cancel all open orders result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/order/test": {
+      "post": {
+        "operationId": "testOrder",
+        "summary": "Test new order",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrderSymbol"
+          },
+          {
+            "$ref": "#/components/parameters/OrderSide"
+          },
+          {
+            "$ref": "#/components/parameters/OrderType"
+          },
+          {
+            "$ref": "#/components/parameters/TimeInForce"
+          },
+          {
+            "$ref": "#/components/parameters/Quantity"
+          },
+          {
+            "$ref": "#/components/parameters/QuoteOrderQty"
+          },
+          {
+            "$ref": "#/components/parameters/Price"
+          },
+          {
+            "$ref": "#/components/parameters/NewClientOrderId"
+          },
+          {
+            "$ref": "#/components/parameters/RecvWindow"
+          },
+          {
+            "name": "newOrderRespType",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/NewOrderRespType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Test order result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/order": {
+      "get": {
+        "operationId": "getOrder",
+        "summary": "Query order",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orderId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "origClientOrderId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "recvWindow",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/RecvWindow"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createOrder",
+        "summary": "New order",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrderSymbol"
+          },
+          {
+            "$ref": "#/components/parameters/OrderSide"
+          },
+          {
+            "$ref": "#/components/parameters/OrderType"
+          },
+          {
+            "$ref": "#/components/parameters/TimeInForce"
+          },
+          {
+            "$ref": "#/components/parameters/Quantity"
+          },
+          {
+            "$ref": "#/components/parameters/QuoteOrderQty"
+          },
+          {
+            "$ref": "#/components/parameters/Price"
+          },
+          {
+            "$ref": "#/components/parameters/NewClientOrderId"
+          },
+          {
+            "$ref": "#/components/parameters/RecvWindow"
+          },
+          {
+            "name": "newOrderRespType",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/NewOrderRespType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order placement result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "cancelOrder",
+        "summary": "Cancel order",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orderId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "origClientOrderId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "newClientOrderId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cancelRestrictions",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/CancelRestrictions"
+            }
+          },
+          {
+            "name": "recvWindow",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/RecvWindow"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cancel order result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/allOrders": {
+      "get": {
+        "operationId": "getAllOrders",
+        "summary": "All orders",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orderId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "startTime",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "endTime",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 500
+            }
+          },
+          {
+            "name": "recvWindow",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/RecvWindow"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All orders",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Order"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/myTrades": {
+      "get": {
+        "operationId": "getMyTrades",
+        "summary": "Account trade list",
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orderId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "startTime",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "endTime",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "fromId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 500
+            }
+          },
+          {
+            "name": "recvWindow",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/RecvWindow"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account trades",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Trade"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/rateLimit/order": {
+      "get": {
+        "operationId": "getOrderRateLimit",
+        "summary": "Query current order count usage",
+        "parameters": [
+          {
+            "name": "recvWindow",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/RecvWindow"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order count usage",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "rateLimitType": {
+                        "type": "string"
+                      },
+                      "interval": {
+                        "type": "string"
+                      },
+                      "intervalNum": {
+                        "type": "integer"
+                      },
+                      "limit": {
+                        "type": "integer"
+                      },
+                      "count": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "OrderSymbol": {
+        "name": "symbol",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "OrderSide": {
+        "name": "side",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/OrderSide"
+        }
+      },
+      "OrderType": {
+        "name": "type",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/OrderType"
+        }
+      },
+      "TimeInForce": {
+        "name": "timeInForce",
+        "in": "query",
+        "schema": {
+          "$ref": "#/components/schemas/TimeInForce"
+        }
+      },
+      "Quantity": {
+        "name": "quantity",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "QuoteOrderQty": {
+        "name": "quoteOrderQty",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Price": {
+        "name": "price",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "NewClientOrderId": {
+        "name": "newClientOrderId",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "RecvWindow": {
+        "name": "recvWindow",
+        "in": "query",
+        "schema": {
+          "$ref": "#/components/schemas/RecvWindow"
+        }
+      }
+    },
+    "schemas": {
+      "RecvWindow": {
+        "type": "number",
+        "description": "Binance recvWindow in milliseconds, up to 60000 and may contain decimal precision."
+      },
+      "KlineInterval": {
+        "type": "string",
+        "enum": [
+          "1s",
+          "1m",
+          "3m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "4h",
+          "6h",
+          "8h",
+          "12h",
+          "1d",
+          "3d",
+          "1w",
+          "1M"
+        ]
+      },
+      "TickerType": {
+        "type": "string",
+        "enum": [
+          "FULL",
+          "MINI"
+        ]
+      },
+      "SymbolStatus": {
+        "type": "string",
+        "enum": [
+          "TRADING",
+          "END_OF_DAY",
+          "HALT",
+          "BREAK"
+        ]
+      },
+      "OrderSide": {
+        "type": "string",
+        "enum": [
+          "BUY",
+          "SELL"
+        ]
+      },
+      "OrderType": {
+        "type": "string",
+        "enum": [
+          "LIMIT",
+          "MARKET",
+          "STOP_LOSS",
+          "STOP_LOSS_LIMIT",
+          "TAKE_PROFIT",
+          "TAKE_PROFIT_LIMIT",
+          "LIMIT_MAKER"
+        ]
+      },
+      "TimeInForce": {
+        "type": "string",
+        "enum": [
+          "GTC",
+          "IOC",
+          "FOK"
+        ]
+      },
+      "NewOrderRespType": {
+        "type": "string",
+        "enum": [
+          "ACK",
+          "RESULT",
+          "FULL"
+        ]
+      },
+      "CancelRestrictions": {
+        "type": "string",
+        "enum": [
+          "ONLY_NEW",
+          "ONLY_PARTIALLY_FILLED"
+        ]
+      },
+      "PriceLevelArray": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "KlineRow": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "items": false,
+        "minItems": 12,
+        "maxItems": 12
+      },
+      "TickerPrice": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": "string"
+          },
+          "price": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "symbol",
+          "price"
+        ],
+        "additionalProperties": true
+      },
+      "Ticker24hr": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": "string"
+          },
+          "priceChange": {
+            "type": "string"
+          },
+          "priceChangePercent": {
+            "type": "string"
+          },
+          "weightedAvgPrice": {
+            "type": "string"
+          },
+          "lastPrice": {
+            "type": "string"
+          },
+          "volume": {
+            "type": "string"
+          },
+          "quoteVolume": {
+            "type": "string"
+          },
+          "openTime": {
+            "type": "integer"
+          },
+          "closeTime": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "symbol"
+        ],
+        "additionalProperties": true
+      },
+      "RecentTrade": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "price": {
+            "type": "string"
+          },
+          "qty": {
+            "type": "string"
+          },
+          "quoteQty": {
+            "type": "string"
+          },
+          "time": {
+            "type": "integer"
+          },
+          "isBuyerMaker": {
+            "type": "boolean"
+          },
+          "isBestMatch": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Order": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": "string"
+          },
+          "orderId": {
+            "type": "integer"
+          },
+          "orderListId": {
+            "type": "integer"
+          },
+          "clientOrderId": {
+            "type": "string"
+          },
+          "price": {
+            "type": "string"
+          },
+          "origQty": {
+            "type": "string"
+          },
+          "executedQty": {
+            "type": "string"
+          },
+          "cummulativeQuoteQty": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "timeInForce": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "side": {
+            "type": "string"
+          },
+          "stopPrice": {
+            "type": "string"
+          },
+          "icebergQty": {
+            "type": "string"
+          },
+          "time": {
+            "type": "integer"
+          },
+          "updateTime": {
+            "type": "integer"
+          },
+          "isWorking": {
+            "type": "boolean"
+          },
+          "workingTime": {
+            "type": "integer"
+          },
+          "origQuoteOrderQty": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "symbol",
+          "orderId",
+          "status",
+          "type",
+          "side"
+        ],
+        "additionalProperties": true
+      },
+      "Trade": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "orderId": {
+            "type": "integer"
+          },
+          "orderListId": {
+            "type": "integer"
+          },
+          "price": {
+            "type": "string"
+          },
+          "qty": {
+            "type": "string"
+          },
+          "quoteQty": {
+            "type": "string"
+          },
+          "commission": {
+            "type": "string"
+          },
+          "commissionAsset": {
+            "type": "string"
+          },
+          "time": {
+            "type": "integer"
+          },
+          "isBuyer": {
+            "type": "boolean"
+          },
+          "isMaker": {
+            "type": "boolean"
+          },
+          "isBestMatch": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Balance": {
+        "type": "object",
+        "properties": {
+          "asset": {
+            "type": "string"
+          },
+          "free": {
+            "type": "string"
+          },
+          "locked": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset",
+          "free",
+          "locked"
+        ]
+      },
+      "AccountInfo": {
+        "type": "object",
+        "properties": {
+          "makerCommission": {
+            "type": "integer"
+          },
+          "takerCommission": {
+            "type": "integer"
+          },
+          "buyerCommission": {
+            "type": "integer"
+          },
+          "sellerCommission": {
+            "type": "integer"
+          },
+          "canTrade": {
+            "type": "boolean"
+          },
+          "canWithdraw": {
+            "type": "boolean"
+          },
+          "canDeposit": {
+            "type": "boolean"
+          },
+          "brokered": {
+            "type": "boolean"
+          },
+          "requireSelfTradePrevention": {
+            "type": "boolean"
+          },
+          "preventSor": {
+            "type": "boolean"
+          },
+          "updateTime": {
+            "type": "integer"
+          },
+          "accountType": {
+            "type": "string"
+          },
+          "balances": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Balance"
+            }
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "balances"
+        ],
+        "additionalProperties": true
+      },
+      "ExchangeInfo": {
+        "type": "object",
+        "properties": {
+          "timezone": {
+            "type": "string"
+          },
+          "serverTime": {
+            "type": "integer"
+          },
+          "rateLimits": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "exchangeFilters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "symbols": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "symbol": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "baseAsset": {
+                  "type": "string"
+                },
+                "quoteAsset": {
+                  "type": "string"
+                },
+                "filters": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              },
+              "required": [
+                "symbol",
+                "status"
+              ],
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/skills/binance-spot-openapi-skill/references/usage-patterns.md
+++ b/skills/binance-spot-openapi-skill/references/usage-patterns.md
@@ -1,0 +1,181 @@
+# Binance Spot API Skill - Usage Patterns
+
+## Link Setup
+
+```bash
+command -v binance-spot-mainnet-openapi-cli
+uxc link binance-spot-mainnet-openapi-cli https://api.binance.com \
+  --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/binance-spot-openapi-skill/references/binance-spot.openapi.json
+
+command -v binance-spot-testnet-openapi-cli
+uxc link binance-spot-testnet-openapi-cli https://testnet.binance.vision \
+  --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/binance-spot-openapi-skill/references/binance-spot.openapi.json
+
+binance-spot-mainnet-openapi-cli -h
+binance-spot-testnet-openapi-cli -h
+```
+
+## Auth Setup
+
+### Get Spot Testnet Keys
+
+- Open `https://testnet.binance.vision`
+- Create or select a Spot API key record in the testnet UI
+- For `Ed25519`, generate the keypair locally first, upload the public key, then copy the `API key` Binance shows for that record
+- For `HMAC`, Binance shows both `API key` and `Secret key`
+- Keep the `API key` matched with the same record as the signing material
+
+If you want to generate an Ed25519 keypair locally:
+
+```bash
+openssl genpkey -algorithm ed25519 -out binance_testnet_ed25519_private.pem
+openssl pkey -in binance_testnet_ed25519_private.pem -pubout -out binance_testnet_ed25519_public.pem
+```
+
+Then export the private key PEM content and the Binance-displayed API key:
+
+```bash
+export BINANCE_TESTNET_API_KEY='<binance testnet api key for this Ed25519 record>'
+export BINANCE_TESTNET_ED25519_PRIVATE_KEY="$(cat /absolute/path/to/binance_testnet_ed25519_private.pem)"
+```
+
+### Ed25519 Setup
+
+```bash
+uxc auth credential set binance-spot-mainnet \
+  --auth-type api_key \
+  --field api_key=env:BINANCE_MAINNET_API_KEY \
+  --field private_key=env:BINANCE_MAINNET_ED25519_PRIVATE_KEY
+
+uxc auth credential set binance-spot-testnet \
+  --auth-type api_key \
+  --field api_key=env:BINANCE_TESTNET_API_KEY \
+  --field private_key=env:BINANCE_TESTNET_ED25519_PRIVATE_KEY
+```
+
+```bash
+SIGNER='{"kind":"ed25519_query_v1","algorithm":"ed25519","signing_field":"private_key","key_field":"api_key","key_placement":"header","key_name":"X-MBX-APIKEY","signature_param":"signature","signature_encoding":"base64","timestamp_param":"timestamp","timestamp_unit":"milliseconds","canonicalization":{"mode":"preserve_order"}}'
+
+uxc auth binding add \
+  --id binance-spot-mainnet \
+  --host api.binance.com \
+  --path-prefix /api/v3 \
+  --scheme https \
+  --credential binance-spot-mainnet \
+  --signer-json "$SIGNER" \
+  --priority 100
+
+uxc auth binding add \
+  --id binance-spot-testnet \
+  --host testnet.binance.vision \
+  --path-prefix /api/v3 \
+  --scheme https \
+  --credential binance-spot-testnet \
+  --signer-json "$SIGNER" \
+  --priority 100
+```
+
+## Legacy HMAC Setup
+
+```bash
+uxc auth credential set binance-spot-mainnet-hmac \
+  --auth-type api_key \
+  --field api_key=env:BINANCE_MAINNET_API_KEY \
+  --field secret_key=env:BINANCE_MAINNET_SECRET_KEY
+
+uxc auth credential set binance-spot-testnet-hmac \
+  --auth-type api_key \
+  --field api_key=env:BINANCE_TESTNET_API_KEY \
+  --field secret_key=env:BINANCE_TESTNET_SECRET_KEY
+
+HMAC_SIGNER='{"kind":"hmac_query_v1","algorithm":"hmac_sha256","signing_field":"secret_key","key_field":"api_key","key_placement":"header","key_name":"X-MBX-APIKEY","signature_param":"signature","signature_encoding":"hex","timestamp_param":"timestamp","timestamp_unit":"milliseconds","canonicalization":{"mode":"preserve_order"}}'
+```
+
+Common failure mode:
+
+- `-1022 Signature for this request is not valid.`
+  - Usually means the `API key` and signing material came from different Binance key records.
+  - Ed25519 requires the Binance-displayed `API key` for that uploaded public key record.
+  - The uploaded public key itself is not the `API key`.
+
+## Public Read Examples
+
+```bash
+# Server time
+binance-spot-mainnet-openapi-cli get:/api/v3/time
+
+# Exchange filters and symbol metadata
+binance-spot-mainnet-openapi-cli get:/api/v3/exchangeInfo symbol=BTCUSDT
+
+# Latest ticker price
+binance-spot-mainnet-openapi-cli get:/api/v3/ticker/price symbol=BTCUSDT
+
+# 24h stats
+binance-spot-mainnet-openapi-cli get:/api/v3/ticker/24hr symbol=BTCUSDT
+
+# Recent trades
+binance-spot-mainnet-openapi-cli get:/api/v3/trades symbol=BTCUSDT limit=20
+
+# Klines
+binance-spot-mainnet-openapi-cli get:/api/v3/klines symbol=BTCUSDT interval=1h limit=24
+
+# Order book
+binance-spot-mainnet-openapi-cli get:/api/v3/depth symbol=BTCUSDT limit=20
+```
+
+## Signed Read Examples
+
+```bash
+# Account balances on testnet
+binance-spot-testnet-openapi-cli get:/api/v3/account omitZeroBalances=true recvWindow=5000
+
+# Current open orders
+binance-spot-testnet-openapi-cli get:/api/v3/openOrders symbol=BTCUSDT recvWindow=5000
+
+# Query one order
+binance-spot-testnet-openapi-cli get:/api/v3/order symbol=BTCUSDT orderId=123456 recvWindow=5000
+
+# Order history
+binance-spot-testnet-openapi-cli get:/api/v3/allOrders symbol=BTCUSDT limit=20 recvWindow=5000
+
+# Trade history
+binance-spot-testnet-openapi-cli get:/api/v3/myTrades symbol=BTCUSDT limit=20 recvWindow=5000
+
+# Current order count usage
+binance-spot-testnet-openapi-cli get:/api/v3/rateLimit/order recvWindow=5000
+```
+
+## Testnet-First Write Examples
+
+```bash
+# Validate order shape and signature without placing a real order
+binance-spot-testnet-openapi-cli post:/api/v3/order/test \
+  symbol=BTCUSDT side=BUY type=MARKET quoteOrderQty=100 recvWindow=5000
+
+# Place a real testnet order
+binance-spot-testnet-openapi-cli post:/api/v3/order \
+  symbol=BTCUSDT side=BUY type=LIMIT timeInForce=GTC quantity=0.001 price=20000 recvWindow=5000
+
+# Cancel a testnet order
+binance-spot-testnet-openapi-cli delete:/api/v3/order \
+  symbol=BTCUSDT orderId=123456 recvWindow=5000
+
+# Cancel all open orders on a symbol
+binance-spot-testnet-openapi-cli delete:/api/v3/openOrders \
+  symbol=BTCUSDT recvWindow=5000
+```
+
+## Mainnet Write Guardrail
+
+```bash
+# Only run after explicit user confirmation
+binance-spot-mainnet-openapi-cli post:/api/v3/order \
+  symbol=BTCUSDT side=BUY type=MARKET quoteOrderQty=100 recvWindow=5000
+```
+
+## Fallback Equivalence
+
+- `binance-spot-mainnet-openapi-cli <operation> ...` is equivalent to
+  `uxc https://api.binance.com --schema-url <binance_spot_openapi_schema> <operation> ...`.
+- `binance-spot-testnet-openapi-cli <operation> ...` is equivalent to
+  `uxc https://testnet.binance.vision --schema-url <binance_spot_openapi_schema> <operation> ...`.

--- a/skills/binance-spot-openapi-skill/scripts/validate.sh
+++ b/skills/binance-spot-openapi-skill/scripts/validate.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/binance-spot-openapi-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+SCHEMA_FILE="${SKILL_DIR}/references/binance-spot.openapi.json"
+USAGE_FILE="${SKILL_DIR}/references/usage-patterns.md"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd rg
+need_cmd jq
+
+required_files=(
+  "${SKILL_FILE}"
+  "${OPENAI_FILE}"
+  "${USAGE_FILE}"
+  "${SCHEMA_FILE}"
+)
+
+for file in "${required_files[@]}"; do
+  [[ -f "${file}" ]] || fail "missing required file: ${file}"
+done
+
+rg -q '^name:\s*binance-spot-openapi-skill\s*$' "${SKILL_FILE}" || fail 'invalid skill name'
+rg -q '^description:\s*.+' "${SKILL_FILE}" || fail 'missing description'
+rg -q 'command -v binance-spot-mainnet-openapi-cli' "${SKILL_FILE}" || fail 'missing mainnet link-first check'
+rg -q 'command -v binance-spot-testnet-openapi-cli' "${SKILL_FILE}" || fail 'missing testnet link-first check'
+rg -q 'uxc link binance-spot-mainnet-openapi-cli https://api.binance.com --schema-url ' "${SKILL_FILE}" || fail 'missing fixed mainnet link command'
+rg -q 'uxc link binance-spot-testnet-openapi-cli https://testnet.binance.vision --schema-url ' "${SKILL_FILE}" || fail 'missing fixed testnet link command'
+rg -q 'post:/api/v3/order/test -h' "${SKILL_FILE}" || fail 'missing operation-level help example'
+rg -q 'Treat all mainnet write operations as high-risk' "${SKILL_FILE}" || fail 'missing mainnet write guardrail'
+rg -q 'timestamp` and `signature` are injected by the signer binding' "${SKILL_FILE}" || fail 'missing signer injection note'
+rg -q -- '--field api_key=env:BINANCE_MAINNET_API_KEY' "${SKILL_FILE}" || fail 'missing mainnet auth example'
+rg -q -- '--signer-json' "${SKILL_FILE}" || fail 'missing signer-json example'
+
+if rg -q -- "--args\\s+'\\{" "${SKILL_FILE}" "${USAGE_FILE}"; then
+  fail 'found banned legacy JSON argument pattern'
+fi
+
+rg -q '^\s*display_name:\s*"Binance Spot API"\s*$' "${OPENAI_FILE}" || fail 'missing display_name'
+rg -q '^\s*short_description:\s*".+"\s*$' "${OPENAI_FILE}" || fail 'missing short_description'
+rg -q '^\s*default_prompt:\s*".*\$binance-spot-openapi-skill.*"\s*$' "${OPENAI_FILE}" || fail 'default_prompt must mention $binance-spot-openapi-skill'
+
+jq -e '.openapi == "3.1.0"' "${SCHEMA_FILE}" >/dev/null || fail 'schema must be OpenAPI 3.1.0 JSON'
+jq -e '.paths["/api/v3/order"].post.operationId == "createOrder"' "${SCHEMA_FILE}" >/dev/null || fail 'missing create order operation'
+jq -e '.paths["/api/v3/account"].get.operationId == "getAccount"' "${SCHEMA_FILE}" >/dev/null || fail 'missing account operation'
+jq -e '.paths["/api/v3/order/test"].post.operationId == "testOrder"' "${SCHEMA_FILE}" >/dev/null || fail 'missing test order operation'
+
+echo "skills/binance-spot-openapi-skill validation passed"

--- a/src/adapters/openapi.rs
+++ b/src/adapters/openapi.rs
@@ -87,6 +87,10 @@ impl OpenAPIAdapter {
             .or_else(|| self.auth_profile.clone())
     }
 
+    fn schema_requests_apply_auth(&self) -> bool {
+        self.schema_url_override.is_none()
+    }
+
     async fn set_effective_auth_profile(&self, profile: Profile) {
         *self.runtime_auth_profile.lock().await = Some(profile);
     }
@@ -105,6 +109,30 @@ impl OpenAPIAdapter {
         match profile {
             Some(profile) => crate::auth::apply_profile_auth_to_url(url, profile),
             None => Ok(url.to_string()),
+        }
+    }
+
+    fn apply_schema_auth_profile(
+        &self,
+        req: reqwest::RequestBuilder,
+        profile: Option<&Profile>,
+    ) -> Result<reqwest::RequestBuilder> {
+        if self.schema_requests_apply_auth() {
+            Self::apply_auth_profile(req, profile)
+        } else {
+            Ok(req)
+        }
+    }
+
+    fn apply_schema_auth_profile_to_url(
+        &self,
+        url: &str,
+        profile: Option<&Profile>,
+    ) -> Result<String> {
+        if self.schema_requests_apply_auth() {
+            Self::apply_auth_profile_to_url(url, profile)
+        } else {
+            Ok(url.to_string())
         }
     }
 
@@ -181,13 +209,13 @@ impl OpenAPIAdapter {
     async fn check_schema_url(&self, schema_url: &str) -> Result<bool> {
         let response = self
             .send_with_oauth_retry(|profile| {
-                let schema_url = Self::apply_auth_profile_to_url(schema_url, profile)?;
+                let schema_url = self.apply_schema_auth_profile_to_url(schema_url, profile)?;
                 let req = self
                     .client
                     .get(&schema_url)
                     .timeout(std::time::Duration::from_secs(10))
                     .header("Accept", "application/json");
-                Self::apply_auth_profile(req, profile)
+                self.apply_schema_auth_profile(req, profile)
             })
             .await?;
 
@@ -295,13 +323,13 @@ impl OpenAPIAdapter {
         for full_url in Self::schema_candidates(&normalized) {
             let resp = match self
                 .send_with_oauth_retry(|profile| {
-                    let full_url = Self::apply_auth_profile_to_url(&full_url, profile)?;
+                    let full_url = self.apply_schema_auth_profile_to_url(&full_url, profile)?;
                     let req = self
                         .client
                         .get(&full_url)
                         .timeout(std::time::Duration::from_secs(2))
                         .header("Accept", "application/json");
-                    Self::apply_auth_profile(req, profile)
+                    self.apply_schema_auth_profile(req, profile)
                 })
                 .await
             {
@@ -854,9 +882,9 @@ impl Adapter for OpenAPIAdapter {
         // Fetch from remote
         let resp = self
             .send_with_oauth_retry(|profile| {
-                let schema_url = Self::apply_auth_profile_to_url(&schema_url, profile)?;
+                let schema_url = self.apply_schema_auth_profile_to_url(&schema_url, profile)?;
                 let req = self.client.get(&schema_url);
-                Self::apply_auth_profile(req, profile)
+                self.apply_schema_auth_profile(req, profile)
             })
             .await?;
         let schema: Value = resp.json().await?;
@@ -1300,7 +1328,6 @@ mod tests {
 
         let _schema = server
             .mock("GET", "/openapi.json")
-            .match_header("authorization", "Bearer old-token")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
@@ -1381,6 +1408,34 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.data["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn schema_url_override_does_not_apply_business_query_auth() {
+        let mut server = mockito::Server::new_async().await;
+        let schema_url = format!("{}/schema.json", server.url());
+
+        let _schema = server
+            .mock("GET", "/schema.json")
+            .match_query(mockito::Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(openapi_doc())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut profile = Profile::new("secret".to_string(), crate::auth::AuthType::ApiKey);
+        profile.auth_query_params = Some(vec![crate::auth::AuthQueryParam::parse(
+            "apiKey={{secret}}",
+        )
+        .unwrap()]);
+
+        let adapter = OpenAPIAdapter::new()
+            .with_auth(profile)
+            .with_schema_url_override(Some(schema_url));
+
+        assert!(adapter.can_handle(&server.url()).await.unwrap());
     }
 
     #[test]

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -186,6 +186,7 @@ impl SecretSource {
 #[serde(rename_all = "snake_case")]
 pub enum SignerAlgorithm {
     HmacSha256,
+    Ed25519,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -250,9 +251,30 @@ pub struct HmacQuerySignerConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Ed25519QuerySignerConfig {
+    pub algorithm: SignerAlgorithm,
+    pub signing_field: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_field: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_placement: Option<SignerValuePlacement>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_name: Option<String>,
+    pub signature_param: String,
+    pub signature_encoding: SignatureEncoding,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp_param: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp_unit: Option<TimestampUnit>,
+    #[serde(default)]
+    pub canonicalization: QueryCanonicalization,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AuthSignerConfig {
     HmacQueryV1(HmacQuerySignerConfig),
+    Ed25519QueryV1(Ed25519QuerySignerConfig),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1159,6 +1181,9 @@ fn validate_ready(profile: &Profile) -> Result<()> {
 pub fn validate_signer_config(config: &AuthSignerConfig) -> Result<()> {
     match config {
         AuthSignerConfig::HmacQueryV1(hmac) => {
+            if hmac.algorithm != SignerAlgorithm::HmacSha256 {
+                anyhow::bail!("hmac_query_v1 signer requires algorithm=hmac_sha256");
+            }
             validate_field_name(&hmac.signing_field)?;
             validate_query_param_name(&hmac.signature_param)?;
             if let Some(timestamp_param) = &hmac.timestamp_param {
@@ -1184,6 +1209,45 @@ pub fn validate_signer_config(config: &AuthSignerConfig) -> Result<()> {
                         "hmac_query_v1 signer requires key_field, key_placement, and key_name to be set together"
                     );
                 }
+            }
+        }
+        AuthSignerConfig::Ed25519QueryV1(ed25519) => {
+            if ed25519.algorithm != SignerAlgorithm::Ed25519 {
+                anyhow::bail!("ed25519_query_v1 signer requires algorithm=ed25519");
+            }
+            validate_field_name(&ed25519.signing_field)?;
+            validate_query_param_name(&ed25519.signature_param)?;
+            if let Some(timestamp_param) = &ed25519.timestamp_param {
+                validate_query_param_name(timestamp_param)?;
+            }
+
+            match (
+                &ed25519.key_field,
+                &ed25519.key_placement,
+                &ed25519.key_name,
+            ) {
+                (None, None, None) => {}
+                (Some(field), Some(_), Some(name)) => {
+                    validate_field_name(field)?;
+                    match ed25519.key_placement {
+                        Some(SignerValuePlacement::Query) => {
+                            validate_query_param_name(name)?;
+                        }
+                        Some(SignerValuePlacement::Header) => {
+                            validate_header_name(name)?;
+                        }
+                        None => unreachable!(),
+                    };
+                }
+                _ => {
+                    anyhow::bail!(
+                        "ed25519_query_v1 signer requires key_field, key_placement, and key_name to be set together"
+                    );
+                }
+            }
+
+            if ed25519.signature_encoding != SignatureEncoding::Base64 {
+                anyhow::bail!("ed25519_query_v1 signer requires signature_encoding=base64");
             }
         }
     }
@@ -1649,6 +1713,17 @@ fn hmac_sha256(secret: &str, data: &[u8]) -> Vec<u8> {
     mac.finalize().into_bytes().to_vec()
 }
 
+fn ed25519_sign(private_key_pem: &str, data: &[u8]) -> Result<Vec<u8>> {
+    use ed25519_dalek::pkcs8::DecodePrivateKey;
+    use ed25519_dalek::Signer;
+
+    let signing_key =
+        ed25519_dalek::SigningKey::from_pkcs8_pem(private_key_pem.trim()).map_err(|err| {
+            anyhow::anyhow!("Failed to parse Ed25519 private key as PKCS#8 PEM: {}", err)
+        })?;
+    Ok(signing_key.sign(data).to_bytes().to_vec())
+}
+
 fn encode_signature(bytes: &[u8], encoding: &SignatureEncoding) -> String {
     match encoding {
         SignatureEncoding::Hex => bytes.iter().map(|byte| format!("{:02x}", byte)).collect(),
@@ -1659,15 +1734,15 @@ fn encode_signature(bytes: &[u8], encoding: &SignatureEncoding) -> String {
     }
 }
 
-fn signer_header(profile: &Profile) -> Result<Option<(String, String)>> {
-    let Some(AuthSignerConfig::HmacQueryV1(config)) = profile.signer.as_ref() else {
-        return Ok(None);
-    };
-    let (Some(field_name), Some(SignerValuePlacement::Header), Some(header_name)) = (
-        config.key_field.as_ref(),
-        config.key_placement.as_ref(),
-        config.key_name.as_ref(),
-    ) else {
+fn signer_key_header(
+    key_field: Option<&String>,
+    key_placement: Option<&SignerValuePlacement>,
+    key_name: Option<&String>,
+    profile: &Profile,
+) -> Result<Option<(String, String)>> {
+    let (Some(field_name), Some(SignerValuePlacement::Header), Some(header_name)) =
+        (key_field, key_placement, key_name)
+    else {
         return Ok(None);
     };
 
@@ -1681,8 +1756,26 @@ fn signer_header(profile: &Profile) -> Result<Option<(String, String)>> {
     Ok(Some((header_name.clone(), value)))
 }
 
+fn signer_header(profile: &Profile) -> Result<Option<(String, String)>> {
+    match profile.signer.as_ref() {
+        Some(AuthSignerConfig::HmacQueryV1(config)) => signer_key_header(
+            config.key_field.as_ref(),
+            config.key_placement.as_ref(),
+            config.key_name.as_ref(),
+            profile,
+        ),
+        Some(AuthSignerConfig::Ed25519QueryV1(config)) => signer_key_header(
+            config.key_field.as_ref(),
+            config.key_placement.as_ref(),
+            config.key_name.as_ref(),
+            profile,
+        ),
+        None => Ok(None),
+    }
+}
+
 fn apply_signer_to_url(url: &str, profile: &Profile) -> Result<String> {
-    let Some(AuthSignerConfig::HmacQueryV1(config)) = profile.signer.as_ref() else {
+    let Some(config) = profile.signer.as_ref() else {
         return Ok(url.to_string());
     };
 
@@ -1693,21 +1786,60 @@ fn apply_signer_to_url(url: &str, profile: &Profile) -> Result<String> {
         .map(|(name, value)| (name.into_owned(), value.into_owned()))
         .collect();
 
-    pairs.retain(|(name, _)| name != &config.signature_param);
+    let (
+        signature_param,
+        timestamp_param,
+        timestamp_unit,
+        key_field,
+        key_placement,
+        key_name,
+        signing_field,
+        signature_encoding,
+        canonicalization_mode,
+    ) = match config {
+        AuthSignerConfig::HmacQueryV1(config) => (
+            &config.signature_param,
+            config.timestamp_param.as_ref(),
+            config
+                .timestamp_unit
+                .as_ref()
+                .unwrap_or(&TimestampUnit::Milliseconds),
+            config.key_field.as_ref(),
+            config.key_placement.as_ref(),
+            config.key_name.as_ref(),
+            &config.signing_field,
+            &config.signature_encoding,
+            &config.canonicalization.mode,
+        ),
+        AuthSignerConfig::Ed25519QueryV1(config) => (
+            &config.signature_param,
+            config.timestamp_param.as_ref(),
+            config
+                .timestamp_unit
+                .as_ref()
+                .unwrap_or(&TimestampUnit::Milliseconds),
+            config.key_field.as_ref(),
+            config.key_placement.as_ref(),
+            config.key_name.as_ref(),
+            &config.signing_field,
+            &config.signature_encoding,
+            &config.canonicalization.mode,
+        ),
+    };
 
-    if let Some(timestamp_param) = &config.timestamp_param {
-        let unit = config
-            .timestamp_unit
-            .as_ref()
-            .unwrap_or(&TimestampUnit::Milliseconds);
-        upsert_query_pair(&mut pairs, timestamp_param, current_timestamp(unit));
+    pairs.retain(|(name, _)| name != signature_param);
+
+    if let Some(timestamp_param) = timestamp_param {
+        upsert_query_pair(
+            &mut pairs,
+            timestamp_param,
+            current_timestamp(timestamp_unit),
+        );
     }
 
-    if let (Some(field_name), Some(SignerValuePlacement::Query), Some(param_name)) = (
-        config.key_field.as_ref(),
-        config.key_placement.as_ref(),
-        config.key_name.as_ref(),
-    ) {
+    if let (Some(field_name), Some(SignerValuePlacement::Query), Some(param_name)) =
+        (key_field, key_placement, key_name)
+    {
         let Some(value) = profile.resolve_field_value(field_name)? else {
             anyhow::bail!(
                 "Credential '{}' is missing field '{}' required by signer query injection",
@@ -1718,24 +1850,27 @@ fn apply_signer_to_url(url: &str, profile: &Profile) -> Result<String> {
         upsert_query_pair(&mut pairs, param_name, value);
     }
 
-    let canonical_pairs = canonicalize_pairs(&pairs, &config.canonicalization.mode);
+    let canonical_pairs = canonicalize_pairs(&pairs, canonicalization_mode);
     let canonical_query = encode_query_pairs(&canonical_pairs);
-    let Some(signing_secret) = profile.resolve_field_value(&config.signing_field)? else {
+    let Some(signing_secret) = profile.resolve_field_value(signing_field)? else {
         anyhow::bail!(
             "Credential '{}' is missing signing field '{}'",
             profile.name.as_deref().unwrap_or("unknown"),
-            config.signing_field
+            signing_field
         );
     };
-    let signature = match config.algorithm {
-        SignerAlgorithm::HmacSha256 => encode_signature(
-            &hmac_sha256(&signing_secret, canonical_query.as_bytes()),
-            &config.signature_encoding,
-        ),
+    let signature_bytes = match config {
+        AuthSignerConfig::HmacQueryV1(_) => {
+            hmac_sha256(&signing_secret, canonical_query.as_bytes())
+        }
+        AuthSignerConfig::Ed25519QueryV1(_) => {
+            ed25519_sign(&signing_secret, canonical_query.as_bytes())?
+        }
     };
+    let signature = encode_signature(&signature_bytes, signature_encoding);
 
-    pairs.push((config.signature_param.clone(), signature));
-    let final_pairs = canonicalize_pairs(&pairs, &config.canonicalization.mode);
+    pairs.push((signature_param.clone(), signature));
+    let final_pairs = canonicalize_pairs(&pairs, canonicalization_mode);
     let final_query = encode_query_pairs(&final_pairs);
     parsed.set_query(Some(&final_query));
     Ok(parsed.to_string())
@@ -1910,6 +2045,9 @@ mod dirs {
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    // Test-only Ed25519 key for signer unit tests. Never used in production.
+    const TEST_ED25519_PRIVATE_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIFM839r6dC+FQ4zIFCwogFaLq3ugAG4cxQWjSZZu6Cxl\n-----END PRIVATE KEY-----";
 
     #[test]
     fn test_profile_default() {
@@ -2302,5 +2440,105 @@ mod tests {
         }));
 
         validate_ready(&profile).unwrap();
+    }
+
+    #[test]
+    fn apply_profile_auth_to_url_signs_ed25519_query_requests() {
+        let mut profile = Profile::new("unused".to_string(), AuthType::ApiKey);
+        profile
+            .set_field_source(
+                "private_key".to_string(),
+                SecretSource::Literal {
+                    value: TEST_ED25519_PRIVATE_KEY_PEM.to_string(),
+                },
+            )
+            .unwrap();
+        profile.signer = Some(AuthSignerConfig::Ed25519QueryV1(Ed25519QuerySignerConfig {
+            algorithm: SignerAlgorithm::Ed25519,
+            signing_field: "private_key".to_string(),
+            key_field: Some("api_key".to_string()),
+            key_placement: Some(SignerValuePlacement::Header),
+            key_name: Some("X-MBX-APIKEY".to_string()),
+            signature_param: "signature".to_string(),
+            signature_encoding: SignatureEncoding::Base64,
+            timestamp_param: None,
+            timestamp_unit: None,
+            canonicalization: QueryCanonicalization {
+                mode: QueryCanonicalizationMode::SortByKey,
+            },
+        }));
+
+        let url = apply_profile_auth_to_url(
+            "https://api.binance.com/api/v3/account?recvWindow=5000&symbol=BTCUSDT",
+            &profile,
+        )
+        .unwrap();
+        let parsed = url::Url::parse(&url).unwrap();
+        let pairs: Vec<(String, String)> = parsed
+            .query_pairs()
+            .map(|(name, value)| (name.into_owned(), value.into_owned()))
+            .collect();
+        let canonical = canonicalize_pairs(
+            &pairs
+                .iter()
+                .filter(|(name, _)| name != "signature")
+                .cloned()
+                .collect::<Vec<_>>(),
+            &QueryCanonicalizationMode::SortByKey,
+        );
+        let expected = encode_signature(
+            &ed25519_sign(
+                TEST_ED25519_PRIVATE_KEY_PEM,
+                encode_query_pairs(&canonical).as_bytes(),
+            )
+            .unwrap(),
+            &SignatureEncoding::Base64,
+        );
+        let actual = pairs
+            .iter()
+            .find(|(name, _)| name == "signature")
+            .map(|(_, value)| value.clone())
+            .unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn validate_signer_config_rejects_ed25519_non_base64_encoding() {
+        let err = validate_signer_config(&AuthSignerConfig::Ed25519QueryV1(
+            Ed25519QuerySignerConfig {
+                algorithm: SignerAlgorithm::Ed25519,
+                signing_field: "private_key".to_string(),
+                key_field: Some("api_key".to_string()),
+                key_placement: Some(SignerValuePlacement::Header),
+                key_name: Some("X-MBX-APIKEY".to_string()),
+                signature_param: "signature".to_string(),
+                signature_encoding: SignatureEncoding::Hex,
+                timestamp_param: None,
+                timestamp_unit: None,
+                canonicalization: QueryCanonicalization::default(),
+            },
+        ))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("signature_encoding=base64"));
+    }
+
+    #[test]
+    fn resolved_api_key_headers_skip_default_when_ed25519_signer_is_present() {
+        let mut profile = Profile::new(String::new(), AuthType::ApiKey);
+        profile.signer = Some(AuthSignerConfig::Ed25519QueryV1(Ed25519QuerySignerConfig {
+            algorithm: SignerAlgorithm::Ed25519,
+            signing_field: "private_key".to_string(),
+            key_field: Some("api_key".to_string()),
+            key_placement: Some(SignerValuePlacement::Header),
+            key_name: Some("X-MBX-APIKEY".to_string()),
+            signature_param: "signature".to_string(),
+            signature_encoding: SignatureEncoding::Base64,
+            timestamp_param: None,
+            timestamp_unit: None,
+            canonicalization: QueryCanonicalization::default(),
+        }));
+
+        assert!(profile.resolved_api_key_headers().unwrap().is_empty());
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -696,14 +696,22 @@ impl DaemonRuntime {
         let cache = self.build_cache(&request.options)?;
         let cache_for_fallback = cache.clone();
         let cache_for_mcp = cache.clone();
-        let auth_profile =
+        let root_auth_profile =
             auth::resolve_auth_for_endpoint(&request.endpoint, request.options.auth.clone())?;
-        let stdio_spawn_options =
-            build_stdio_spawn_options(&request.endpoint, &request.options, auth_profile.as_ref())?;
+        let detection_auth_profile = if request.options.schema_url.is_some() {
+            None
+        } else {
+            root_auth_profile.clone()
+        };
+        let stdio_spawn_options = build_stdio_spawn_options(
+            &request.endpoint,
+            &request.options,
+            root_auth_profile.as_ref(),
+        )?;
 
         let detection_options = DetectionOptions {
             schema_url: request.options.schema_url.clone(),
-            auth_profile: auth_profile.clone(),
+            auth_profile: detection_auth_profile.clone(),
             stdio_spawn_options: stdio_spawn_options.clone(),
         };
 
@@ -711,13 +719,13 @@ impl DaemonRuntime {
             &request.endpoint,
             &detection_options,
             cache,
-            auth_profile.clone(),
+            detection_auth_profile.clone(),
             request.options.no_cache,
             request.options.refresh_schema,
         )
         .await;
 
-        let resolved = match resolved {
+        let mut resolved = match resolved {
             Ok(r) => r,
             Err(e) => {
                 // Log protocol detection failure
@@ -740,6 +748,13 @@ impl DaemonRuntime {
         };
 
         let mut protocol = resolved.adapter.protocol_type().as_str().to_string();
+        let execution_auth_profile = effective_runtime_auth_profile(
+            &request,
+            resolved.adapter.protocol_type(),
+            root_auth_profile.clone(),
+        )?;
+        resolved.adapter =
+            inject_auth_if_supported(resolved.adapter, execution_auth_profile.clone());
         let mut meta = RuntimeMeta::default();
         if let Some(cache_meta) = resolved.cache_meta {
             meta.schema_involved = Some(true);
@@ -788,7 +803,7 @@ impl DaemonRuntime {
                 .invoke_mcp_execute(
                     &request,
                     prepared_args,
-                    auth_profile.clone(),
+                    execution_auth_profile.clone(),
                     stdio_options,
                     cache_for_mcp.clone(),
                 )
@@ -810,7 +825,7 @@ impl DaemonRuntime {
                 if let Some(live_result) = invoke_live_stdio_mcp_help(
                     self,
                     &request,
-                    auth_profile.as_ref(),
+                    execution_auth_profile.as_ref(),
                     cache_for_mcp.clone(),
                 )
                 .await?
@@ -838,7 +853,12 @@ impl DaemonRuntime {
                         let mut adapter =
                             adapter_from_protocol(fallback_protocol, &detection_options);
                         adapter = inject_cache_if_supported(adapter, cache_for_fallback.clone());
-                        adapter = inject_auth_if_supported(adapter, auth_profile.clone());
+                        let fallback_auth_profile = effective_runtime_auth_profile(
+                            &request,
+                            fallback_protocol,
+                            root_auth_profile.clone(),
+                        )?;
+                        adapter = inject_auth_if_supported(adapter, fallback_auth_profile.clone());
                         adapter =
                             inject_refresh_if_supported(adapter, request.options.refresh_schema);
 
@@ -868,7 +888,7 @@ impl DaemonRuntime {
                                 .invoke_mcp_execute(
                                     &request,
                                     prepared_args,
-                                    auth_profile.clone(),
+                                    fallback_auth_profile.clone(),
                                     None,
                                     cache_for_fallback.clone(),
                                 )
@@ -1796,6 +1816,38 @@ fn inject_refresh_if_supported(
     }
 }
 
+fn openapi_runtime_endpoint(request: &RuntimeInvokeRequest) -> Option<String> {
+    if !matches!(request.action, RuntimeAction::Execute) {
+        return None;
+    }
+
+    let operation_id = request.operation_id.as_deref()?;
+    let (_, path) = operation_id.split_once(':')?;
+    if !path.starts_with('/') {
+        return None;
+    }
+
+    Some(format!(
+        "{}{}",
+        request.endpoint.trim_end_matches('/'),
+        path
+    ))
+}
+
+fn effective_runtime_auth_profile(
+    request: &RuntimeInvokeRequest,
+    protocol: ProtocolType,
+    root_auth_profile: Option<Profile>,
+) -> Result<Option<Profile>> {
+    if protocol == ProtocolType::OpenAPI {
+        if let Some(endpoint) = openapi_runtime_endpoint(request) {
+            return auth::resolve_auth_for_endpoint(&endpoint, request.options.auth.clone());
+        }
+    }
+
+    Ok(root_auth_profile)
+}
+
 async fn resolve_adapter_with_schema_cache(
     url: &str,
     detection_options: &DetectionOptions,
@@ -2244,6 +2296,62 @@ fn map_runtime_error_code(err: &anyhow::Error) -> i32 {
 impl Default for DaemonRuntime {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openapi_runtime_endpoint_appends_operation_path_for_execute() {
+        let request = RuntimeInvokeRequest {
+            request_id: "req-1".to_string(),
+            endpoint: "https://testnet.binance.vision".to_string(),
+            action: RuntimeAction::Execute,
+            operation_id: Some("get:/api/v3/account".to_string()),
+            args: None,
+            options: RuntimeInvokeOptions {
+                auth: None,
+                inject_env: Vec::new(),
+                no_cache: false,
+                cache_ttl: None,
+                refresh_schema: false,
+                schema_url: Some("https://example.com/schema.json".to_string()),
+                link_name: None,
+                schema_mapping_file: None,
+                daemon_exclusive: Vec::new(),
+            },
+        };
+
+        assert_eq!(
+            openapi_runtime_endpoint(&request).as_deref(),
+            Some("https://testnet.binance.vision/api/v3/account")
+        );
+    }
+
+    #[test]
+    fn openapi_runtime_endpoint_ignores_non_execute_requests() {
+        let request = RuntimeInvokeRequest {
+            request_id: "req-1".to_string(),
+            endpoint: "https://api.binance.com".to_string(),
+            action: RuntimeAction::OperationHelp,
+            operation_id: Some("post:/api/v3/order".to_string()),
+            args: None,
+            options: RuntimeInvokeOptions {
+                auth: None,
+                inject_env: Vec::new(),
+                no_cache: false,
+                cache_ttl: None,
+                refresh_schema: false,
+                schema_url: Some("https://example.com/schema.json".to_string()),
+                link_name: None,
+                schema_mapping_file: None,
+                daemon_exclusive: Vec::new(),
+            },
+        };
+
+        assert!(openapi_runtime_endpoint(&request).is_none());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1601,11 +1601,12 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
             usage: "uxc auth binding add --id <id> --host <host> --credential <credential> [--path-prefix <path>] [--scheme <scheme>] [--signer-json <json>] [--priority <n>] [--disabled]".to_string(),
             commands: vec![],
             notes: vec![
-                "--signer-json attaches a typed signer config to this binding, for example kind=hmac_query_v1.".to_string(),
+                "--signer-json attaches a typed signer config to this binding, e.g. {\"kind\":\"hmac_query_v1\", ...} or {\"kind\":\"ed25519_query_v1\", ...}.".to_string(),
             ],
             examples: vec![
                 "uxc auth binding add --id deepwiki-mcp --host mcp.deepwiki.com --path-prefix /mcp --scheme https --credential deepwiki --priority 100".to_string(),
                 "uxc auth binding add --id binance-account --host api.binance.com --path-prefix /api/v3 --scheme https --credential binance --signer-json '{\"kind\":\"hmac_query_v1\",\"algorithm\":\"hmac_sha256\",\"signing_field\":\"secret_key\",\"key_field\":\"api_key\",\"key_placement\":\"header\",\"key_name\":\"X-MBX-APIKEY\",\"signature_param\":\"signature\",\"signature_encoding\":\"hex\",\"timestamp_param\":\"timestamp\",\"timestamp_unit\":\"milliseconds\",\"canonicalization\":{\"mode\":\"preserve_order\"}}'".to_string(),
+                "uxc auth binding add --id binance-account-ed25519 --host api.binance.com --path-prefix /api/v3 --scheme https --credential binance-ed25519 --signer-json '{\"kind\":\"ed25519_query_v1\",\"algorithm\":\"ed25519\",\"signing_field\":\"private_key\",\"key_field\":\"api_key\",\"key_placement\":\"header\",\"key_name\":\"X-MBX-APIKEY\",\"signature_param\":\"signature\",\"signature_encoding\":\"base64\",\"timestamp_param\":\"timestamp\",\"timestamp_unit\":\"milliseconds\",\"canonicalization\":{\"mode\":\"preserve_order\"}}'".to_string(),
             ],
         },
         ["auth", "binding", "remove"] => HelpData {

--- a/tests/auth_binding_cli_test.rs
+++ b/tests/auth_binding_cli_test.rs
@@ -316,6 +316,51 @@ fn auth_binding_add_supports_signer_json() {
 }
 
 #[test]
+fn auth_binding_add_supports_ed25519_signer_json() {
+    let files = AuthFiles::new();
+
+    let set_output = uxc_command(&files)
+        .arg("auth")
+        .arg("credential")
+        .arg("set")
+        .arg("binance-ed25519")
+        .arg("--auth-type")
+        .arg("api_key")
+        .arg("--field")
+        .arg("api_key=env:BINANCE_API_KEY")
+        .arg("--field")
+        .arg("private_key=env:BINANCE_PRIVATE_KEY")
+        .output()
+        .expect("credential set should run");
+    assert!(set_output.status.success(), "credential set should succeed");
+
+    let signer = r#"{"kind":"ed25519_query_v1","algorithm":"ed25519","signing_field":"private_key","key_field":"api_key","key_placement":"header","key_name":"X-MBX-APIKEY","signature_param":"signature","signature_encoding":"base64","timestamp_param":"timestamp","timestamp_unit":"milliseconds","canonicalization":{"mode":"preserve_order"}}"#;
+    let add_output = uxc_command(&files)
+        .arg("auth")
+        .arg("binding")
+        .arg("add")
+        .arg("--id")
+        .arg("binance-ed25519")
+        .arg("--host")
+        .arg("api.binance.com")
+        .arg("--path-prefix")
+        .arg("/api/v3")
+        .arg("--scheme")
+        .arg("https")
+        .arg("--credential")
+        .arg("binance-ed25519")
+        .arg("--signer-json")
+        .arg(signer)
+        .output()
+        .expect("binding add should run");
+    assert!(add_output.status.success(), "binding add should succeed");
+
+    let add_json = parse_stdout_json(&add_output);
+    assert_eq!(add_json["data"]["signer"]["kind"], "ed25519_query_v1");
+    assert_eq!(add_json["data"]["signer"]["signing_field"], "private_key");
+}
+
+#[test]
 fn auth_binding_add_rejects_invalid_signer_json() {
     let files = AuthFiles::new();
     create_test_credential(&files, "binance");


### PR DESCRIPTION
## What
- add a curated Binance Spot OpenAPI wrapper skill with separate mainnet/testnet link flows
- add `ed25519_query_v1` alongside the existing HMAC query signer for Binance-style signed requests
- fix OpenAPI auth resolution so bindings can match the final operation path and schema URL fetches are not polluted by business auth
- document Spot testnet key acquisition, Ed25519 vs HMAC setup, and common Binance key mismatches

## Why
Binance Spot testnet now practically needs Ed25519 support for the recommended key flow, and the Spot skill was missing the operational guidance needed to obtain and pair the correct API key with signing material.

## How
- extend auth signer config/runtime to support PKCS#8 PEM Ed25519 signing with base64 signatures
- keep `hmac_query_v1` unchanged for compatibility
- add targeted unit and CLI tests for signer parsing and signing behavior
- add the new `skills/binance-spot-openapi-skill` package and validation script
- update the skill docs with testnet setup steps and the `-1022` mismatch pitfall

## Testing
- `bash skills/binance-spot-openapi-skill/scripts/validate.sh`
- `cargo test auth::tests:: --lib -- --test-threads=1`
- `cargo test --test auth_binding_cli_test -- --test-threads=1`
- `cargo test daemon::tests:: --lib -- --test-threads=1`
- `cargo test openapi::tests:: --lib -- --test-threads=1`
- live Binance Spot testnet verification for Ed25519:
  - `get:/api/v3/account`
  - `post:/api/v3/order/test`
