### PR TITLE
fix(openapi): improve Swagger 2.0 request-body support

### DIFF
--- a/src/adapters/openapi.rs
+++ b/src/adapters/openapi.rs
@@ -33,14 +33,14 @@ impl OpenAPIAdapter {
         .remove(b'_')
         .remove(b'~');
     const MAX_SCHEMA_EXPANSION_DEPTH: usize = 8;
-    const SCHEMA_ENDPOINTS: [&'static str; 7] = [
+    pub(crate) const SCHEMA_ENDPOINTS: [&'static str; 7] = [
+        "/swagger/v1/swagger.json",
+        "/docs/swagger.json",
         "/openapi.json",
         "/swagger.json",
-        "/api-docs",
-        "/swagger/v1/swagger.json",
-        "/api/docs",
-        "/docs/swagger.json",
         "/swagger-docs",
+        "/api-docs",
+        "/api/docs",
     ];
     const HTTP_METHODS: [&'static str; 8] = [
         "get", "post", "put", "patch", "delete", "head", "options", "trace",
@@ -770,12 +770,17 @@ impl OpenAPIAdapter {
         let (json_body, form_body) = match body_config {
             RequestBodyConfig::None => (None, None),
             RequestBodyConfig::FormUrlEncoded => {
-                if let Some(body) = remaining.remove("body") {
+                if let Some(body) = explicit_body.or_else(|| remaining.remove("body")) {
                     if !remaining.is_empty() || !form_pairs.is_empty() {
                         anyhow::bail!("Cannot mix 'body' with form arguments for this operation");
                     }
                     form_pairs.extend(Self::form_pairs_from_value(body)?);
                 } else {
+                    if remaining.is_empty() && form_pairs.is_empty() {
+                        if let Some(name) = &missing_required_body_param {
+                            anyhow::bail!("Missing required parameter '{}'", name);
+                        }
+                    }
                     form_pairs.extend(Self::query_pairs_from_remaining(&mut remaining)?);
                 }
                 (None, Some(form_pairs))
@@ -995,7 +1000,7 @@ impl OpenAPIAdapter {
         if let Some(body) = explicit_body.or_else(|| remaining.remove("body")) {
             if !remaining.is_empty() {
                 anyhow::bail!(
-                    "Cannot mix 'body' with other request body arguments: {}",
+                    "Cannot mix explicit request body with other request body arguments: {}",
                     remaining.keys().cloned().collect::<Vec<_>>().join(", ")
                 );
             }
@@ -2264,6 +2269,13 @@ mod tests {
     }
 
     #[test]
+    fn strip_schema_endpoint_prefers_longest_suffix() {
+        let stripped =
+            OpenAPIAdapter::strip_schema_endpoint("https://example.com/swagger/v1/swagger.json");
+        assert_eq!(stripped, "https://example.com");
+    }
+
+    #[test]
     fn prepare_request_prefers_operation_parameters_over_path_item_parameters() {
         let root = json!({});
         let path_item = json!({
@@ -2419,6 +2431,51 @@ mod tests {
         assert_eq!(
             prepared.json_body,
             Some(json!({"email": "john@example.com", "name": "John"}))
+        );
+    }
+
+    #[test]
+    fn prepare_request_swagger2_form_urlencoded_uses_explicit_body() {
+        let root = json!({
+            "swagger": "2.0"
+        });
+        let path_item = json!({});
+        let operation = json!({
+            "consumes": ["application/x-www-form-urlencoded"],
+            "parameters": [
+                {"name": "body", "in": "body", "required": true, "schema": {"type": "object"}}
+            ]
+        });
+
+        let mut args = HashMap::new();
+        args.insert(
+            "body".to_string(),
+            json!({
+                "symbol": "BTCUSDT",
+                "side": "BUY"
+            }),
+        );
+
+        let prepared = OpenAPIAdapter::prepare_request(
+            "post",
+            "https://example.com",
+            "/order",
+            &path_item,
+            &operation,
+            &root,
+            &args,
+        )
+        .unwrap();
+
+        assert!(prepared.json_body.is_none());
+        let mut actual = prepared.form_body.expect("form body should exist");
+        actual.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            actual,
+            vec![
+                ("side".to_string(), "BUY".to_string()),
+                ("symbol".to_string(), "BTCUSDT".to_string()),
+            ]
         );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1826,19 +1826,11 @@ fn openapi_runtime_endpoint(request: &RuntimeInvokeRequest) -> Option<String> {
     }
 
     let endpoint = request.endpoint.trim_end_matches('/');
-    let endpoint = [
-        "/openapi.json",
-        "/swagger.json",
-        "/api-docs",
-        "/swagger/v1/swagger.json",
-        "/api/docs",
-        "/docs/swagger.json",
-        "/swagger-docs",
-    ]
-    .iter()
-    .find_map(|suffix| endpoint.strip_suffix(suffix))
-    .unwrap_or(endpoint)
-    .trim_end_matches('/');
+    let endpoint = adapters::openapi::OpenAPIAdapter::SCHEMA_ENDPOINTS
+        .iter()
+        .find_map(|suffix| endpoint.strip_suffix(suffix))
+        .unwrap_or(endpoint)
+        .trim_end_matches('/');
 
     Some(format!("{}{}", endpoint, path))
 }
@@ -2387,6 +2379,33 @@ mod tests {
         assert_eq!(
             openapi_runtime_endpoint(&request).as_deref(),
             Some("https://petstore.swagger.io/v2/pet")
+        );
+    }
+
+    #[test]
+    fn openapi_runtime_endpoint_prefers_longest_schema_suffix_match() {
+        let request = RuntimeInvokeRequest {
+            request_id: "req-1".to_string(),
+            endpoint: "https://example.com/swagger/v1/swagger.json".to_string(),
+            action: RuntimeAction::Execute,
+            operation_id: Some("get:/health".to_string()),
+            args: None,
+            options: RuntimeInvokeOptions {
+                auth: None,
+                inject_env: Vec::new(),
+                no_cache: false,
+                cache_ttl: None,
+                refresh_schema: false,
+                schema_url: None,
+                link_name: None,
+                schema_mapping_file: None,
+                daemon_exclusive: Vec::new(),
+            },
+        };
+
+        assert_eq!(
+            openapi_runtime_endpoint(&request).as_deref(),
+            Some("https://example.com/health")
         );
     }
 }


### PR DESCRIPTION
## What
- add Swagger 2.0 request-body support for `in: body` and `in: formData` in OpenAPI adapter
- generate `input_schema` from Swagger 2.0 body parameter schema (`#/definitions/...`)
- support execute with schema URL inputs (e.g. `https://petstore.swagger.io/v2/swagger.json`) by resolving real operation base URL
- return explicit unsupported error for multipart/file request body
- strip schema endpoint suffix in daemon OpenAPI runtime endpoint composition

## Why
Issue #188 reports that legacy Swagger 2.0 services are not fully usable in UXC, especially around request bodies and schema URL based execution.

## How
- introduce request body config detection that covers OAS3 `requestBody` and Swagger2 `parameters` (`body`/`formData`)
- route request payload generation by config: JSON body vs form-urlencoded
- allow required Swagger2 body parameter to be satisfied by top-level args object
- add Swagger2 operation base URL derivation from `schemes`/`host`/`basePath` with schema-suffix fallback
- add regression tests in OpenAPI adapter and daemon runtime endpoint tests

## Testing
- `cargo fmt -- --check`
- `cargo test --package uxc openapi::tests:: -- --nocapture`
- `cargo test --package uxc daemon::tests::openapi_runtime_endpoint -- --nocapture`
- manual check against petstore Swagger2 endpoint:
  - `post:/pet` works via `https://petstore.swagger.io/v2/swagger.json`
  - multipart upload path returns explicit unsupported error

Closes #188
