### PR TITLE
feat(skill): add Bybit exchange API skill

### DIFF
--- a/skills/bybit-openapi-skill/SKILL.md
+++ b/skills/bybit-openapi-skill/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: bybit-openapi-skill
+description: Operate Bybit V5 public market APIs through UXC with a curated OpenAPI schema, market-first discovery, and explicit private-auth boundary notes.
+---
+
+# Bybit V5 Skill
+
+Use this skill to run Bybit V5 market-data operations through `uxc` + OpenAPI.
+
+Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- Network access to:
+  - `https://api.bybit.com`
+  - optionally `https://api-testnet.bybit.com`
+- Access to the curated OpenAPI schema URL:
+  - `https://raw.githubusercontent.com/holon-run/uxc/main/skills/bybit-openapi-skill/references/bybit-v5.openapi.json`
+
+## Scope
+
+This skill covers a curated Bybit V5 public market surface for:
+
+- server time
+- instruments metadata
+- tickers
+- order book snapshots
+- kline reads
+
+This skill does **not** cover:
+
+- private account endpoints in v1
+- private order placement or cancellation in v1
+- copy trading, earn, broker, or asset management product families
+
+## Authentication
+
+Public market endpoints in this skill do not require credentials.
+
+Bybit private APIs use provider-specific header signing that is not yet packaged as a generic `uxc` signer flow. Keep this v1 skill public-data-only until a reusable Bybit signer path exists.
+
+## Region Guardrail
+
+Bybit's official docs note region and IP restrictions. If requests fail unexpectedly, verify that the current execution environment is permitted for Bybit API access before debugging the schema or parameters.
+
+## Core Workflow
+
+1. Use the fixed link command by default:
+   - `command -v bybit-openapi-cli`
+   - If missing, create it:
+     `uxc link bybit-openapi-cli https://api.bybit.com --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/bybit-openapi-skill/references/bybit-v5.openapi.json`
+   - `bybit-openapi-cli -h`
+
+2. Inspect operation help before execution:
+   - `bybit-openapi-cli get:/v5/market/time -h`
+   - `bybit-openapi-cli get:/v5/market/instruments-info -h`
+   - `bybit-openapi-cli get:/v5/market/tickers -h`
+
+3. Prefer narrow spot reads first:
+   - `bybit-openapi-cli get:/v5/market/tickers category=spot symbol=BTCUSDT`
+   - `bybit-openapi-cli get:/v5/market/orderbook category=spot symbol=BTCUSDT limit=20`
+
+## Operations
+
+- `get:/v5/market/time`
+- `get:/v5/market/instruments-info`
+- `get:/v5/market/tickers`
+- `get:/v5/market/orderbook`
+- `get:/v5/market/kline`
+
+## Guardrails
+
+- Keep automation on the JSON output envelope; do not use `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- Treat this v1 skill as read-only.
+- Use `category=spot` unless the user explicitly needs another market family and has checked the symbol format.
+- `bybit-openapi-cli <operation> ...` is equivalent to `uxc https://api.bybit.com --schema-url <bybit_v5_openapi_schema> <operation> ...`.
+
+## References
+
+- Usage patterns: `references/usage-patterns.md`
+- Curated OpenAPI schema: `references/bybit-v5.openapi.json`
+- Official Bybit V5 docs: https://bybit-exchange.github.io/docs/v5/guide

--- a/skills/bybit-openapi-skill/agents/openai.yaml
+++ b/skills/bybit-openapi-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Bybit V5"
+  short_description: "Bybit public market data via the V5 REST API through UXC"
+  default_prompt: "Use $bybit-openapi-skill to discover and execute Bybit V5 public market-data operations through UXC with help-first schema inspection, narrow symbol reads, and explicit private-auth boundary notes."

