### PR TITLE
feat: add Telegram Bot API skill integration

### DIFF
--- a/skills/telegram-openapi-skill/SKILL.md
+++ b/skills/telegram-openapi-skill/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: telegram-openapi-skill
+description: Operate Telegram Bot API through UXC with a curated OpenAPI schema, bot-token path auth, polling-based reads, and webhook management guardrails.
+---
+
+# Telegram Bot API Skill
+
+Use this skill to run Telegram Bot API operations through `uxc` + OpenAPI.
+
+Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- Network access to `https://api.telegram.org`.
+- Access to the curated OpenAPI schema URL:
+  - `https://raw.githubusercontent.com/holon-run/uxc/main/skills/telegram-openapi-skill/references/telegram-bot.openapi.json`
+- A Telegram bot token from BotFather.
+
+## Scope
+
+This skill covers a lean bot core surface:
+
+- bot identity and chat lookup
+- text sends
+- media sends by `file_id` or HTTP URL
+- polling via `getUpdates`
+- webhook setup/status/delete operations
+
+This skill does **not** cover:
+
+- multipart new-file uploads
+- self-signed webhook certificate upload
+- generic webhook ingestion/runtime hosting
+- the full Telegram Bot API surface
+
+## Authentication
+
+Telegram Bot API requires the bot token in the request path: `https://api.telegram.org/bot<TOKEN>/METHOD_NAME`.
+
+Configure the credential with a request path prefix template:
+
+```bash
+uxc auth credential set telegram-bot \
+  --auth-type api_key \
+  --secret-env TELEGRAM_BOT_TOKEN \
+  --path-prefix-template "/bot{{secret}}"
+
+uxc auth binding add \
+  --id telegram-bot \
+  --host api.telegram.org \
+  --scheme https \
+  --credential telegram-bot \
+  --priority 100
+```
+
+Validate the local mapping when auth looks wrong:
+
+```bash
+uxc auth binding match https://api.telegram.org
+```
+
+## Core Workflow
+
+1. Use the fixed link command by default:
+   - `command -v telegram-openapi-cli`
+   - If missing, create it:
+     `uxc link telegram-openapi-cli https://api.telegram.org --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/telegram-openapi-skill/references/telegram-bot.openapi.json`
+   - `telegram-openapi-cli -h`
+
+2. Inspect operation schema first:
+   - `telegram-openapi-cli get:/getMe -h`
+   - `telegram-openapi-cli post:/sendMessage -h`
+   - `telegram-openapi-cli post:/getUpdates -h`
+
+3. Prefer read/setup validation before writes:
+   - `telegram-openapi-cli get:/getMe`
+   - `telegram-openapi-cli get:/getWebhookInfo`
+   - `telegram-openapi-cli get:/getChat chat_id=@channel_or_chat_id`
+
+4. Execute operations with key/value or positional JSON:
+   - key/value:
+     `telegram-openapi-cli post:/sendMessage chat_id=CHAT_ID text="Hello from uxc"`
+   - positional JSON:
+     `telegram-openapi-cli post:/sendMessage '{"chat_id":"CHAT_ID","text":"Hello from uxc"}'`
+
+## Operation Groups
+
+### Read / Lookup
+
+- `get:/getMe`
+- `get:/getChat`
+- `get:/getChatMember`
+- `get:/getWebhookInfo`
+
+### Messaging
+
+- `post:/sendMessage`
+- `post:/sendPhoto`
+- `post:/sendDocument`
+- `post:/sendMediaGroup`
+
+### Update Delivery
+
+- `post:/getUpdates`
+- `post:/setWebhook`
+- `post:/deleteWebhook`
+
+## Guardrails
+
+- Keep automation on the JSON output envelope; do not use `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- `getUpdates` and webhook delivery are mutually exclusive:
+  - if a webhook is configured, call `post:/deleteWebhook` before polling with `post:/getUpdates`
+  - if polling is active, do not treat webhook operations as background subscription support
+- `sendPhoto`, `sendDocument`, and `sendMediaGroup` in this skill accept existing `file_id` values or HTTP URLs only; they do not upload new local files.
+- `setWebhook` in this skill does not support certificate upload for self-signed certs.
+- Treat `post:/sendMessage`, all `send*` operations, and webhook-changing operations as write/high-risk actions; require explicit user confirmation before execution.
+- `telegram-openapi-cli <operation> ...` is equivalent to `uxc https://api.telegram.org --schema-url <telegram_openapi_schema> <operation> ...`.
+
+## References
+
+- Usage patterns: `references/usage-patterns.md`
+- Curated OpenAPI schema: `references/telegram-bot.openapi.json`
+- Telegram Bot API docs: https://core.telegram.org/bots/api
+- Local Bot API server: https://github.com/tdlib/telegram-bot-api