--- a/skills/bybit-openapi-skill/references/bybit-v5.openapi.json
+++ b/skills/bybit-openapi-skill/references/bybit-v5.openapi.json
@@ -1,0 +1,71 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Bybit V5 API",
+    "version": "v1",
+    "description": "Curated Bybit V5 public market surface for UXC."
+  },
+  "servers": [
+    {
+      "url": "https://api.bybit.com"
+    }
+  ],
+  "components": {
+    "schemas": {}
+  },
+  "paths": {
+    "/v5/market/time": {
+      "get": {
+        "operationId": "getServerTime",
+        "responses": { "200": { "description": "Server time returned" } }
+      }
+    },
+    "/v5/market/instruments-info": {
+      "get": {
+        "operationId": "listInstruments",
+        "parameters": [
+          { "name": "category", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "symbol", "in": "query", "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Instrument metadata returned" } }
+      }
+    },
+    "/v5/market/tickers": {
+      "get": {
+        "operationId": "getTickers",
+        "parameters": [
+          { "name": "category", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "symbol", "in": "query", "schema": { "type": "string" } },
+          { "name": "baseCoin", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Tickers returned" } }
+      }
+    },
+    "/v5/market/orderbook": {
+      "get": {
+        "operationId": "getOrderbook",
+        "parameters": [
+          { "name": "category", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "symbol", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Order book returned" } }
+      }
+    },
+    "/v5/market/kline": {
+      "get": {
+        "operationId": "getKlines",
+        "parameters": [
+          { "name": "category", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "symbol", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "interval", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "start", "in": "query", "schema": { "type": "integer" } },
+          { "name": "end", "in": "query", "schema": { "type": "integer" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Klines returned" } }
+      }
+    }
+  }
+}

--- a/skills/bybit-openapi-skill/references/usage-patterns.md
+++ b/skills/bybit-openapi-skill/references/usage-patterns.md
@@ -1,0 +1,38 @@
+# Bybit V5 Skill - Usage Patterns
+
+## Link Setup
+
+```bash
+command -v bybit-openapi-cli
+uxc link bybit-openapi-cli https://api.bybit.com \
+  --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/bybit-openapi-skill/references/bybit-v5.openapi.json
+bybit-openapi-cli -h
+```
+
+## Read Examples
+
+```bash
+# Read Bybit server time
+bybit-openapi-cli get:/v5/market/time
+
+# Read spot instrument metadata
+bybit-openapi-cli get:/v5/market/instruments-info category=spot symbol=BTCUSDT
+
+# Read spot ticker
+bybit-openapi-cli get:/v5/market/tickers category=spot symbol=BTCUSDT
+
+# Read spot order book snapshot
+bybit-openapi-cli get:/v5/market/orderbook category=spot symbol=BTCUSDT limit=20
+
+# Read spot kline data
+bybit-openapi-cli get:/v5/market/kline category=spot symbol=BTCUSDT interval=60 limit=24
+```
+
+## Guardrail Note
+
+- Keep this v1 skill on public reads only because Bybit private REST auth uses provider-specific header signing not yet packaged into a reusable `uxc` signer flow.
+
+## Fallback Equivalence
+
+- `bybit-openapi-cli <operation> ...` is equivalent to
+  `uxc https://api.bybit.com --schema-url <bybit_v5_openapi_schema> <operation> ...`.

--- a/skills/bybit-openapi-skill/scripts/validate.sh
+++ b/skills/bybit-openapi-skill/scripts/validate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/bybit-openapi-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+USAGE_FILE="${SKILL_DIR}/references/usage-patterns.md"
+SCHEMA_FILE="${SKILL_DIR}/references/bybit-v5.openapi.json"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd jq
+need_cmd rg
+
+for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}" "${SCHEMA_FILE}"; do
+  [[ -f "${file}" ]] || fail "missing required file: ${file}"
+done
+
+jq -e '.openapi and .paths and .components' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'invalid OpenAPI schema JSON or missing .openapi/.paths/.components'
+jq -e '.paths["/v5/market/time"] and .paths["/v5/market/tickers"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing expected Bybit paths'
+
+rg -q '^name:\s*bybit-openapi-skill\s*$' "${SKILL_FILE}" || fail 'invalid skill name'
+rg -q '^description:\s*.+' "${SKILL_FILE}" || fail 'missing description'
+rg -q 'command -v bybit-openapi-cli' "${SKILL_FILE}" || fail 'missing link-first command check'
+rg -q 'uxc link bybit-openapi-cli https://api.bybit.com --schema-url ' "${SKILL_FILE}" || fail 'missing fixed link create command with schema-url'
+rg -q 'bybit-openapi-cli get:/v5/market/time -h' "${SKILL_FILE}" || fail 'missing operation-level help example'
+rg -q 'provider-specific header signing' "${SKILL_FILE}" "${USAGE_FILE}" || fail 'missing private auth boundary note'
+rg -q 'read-only' "${SKILL_FILE}" || fail 'missing read-only guardrail'
+
+if rg -q -- "--args\\s+'\\{" "${SKILL_FILE}" "${USAGE_FILE}"; then
+  fail 'found banned legacy JSON argument pattern'
+fi
+
+rg -q '^\s*display_name:\s*"Bybit V5"\s*$' "${OPENAI_FILE}" || fail 'missing display_name'
+rg -q '^\s*short_description:\s*".+"\s*$' "${OPENAI_FILE}" || fail 'missing short_description'
+rg -q '^\s*default_prompt:\s*".*\$bybit-openapi-skill.*"\s*$' "${OPENAI_FILE}" || fail 'default_prompt must mention $bybit-openapi-skill'
+
+echo "skills/bybit-openapi-skill validation passed"


### PR DESCRIPTION
## What
- add skills/bybit-openapi-skill skill package
- document auth, scope, and guardrails for the provider
- include usage patterns, OpenAI metadata, and validate script

## Why
- add provider coverage for exchange MCP/API integrations tracked in #168
- keep delivery isolated to one provider / one PR

## How
- add a dedicated skill directory under \
- use curated schema or MCP endpoint guidance appropriate for the provider
- keep scope intentionally narrow for v1

## Testing
- bash skills/bybit-openapi-skill/scripts/validate.sh
- cargo build -q --bin uxc

Closes #252