--- a/skills/telegram-openapi-skill/agents/openai.yaml
+++ b/skills/telegram-openapi-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Telegram Bot API"
+  short_description: "Operate Telegram Bot API via UXC + curated OpenAPI schema"
+  default_prompt: "Use $telegram-openapi-skill to discover and execute Telegram Bot API operations through UXC with bot-token path auth and polling/webhook guardrails."

--- a/skills/telegram-openapi-skill/references/telegram-bot.openapi.json
+++ b/skills/telegram-openapi-skill/references/telegram-bot.openapi.json
@@ -1,0 +1,454 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Telegram Bot API (Curated Lean Core)",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.telegram.org"
+    }
+  ],
+  "paths": {
+    "/getMe": {
+      "get": {
+        "summary": "Get basic bot identity information",
+        "responses": {
+          "200": {
+            "description": "Bot identity response"
+          }
+        }
+      }
+    },
+    "/getChat": {
+      "get": {
+        "summary": "Get information about a chat the bot can access",
+        "parameters": [
+          {
+            "name": "chat_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier for the target chat or username of the target supergroup/channel"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chat info response"
+          }
+        }
+      }
+    },
+    "/getChatMember": {
+      "get": {
+        "summary": "Get information about a member of a chat",
+        "parameters": [
+          {
+            "name": "chat_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chat member response"
+          }
+        }
+      }
+    },
+    "/getWebhookInfo": {
+      "get": {
+        "summary": "Get current webhook status",
+        "responses": {
+          "200": {
+            "description": "Webhook info response"
+          }
+        }
+      }
+    },
+    "/sendMessage": {
+      "post": {
+        "summary": "Send a text message",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendMessageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sent message response"
+          }
+        }
+      }
+    },
+    "/sendPhoto": {
+      "post": {
+        "summary": "Send a photo by file_id or HTTP URL",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendPhotoRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sent photo response"
+          }
+        }
+      }
+    },
+    "/sendDocument": {
+      "post": {
+        "summary": "Send a document by file_id or HTTP URL",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendDocumentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sent document response"
+          }
+        }
+      }
+    },
+    "/sendMediaGroup": {
+      "post": {
+        "summary": "Send a group of photos or documents by file_id or HTTP URL",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendMediaGroupRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sent media group response"
+          }
+        }
+      }
+    },
+    "/getUpdates": {
+      "post": {
+        "summary": "Poll for incoming updates",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetUpdatesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updates response"
+          }
+        }
+      }
+    },
+    "/setWebhook": {
+      "post": {
+        "summary": "Configure webhook delivery without certificate upload",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetWebhookRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook set response"
+          }
+        }
+      }
+    },
+    "/deleteWebhook": {
+      "post": {
+        "summary": "Delete webhook configuration",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteWebhookRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook delete response"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ChatId": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer",
+            "format": "int64"
+          }
+        ]
+      },
+      "ReplyMarkup": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Telegram reply markup object passed as JSON"
+      },
+      "SendMessageRequest": {
+        "type": "object",
+        "required": [
+          "chat_id",
+          "text"
+        ],
+        "properties": {
+          "chat_id": {
+            "$ref": "#/components/schemas/ChatId"
+          },
+          "text": {
+            "type": "string"
+          },
+          "parse_mode": {
+            "type": "string"
+          },
+          "disable_notification": {
+            "type": "boolean"
+          },
+          "protect_content": {
+            "type": "boolean"
+          },
+          "reply_markup": {
+            "$ref": "#/components/schemas/ReplyMarkup"
+          }
+        },
+        "additionalProperties": true
+      },
+      "SendPhotoRequest": {
+        "type": "object",
+        "required": [
+          "chat_id",
+          "photo"
+        ],
+        "properties": {
+          "chat_id": {
+            "$ref": "#/components/schemas/ChatId"
+          },
+          "photo": {
+            "type": "string",
+            "description": "Existing file_id or HTTP URL only in this curated schema"
+          },
+          "caption": {
+            "type": "string"
+          },
+          "parse_mode": {
+            "type": "string"
+          },
+          "disable_notification": {
+            "type": "boolean"
+          },
+          "protect_content": {
+            "type": "boolean"
+          },
+          "reply_markup": {
+            "$ref": "#/components/schemas/ReplyMarkup"
+          }
+        },
+        "additionalProperties": true
+      },
+      "SendDocumentRequest": {
+        "type": "object",
+        "required": [
+          "chat_id",
+          "document"
+        ],
+        "properties": {
+          "chat_id": {
+            "$ref": "#/components/schemas/ChatId"
+          },
+          "document": {
+            "type": "string",
+            "description": "Existing file_id or HTTP URL only in this curated schema"
+          },
+          "caption": {
+            "type": "string"
+          },
+          "parse_mode": {
+            "type": "string"
+          },
+          "disable_notification": {
+            "type": "boolean"
+          },
+          "protect_content": {
+            "type": "boolean"
+          },
+          "reply_markup": {
+            "$ref": "#/components/schemas/ReplyMarkup"
+          }
+        },
+        "additionalProperties": true
+      },
+      "InputMediaItem": {
+        "type": "object",
+        "required": [
+          "type",
+          "media"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "photo",
+              "document"
+            ]
+          },
+          "media": {
+            "type": "string",
+            "description": "Existing file_id or HTTP URL only in this curated schema"
+          },
+          "caption": {
+            "type": "string"
+          },
+          "parse_mode": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "SendMediaGroupRequest": {
+        "type": "object",
+        "required": [
+          "chat_id",
+          "media"
+        ],
+        "properties": {
+          "chat_id": {
+            "$ref": "#/components/schemas/ChatId"
+          },
+          "media": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "$ref": "#/components/schemas/InputMediaItem"
+            }
+          },
+          "disable_notification": {
+            "type": "boolean"
+          },
+          "protect_content": {
+            "type": "boolean"
+          },
+          "reply_to_message_id": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": true
+      },
+      "GetUpdatesRequest": {
+        "type": "object",
+        "properties": {
+          "offset": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "timeout": {
+            "type": "integer"
+          },
+          "allowed_updates": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "SetWebhookRequest": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "ip_address": {
+            "type": "string"
+          },
+          "max_connections": {
+            "type": "integer"
+          },
+          "allowed_updates": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "drop_pending_updates": {
+            "type": "boolean"
+          },
+          "secret_token": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "DeleteWebhookRequest": {
+        "type": "object",
+        "properties": {
+          "drop_pending_updates": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/skills/telegram-openapi-skill/references/usage-patterns.md
+++ b/skills/telegram-openapi-skill/references/usage-patterns.md
@@ -1,0 +1,64 @@
+# Telegram Bot API Skill - Usage Patterns
+
+## Link Setup
+
+```bash
+command -v telegram-openapi-cli
+uxc link telegram-openapi-cli https://api.telegram.org \
+  --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/telegram-openapi-skill/references/telegram-bot.openapi.json
+telegram-openapi-cli -h
+```
+
+## Auth Setup
+
+```bash
+uxc auth credential set telegram-bot \
+  --auth-type api_key \
+  --secret-env TELEGRAM_BOT_TOKEN \
+  --path-prefix-template "/bot{{secret}}"
+
+uxc auth binding add \
+  --id telegram-bot \
+  --host api.telegram.org \
+  --scheme https \
+  --credential telegram-bot \
+  --priority 100
+```
+
+## Read Examples
+
+```bash
+# Confirm the bot identity
+telegram-openapi-cli get:/getMe
+
+# Inspect a chat the bot can access
+telegram-openapi-cli get:/getChat chat_id=@my_channel
+
+# Check webhook state before deciding between webhook and polling
+telegram-openapi-cli get:/getWebhookInfo
+```
+
+## Polling Example
+
+```bash
+# Remove webhook first if one is configured
+telegram-openapi-cli post:/deleteWebhook '{"drop_pending_updates":false}'
+
+# Poll for updates with long-poll timeout
+telegram-openapi-cli post:/getUpdates '{"timeout":30,"allowed_updates":["message","callback_query"]}'
+```
+
+## Write Examples (Confirm Intent First)
+
+```bash
+# Send a text message
+telegram-openapi-cli post:/sendMessage '{"chat_id":"CHAT_ID","text":"Hello from UXC"}'
+
+# Send a photo by existing file_id or HTTP URL only
+telegram-openapi-cli post:/sendPhoto '{"chat_id":"CHAT_ID","photo":"https://example.com/photo.jpg","caption":"From UXC"}'
+```
+
+## Fallback Equivalence
+
+- `telegram-openapi-cli <operation> ...` is equivalent to
+  `uxc https://api.telegram.org --schema-url <telegram_openapi_schema> <operation> ...`.

--- a/skills/telegram-openapi-skill/scripts/validate.sh
+++ b/skills/telegram-openapi-skill/scripts/validate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/telegram-openapi-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+USAGE_FILE="${SKILL_DIR}/references/usage-patterns.md"
+SCHEMA_FILE="${SKILL_DIR}/references/telegram-bot.openapi.json"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd rg
+
+for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}" "${SCHEMA_FILE}"; do
+  [[ -f "${file}" ]] || fail "missing required file: ${file}"
+done
+
+rg -q '^name:\s*telegram-openapi-skill\s*$' "${SKILL_FILE}" || fail 'invalid skill name'
+rg -q '^description:\s*.+' "${SKILL_FILE}" || fail 'missing description'
+
+rg -q 'command -v telegram-openapi-cli' "${SKILL_FILE}" || fail 'missing link-first command check'
+rg -q 'uxc link telegram-openapi-cli https://api.telegram.org --schema-url ' "${SKILL_FILE}" || fail 'missing fixed link create command with schema-url'
+rg -q 'telegram-openapi-cli -h' "${SKILL_FILE}" || fail 'missing help-first host discovery example'
+rg -q 'telegram-openapi-cli get:/getMe -h' "${SKILL_FILE}" || fail 'missing operation-level help example'
+rg -q -- '--path-prefix-template "/bot\{\{secret\}\}"' "${SKILL_FILE}" || fail 'missing Telegram path auth setup'
+rg -q 'uxc auth binding match https://api.telegram.org' "${SKILL_FILE}" || fail 'missing binding match check'
+rg -q 'positional JSON' "${SKILL_FILE}" || fail 'missing positional JSON guidance'
+
+if rg -q -- "--args\\s+'\\{" "${SKILL_FILE}" "${USAGE_FILE}"; then
+  fail 'found banned legacy JSON argument pattern'
+fi
+
+rg -q '^\s*display_name:\s*"Telegram Bot API"\s*$' "${OPENAI_FILE}" || fail 'missing display_name'
+rg -q '^\s*short_description:\s*".+"\s*$' "${OPENAI_FILE}" || fail 'missing short_description'
+rg -q '^\s*default_prompt:\s*".*\$telegram-openapi-skill.*"\s*$' "${OPENAI_FILE}" || fail 'default_prompt must mention $telegram-openapi-skill'
+
+echo "skills/telegram-openapi-skill validation passed"

--- a/src/adapters/openapi.rs
+++ b/src/adapters/openapi.rs
@@ -112,6 +112,13 @@ impl OpenAPIAdapter {
         }
     }
 
+    fn apply_auth_profile_to_operation_url(url: &str, profile: Option<&Profile>) -> Result<String> {
+        match profile {
+            Some(profile) => crate::auth::apply_profile_auth_to_operation_url(url, profile),
+            None => Ok(url.to_string()),
+        }
+    }
+
     fn apply_schema_auth_profile(
         &self,
         req: reqwest::RequestBuilder,
@@ -1395,7 +1402,7 @@ impl Adapter for OpenAPIAdapter {
                     }
                     let with_args = parsed.to_string();
                     if should_apply_auth {
-                        Self::apply_auth_profile_to_url(&with_args, profile)?
+                        Self::apply_auth_profile_to_operation_url(&with_args, profile)?
                     } else {
                         with_args
                     }

--- a/src/auth/injected_env.rs
+++ b/src/auth/injected_env.rs
@@ -207,6 +207,7 @@ mod tests {
             fields: std::collections::HashMap::new(),
             auth_headers: None,
             auth_query_params: None,
+            auth_path_prefix: None,
             signer: None,
         };
         let rendered = InjectEnvSpec::parse("TOKEN=Bearer {{secret}}")

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -385,6 +385,10 @@ pub struct Profile {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_query_params: Option<Vec<AuthQueryParam>>,
 
+    /// Optional request path prefix template used by api_key auth type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_path_prefix: Option<String>,
+
     /// Optional binding-level signer attached at runtime.
     #[serde(skip)]
     pub signer: Option<AuthSignerConfig>,
@@ -411,6 +415,7 @@ impl Profile {
             fields: HashMap::new(),
             auth_headers: None,
             auth_query_params: None,
+            auth_path_prefix: None,
             signer: None,
         }
     }
@@ -551,13 +556,24 @@ impl Profile {
                 .is_some_and(|params| !params.is_empty())
     }
 
+    pub fn has_custom_api_key_path_prefix(&self) -> bool {
+        self.auth_type == AuthType::ApiKey
+            && self
+                .auth_path_prefix
+                .as_ref()
+                .is_some_and(|prefix| !prefix.trim().is_empty())
+    }
+
     pub fn api_key_injections_require_secret(&self) -> bool {
         self.auth_type == AuthType::ApiKey
             && (self.auth_headers.as_ref().is_some_and(|headers| {
                 !headers.is_empty() && headers.iter().any(AuthHeader::requires_primary_secret)
             }) || self.auth_query_params.as_ref().is_some_and(|params| {
                 !params.is_empty() && params.iter().any(AuthQueryParam::requires_primary_secret)
-            }))
+            }) || self
+                .auth_path_prefix
+                .as_ref()
+                .is_some_and(|prefix| !prefix.trim().is_empty() && template_has_secret(prefix)))
     }
 
     pub fn field_source_kinds(&self) -> Vec<(String, String)> {
@@ -622,6 +638,22 @@ impl Profile {
 
         Ok(Vec::new())
     }
+
+    pub fn resolved_api_key_path_prefix(&self) -> Result<Option<String>> {
+        if self.auth_type != AuthType::ApiKey {
+            return Ok(None);
+        }
+
+        let Some(prefix) = &self.auth_path_prefix else {
+            return Ok(None);
+        };
+        if prefix.trim().is_empty() {
+            return Ok(None);
+        }
+
+        let rendered = render_template(prefix, self, "auth path prefix")?;
+        Ok(Some(normalize_auth_path_prefix(&rendered)?))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -655,6 +687,8 @@ struct StoredCredential {
     auth_headers: Option<Vec<AuthHeader>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     auth_query_params: Option<Vec<AuthQueryParam>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auth_path_prefix: Option<String>,
 }
 
 impl StoredCredential {
@@ -687,6 +721,7 @@ impl StoredCredential {
             fields: profile.fields.clone(),
             auth_headers: profile.auth_headers.clone(),
             auth_query_params: profile.auth_query_params.clone(),
+            auth_path_prefix: profile.auth_path_prefix.clone(),
         }
     }
 
@@ -711,6 +746,7 @@ impl StoredCredential {
             fields: self.fields.clone(),
             auth_headers: self.auth_headers.clone(),
             auth_query_params: self.auth_query_params.clone(),
+            auth_path_prefix: self.auth_path_prefix.clone(),
             signer: None,
         };
 
@@ -1150,6 +1186,7 @@ fn validate_ready(profile: &Profile) -> Result<()> {
         AuthType::ApiKey => {
             let requires_primary_secret = if profile.has_custom_api_key_headers()
                 || profile.has_custom_api_key_query_params()
+                || profile.has_custom_api_key_path_prefix()
             {
                 profile.api_key_injections_require_secret()
             } else {
@@ -1288,6 +1325,11 @@ pub fn validate_auth_query_params(params: &[AuthQueryParam]) -> Result<()> {
     Ok(())
 }
 
+pub fn validate_auth_path_prefix_template(template: &str) -> Result<String> {
+    validate_template(template)?;
+    normalize_auth_path_prefix(template)
+}
+
 fn validate_header_name(name: &str) -> Result<String> {
     let trimmed = name.trim();
     if trimmed.is_empty() {
@@ -1316,6 +1358,31 @@ fn validate_query_param_name(name: &str) -> Result<String> {
         anyhow::bail!("Invalid query param name '{}'", trimmed);
     }
     Ok(trimmed.to_string())
+}
+
+fn normalize_auth_path_prefix(prefix: &str) -> Result<String> {
+    let trimmed = prefix.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("Auth path prefix template cannot be empty");
+    }
+
+    let with_leading = if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{}", trimmed)
+    };
+
+    let normalized = if with_leading.len() > 1 {
+        with_leading.trim_end_matches('/').to_string()
+    } else {
+        with_leading
+    };
+
+    if normalized == "/" {
+        anyhow::bail!("Auth path prefix template cannot be '/'");
+    }
+
+    Ok(normalized)
 }
 
 pub fn validate_field_name(name: &str) -> Result<String> {
@@ -1936,7 +2003,7 @@ fn resolved_profile_auth_headers(profile: &Profile) -> Result<Vec<(String, Strin
 
 pub fn resolve_profile_request_auth(url: &str, profile: &Profile) -> Result<ResolvedRequestAuth> {
     Ok(ResolvedRequestAuth {
-        url: apply_profile_auth_to_url(url, profile)?,
+        url: apply_profile_auth_to_operation_url(url, profile)?,
         headers: resolved_profile_auth_headers(profile)?,
     })
 }
@@ -1951,6 +2018,11 @@ pub fn apply_profile_auth_to_request(
     }
 
     Ok(request_builder)
+}
+
+pub fn apply_profile_auth_to_operation_url(url: &str, profile: &Profile) -> Result<String> {
+    let url = apply_profile_auth_path_prefix(url, profile)?;
+    apply_profile_auth_to_url(&url, profile)
 }
 
 pub fn apply_profile_auth_to_url(url: &str, profile: &Profile) -> Result<String> {
@@ -1973,6 +2045,27 @@ pub fn apply_profile_auth_to_url(url: &str, profile: &Profile) -> Result<String>
     }
 
     apply_signer_to_url(&authed_url, profile)
+}
+
+fn apply_profile_auth_path_prefix(url: &str, profile: &Profile) -> Result<String> {
+    let Some(prefix) = profile.resolved_api_key_path_prefix()? else {
+        return Ok(url.to_string());
+    };
+
+    let mut parsed = url::Url::parse(url)
+        .with_context(|| format!("Invalid endpoint URL for auth path prefix: {}", url))?;
+    let path = parsed.path();
+    if path == prefix || path.starts_with(&format!("{}/", prefix)) {
+        return Ok(parsed.to_string());
+    }
+
+    let suffix = if path == "/" {
+        String::new()
+    } else {
+        path.to_string()
+    };
+    parsed.set_path(&format!("{}{}", prefix, suffix));
+    Ok(parsed.to_string())
 }
 
 pub fn auth_profile_to_metadata(
@@ -2582,6 +2675,34 @@ mod tests {
             resolved.headers,
             vec![("X-Test-Key".to_string(), "token-123".to_string())]
         );
+    }
+
+    #[test]
+    fn resolve_profile_request_auth_applies_path_prefix_before_query_params() {
+        let mut profile = Profile::new("123:abc".to_string(), AuthType::ApiKey);
+        profile.auth_query_params =
+            Some(vec![AuthQueryParam::new("api_key", "{{secret}}").unwrap()]);
+        profile.auth_path_prefix = Some("/bot{{secret}}".to_string());
+
+        let resolved =
+            resolve_profile_request_auth("https://api.telegram.org/getMe?existing=1", &profile)
+                .unwrap();
+
+        assert_eq!(
+            resolved.url,
+            "https://api.telegram.org/bot123:abc/getMe?existing=1&api_key=123%3Aabc"
+        );
+    }
+
+    #[test]
+    fn apply_profile_auth_to_url_does_not_apply_path_prefix() {
+        let mut profile = Profile::new("123:abc".to_string(), AuthType::ApiKey);
+        profile.auth_path_prefix = Some("/bot{{secret}}".to_string());
+
+        let resolved =
+            apply_profile_auth_to_url("https://api.telegram.org/openapi.json", &profile).unwrap();
+
+        assert_eq!(resolved, "https://api.telegram.org/openapi.json");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,6 +324,11 @@ enum AuthCredentialCommands {
         #[arg(long)]
         query_param: Vec<String>,
 
+        /// Request path prefix template: <template>
+        /// Template supports {{secret}}, {{field:name}}, {{env:VAR}}, {{op://...}}
+        #[arg(long)]
+        path_prefix_template: Option<String>,
+
         /// Named auth field source (repeatable): <field-name>=<source>
         /// Source supports literal:<value>, env:<VAR>, op://...
         #[arg(long)]
@@ -627,6 +632,7 @@ struct AuthProfileView {
     fields: Option<Vec<AuthFieldView>>,
     auth_headers: Option<Vec<AuthHeaderView>>,
     auth_query_params: Option<Vec<AuthQueryParamView>>,
+    auth_path_prefix: Option<AuthPathPrefixView>,
     description: Option<String>,
     oauth: Option<AuthOAuthView>,
 }
@@ -652,6 +658,11 @@ struct AuthFieldView {
 #[derive(Debug, Serialize, Deserialize)]
 struct AuthQueryParamView {
     name: String,
+    value_masked: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AuthPathPrefixView {
     value_masked: String,
 }
 
@@ -1697,11 +1708,12 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
         ["auth", "credential", "set"] => HelpData {
             path: "uxc auth credential set".to_string(),
             about: "Set or update a credential".to_string(),
-            usage: "uxc auth credential set <credential_id> [--auth-type <type>] [--secret <value>|--secret-env <key>|--secret-op <op://...>] [--field <name>=<literal:...|env:...|op://...>]... [--api-key-header <name>|--header <name>=<template>] [--query-param <name>=<template>] [--description <text>]".to_string(),
+            usage: "uxc auth credential set <credential_id> [--auth-type <type>] [--secret <value>|--secret-env <key>|--secret-op <op://...>] [--field <name>=<literal:...|env:...|op://...>]... [--api-key-header <name>|--header <name>=<template>] [--query-param <name>=<template>] [--path-prefix-template <template>] [--description <text>]".to_string(),
             commands: vec![],
             notes: vec![
                 "--field is repeatable and stores additional named auth fields on the credential.".to_string(),
                 "{{secret}} remains available and is equivalent to {{field:secret}} for compatible credentials.".to_string(),
+                "--path-prefix-template is for APIs that place credentials in the request path, such as Telegram Bot API.".to_string(),
             ],
             examples: vec![
                 "uxc auth credential set deepwiki --secret-env DEEPWIKI_TOKEN".to_string(),
@@ -1709,6 +1721,7 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
                     .to_string(),
                 "uxc auth credential set flipside --auth-type api_key --query-param \"apiKey={{secret}}\" --secret-env FLIPSIDE_API_KEY".to_string(),
                 "uxc auth credential set binance --auth-type api_key --field api_key=env:BINANCE_API_KEY --field secret_key=env:BINANCE_SECRET_KEY --header \"X-API-Key={{field:api_key}}\"".to_string(),
+                "uxc auth credential set telegram-bot --auth-type api_key --secret-env TELEGRAM_BOT_TOKEN --path-prefix-template \"/bot{{secret}}\"".to_string(),
             ],
         },
         ["auth", "credential", "remove"] => HelpData {
@@ -3583,6 +3596,7 @@ async fn handle_auth_credential_command(
             api_key_header,
             header,
             query_param,
+            path_prefix_template,
             field,
             description,
         } => {
@@ -3620,10 +3634,13 @@ async fn handle_auth_credential_command(
             }
 
             if resolved_auth_type != AuthType::ApiKey
-                && (api_key_header.is_some() || !header.is_empty() || !query_param.is_empty())
+                && (api_key_header.is_some()
+                    || !header.is_empty()
+                    || !query_param.is_empty()
+                    || path_prefix_template.is_some())
             {
                 return Err(UxcError::InvalidArguments(
-                    "--api-key-header/--header/--query-param can only be used with --auth-type api_key"
+                    "--api-key-header/--header/--query-param/--path-prefix-template can only be used with --auth-type api_key"
                         .to_string(),
                 )
                 .into());
@@ -3672,6 +3689,11 @@ async fn handle_auth_credential_command(
                     .map_err(|e| UxcError::InvalidArguments(e.to_string()))?;
                 profile_obj.auth_query_params = Some(auth_query_params);
             }
+            if let Some(template) = path_prefix_template {
+                let normalized = crate::auth::validate_auth_path_prefix_template(template)
+                    .map_err(|e| UxcError::InvalidArguments(e.to_string()))?;
+                profile_obj.auth_path_prefix = Some(normalized);
+            }
 
             if resolved_auth_type == AuthType::OAuth {
                 profile_obj.clear_fields();
@@ -3704,6 +3726,7 @@ async fn handle_auth_credential_command(
                 let requires_secret = if resolved_auth_type == AuthType::ApiKey {
                     if profile_obj.has_custom_api_key_headers()
                         || profile_obj.has_custom_api_key_query_params()
+                        || profile_obj.has_custom_api_key_path_prefix()
                     {
                         profile_obj.api_key_injections_require_secret()
                     } else {
@@ -3749,11 +3772,13 @@ async fn handle_auth_credential_command(
                 profile_obj.secret_source = None;
                 profile_obj.auth_headers = None;
                 profile_obj.auth_query_params = None;
+                profile_obj.auth_path_prefix = None;
             } else {
                 profile_obj.oauth = None;
                 if resolved_auth_type != AuthType::ApiKey {
                     profile_obj.auth_headers = None;
                     profile_obj.auth_query_params = None;
+                    profile_obj.auth_path_prefix = None;
                 } else if profile_obj
                     .auth_headers
                     .as_ref()
@@ -3776,6 +3801,12 @@ async fn handle_auth_credential_command(
                             .expect("checked is_some"),
                     )
                     .map_err(|e| UxcError::InvalidArguments(e.to_string()))?;
+                }
+                if let Some(prefix) = profile_obj.auth_path_prefix.as_ref() {
+                    profile_obj.auth_path_prefix = Some(
+                        crate::auth::validate_auth_path_prefix_template(prefix)
+                            .map_err(|e| UxcError::InvalidArguments(e.to_string()))?,
+                    );
                 }
             }
 
@@ -4412,6 +4443,12 @@ fn to_auth_profile_view(name: &str, profile: &Profile) -> AuthProfileView {
                 })
                 .collect()
         }),
+        auth_path_prefix: profile
+            .auth_path_prefix
+            .as_ref()
+            .map(|_| AuthPathPrefixView {
+                value_masked: "***".to_string(),
+            }),
         description: profile.description.clone(),
         oauth,
     }

--- a/tests/auth_binding_cli_test.rs
+++ b/tests/auth_binding_cli_test.rs
@@ -651,6 +651,41 @@ fn auth_credential_set_supports_query_param_template() {
 }
 
 #[test]
+fn auth_credential_set_supports_path_prefix_template() {
+    let files = AuthFiles::new();
+
+    let output = uxc_command(&files)
+        .arg("auth")
+        .arg("credential")
+        .arg("set")
+        .arg("telegram-bot")
+        .arg("--auth-type")
+        .arg("api_key")
+        .arg("--secret")
+        .arg("123:abc")
+        .arg("--path-prefix-template")
+        .arg("/bot{{secret}}")
+        .output()
+        .expect("credential set should run");
+    assert!(output.status.success(), "credential set should succeed");
+
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["auth_path_prefix"]["value_masked"], "***");
+
+    let info = uxc_command(&files)
+        .arg("auth")
+        .arg("credential")
+        .arg("info")
+        .arg("telegram-bot")
+        .output()
+        .expect("credential info should run");
+    assert!(info.status.success(), "credential info should succeed");
+    let info_json = parse_stdout_json(&info);
+    assert_eq!(info_json["data"]["auth_path_prefix"]["value_masked"], "***");
+}
+
+#[test]
 fn auth_credential_set_rejects_query_param_for_non_api_key() {
     let files = AuthFiles::new();
 
@@ -665,6 +700,30 @@ fn auth_credential_set_rejects_query_param_for_non_api_key() {
         .arg("token")
         .arg("--query-param")
         .arg("apiKey={{secret}}")
+        .output()
+        .expect("credential set should run");
+
+    assert!(!output.status.success(), "command should fail");
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "INVALID_ARGUMENT");
+}
+
+#[test]
+fn auth_credential_set_rejects_path_prefix_template_for_non_api_key() {
+    let files = AuthFiles::new();
+
+    let output = uxc_command(&files)
+        .arg("auth")
+        .arg("credential")
+        .arg("set")
+        .arg("bad-path")
+        .arg("--auth-type")
+        .arg("bearer")
+        .arg("--secret")
+        .arg("token")
+        .arg("--path-prefix-template")
+        .arg("/bot{{secret}}")
         .output()
         .expect("credential set should run");
 

--- a/tests/cli_help_regression_test.rs
+++ b/tests/cli_help_regression_test.rs
@@ -542,6 +542,29 @@ fn auth_credential_without_subcommand_outputs_subcommand_help_json() {
 
 #[test]
 #[serial]
+fn auth_credential_set_help_mentions_path_prefix_template() {
+    let output = uxc_command()
+        .arg("auth")
+        .arg("credential")
+        .arg("set")
+        .arg("--help")
+        .output()
+        .expect("failed to run uxc auth credential set --help");
+
+    assert!(output.status.success(), "command should succeed");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["kind"], "subcommand_help");
+    assert_eq!(json["data"]["path"], "uxc auth credential set");
+    assert!(json["data"]["usage"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("--path-prefix-template <template>"));
+}
+
+#[test]
+#[serial]
 fn host_help_keyword_is_treated_as_operation_literal() {
     let mut server = mockito::Server::new();
     let _schema = server

--- a/tests/openapi_contract_test.rs
+++ b/tests/openapi_contract_test.rs
@@ -18,7 +18,7 @@ where
     F: FnOnce(mockito::ServerGuard) -> R,
     R: Send + 'static,
 {
-    let mut server = mockito::Server::new();
+    let server = mockito::Server::new();
     f(server)
 }
 
@@ -1349,6 +1349,74 @@ fn test_execute_handles_401_unauthorized() {
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("HTTP error 401"));
         assert!(err_msg.contains("Unauthorized"));
+    });
+}
+
+#[test]
+fn test_execute_applies_auth_path_prefix_only_to_operation_url() {
+    run_async(|mut server| {
+        let openapi_doc = serde_json::json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Telegram Bot API", "version": "1.0" },
+            "paths": {
+                "/sendMessage": {
+                    "post": {
+                        "operationId": "sendMessage",
+                        "requestBody": {
+                            "required": true,
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["chat_id", "text"],
+                                        "properties": {
+                                            "chat_id": { "type": "string" },
+                                            "text": { "type": "string" }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "responses": { "200": { "description": "OK" } }
+                    }
+                }
+            }
+        });
+
+        let _schema_mock = server
+            .mock("GET", "/openapi.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&openapi_doc.to_string())
+            .create();
+
+        let _mock = server
+            .mock("POST", "/bot123:abc/sendMessage")
+            .match_header(
+                "content-type",
+                mockito::Matcher::Regex("application/json".into()),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"ok":true,"result":{"message_id":1}}"#)
+            .create();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut profile = Profile::new("123:abc".to_string(), AuthType::ApiKey);
+        profile.auth_path_prefix = Some("/bot{{secret}}".to_string());
+        let adapter = OpenAPIAdapter::new().with_auth(profile);
+
+        let mut args = HashMap::new();
+        args.insert("chat_id".to_string(), json!("123456"));
+        args.insert("text".to_string(), json!("hello"));
+
+        let result = rt.block_on(async {
+            adapter
+                .execute(&server.url(), "post:/sendMessage", args)
+                .await
+        });
+
+        assert!(result.is_ok(), "execution should succeed: {result:?}");
     });
 }
 


### PR DESCRIPTION
## What
- add API key request path-prefix templating for providers that place credentials in the URL path
- apply request-path auth only to OpenAPI operation execution, not schema discovery
- add a Telegram Bot API skill with a curated lean-core OpenAPI schema and validation script
- add regression coverage for credential config, help output, and Telegram-style OpenAPI execution

## Why
Telegram Bot API requires requests in the form https://api.telegram.org/bot<TOKEN>/METHOD_NAME, which did not map cleanly onto the existing uxc auth header/query injection model. This PR adds the minimal runtime support needed to integrate Telegram cleanly and documents it as a reusable skill.

## How
- introduce --path-prefix-template on uxc auth credential set for api_key credentials
- persist and render auth path prefixes alongside existing auth header/query templates
- use the new path prefix only when executing OpenAPI operations so schema fetches stay on the plain host
- add skills/telegram-openapi-skill with bot-token path auth guidance and a curated schema covering bot identity, chat lookup, text/media sends by file_id or URL, polling, and webhook management

## Testing
- bash skills/telegram-openapi-skill/scripts/validate.sh
- cargo test --lib --test auth_binding_cli_test --test cli_help_regression_test --test openapi_contract_test

Closes #206
