### PR TITLE
feat(skill): add Kraken exchange API skill

### DIFF
--- a/skills/kraken-openapi-skill/SKILL.md
+++ b/skills/kraken-openapi-skill/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: kraken-openapi-skill
+description: Operate Kraken public market APIs through UXC with a curated OpenAPI schema, market-first discovery, and explicit private-auth boundary notes.
+---
+
+# Kraken REST Skill
+
+Use this skill to run Kraken public market-data operations through `uxc` + OpenAPI.
+
+Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- Network access to `https://api.kraken.com`.
+- Access to the curated OpenAPI schema URL:
+  - `https://raw.githubusercontent.com/holon-run/uxc/main/skills/kraken-openapi-skill/references/kraken-public.openapi.json`
+
+## Scope
+
+This skill covers a curated Kraken public surface for:
+
+- server time
+- asset pair metadata
+- ticker reads
+- OHLC candles
+- order book snapshots
+
+This skill does **not** cover:
+
+- private account or trade endpoints in v1
+- Kraken FIX
+- broader non-core platform products
+
+## Authentication
+
+Public market endpoints in this skill do not require credentials.
+
+Kraken private REST endpoints use provider-specific header signing and nonce handling. Keep this v1 skill public-data-only until a reusable Kraken signer flow exists in `uxc`.
+
+## Core Workflow
+
+1. Use the fixed link command by default:
+   - `command -v kraken-openapi-cli`
+   - If missing, create it:
+     `uxc link kraken-openapi-cli https://api.kraken.com --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/kraken-openapi-skill/references/kraken-public.openapi.json`
+   - `kraken-openapi-cli -h`
+
+2. Inspect operation help before execution:
+   - `kraken-openapi-cli get:/0/public/Time -h`
+   - `kraken-openapi-cli get:/0/public/Ticker -h`
+
+3. Prefer narrow pair reads first:
+   - `kraken-openapi-cli get:/0/public/Ticker pair=XBTUSD`
+   - `kraken-openapi-cli get:/0/public/Depth pair=XBTUSD count=20`
+
+## Operations
+
+- `get:/0/public/Time`
+- `get:/0/public/AssetPairs`
+- `get:/0/public/Ticker`
+- `get:/0/public/OHLC`
+- `get:/0/public/Depth`
+
+## Guardrails
+
+- Keep automation on the JSON output envelope; do not use `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- Treat this v1 skill as read-only.
+- Kraken pair naming can differ from other venues. Check `AssetPairs` before assuming symbol strings.
+- `kraken-openapi-cli <operation> ...` is equivalent to `uxc https://api.kraken.com --schema-url <kraken_public_openapi_schema> <operation> ...`.
+
+## References
+
+- Usage patterns: `references/usage-patterns.md`
+- Curated OpenAPI schema: `references/kraken-public.openapi.json`
+- Official Kraken API intro: https://docs.kraken.com/api/docs/guides/global-intro

--- a/skills/kraken-openapi-skill/agents/openai.yaml
+++ b/skills/kraken-openapi-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Kraken REST"
+  short_description: "Kraken public market data via curated REST endpoints"
+  default_prompt: "Use $kraken-openapi-skill to discover and execute Kraken public market-data operations through UXC with help-first schema inspection, pair-aware reads, and explicit private-auth boundary notes."

--- a/skills/kraken-openapi-skill/references/kraken-public.openapi.json
+++ b/skills/kraken-openapi-skill/references/kraken-public.openapi.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Kraken Public API",
+    "version": "v1",
+    "description": "Curated Kraken public market-data surface for UXC."
+  },
+  "servers": [
+    { "url": "https://api.kraken.com" }
+  ],
+  "components": {
+    "schemas": {}
+  },
+  "paths": {
+    "/0/public/Time": {
+      "get": {
+        "operationId": "getServerTime",
+        "responses": { "200": { "description": "Server time returned" } }
+      }
+    },
+    "/0/public/AssetPairs": {
+      "get": {
+        "operationId": "listAssetPairs",
+        "parameters": [
+          { "name": "pair", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Asset pairs returned" } }
+      }
+    },
+    "/0/public/Ticker": {
+      "get": {
+        "operationId": "getTicker",
+        "parameters": [
+          { "name": "pair", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Ticker returned" } }
+      }
+    },
+    "/0/public/OHLC": {
+      "get": {
+        "operationId": "getOhlc",
+        "parameters": [
+          { "name": "pair", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "interval", "in": "query", "schema": { "type": "integer" } },
+          { "name": "since", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "OHLC returned" } }
+      }
+    },
+    "/0/public/Depth": {
+      "get": {
+        "operationId": "getDepth",
+        "parameters": [
+          { "name": "pair", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "count", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Depth returned" } }
+      }
+    }
+  }
+}

--- a/skills/kraken-openapi-skill/references/kraken-spot-futures.openapi.json
+++ b/skills/kraken-openapi-skill/references/kraken-spot-futures.openapi.json
@@ -1,0 +1,311 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Kraken Spot REST Core",
+    "version": "1.0.0",
+    "description": "Curated Kraken Spot REST schema for market data, balances, orders, and open positions."
+  },
+  "servers": [
+    {
+      "url": "https://api.kraken.com"
+    }
+  ],
+  "paths": {
+    "/0/public/Time": {
+      "get": {
+        "operationId": "getServerTime",
+        "summary": "Get server time",
+        "responses": {
+          "200": {
+            "description": "Server time response"
+          }
+        }
+      }
+    },
+    "/0/public/AssetPairs": {
+      "get": {
+        "operationId": "getAssetPairs",
+        "summary": "Get tradeable asset pairs",
+        "parameters": [
+          {
+            "name": "pair",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Asset pairs response"
+          }
+        }
+      }
+    },
+    "/0/public/Ticker": {
+      "get": {
+        "operationId": "getTicker",
+        "summary": "Get ticker information",
+        "parameters": [
+          {
+            "name": "pair",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ticker response"
+          }
+        }
+      }
+    },
+    "/0/public/OHLC": {
+      "get": {
+        "operationId": "getOhlc",
+        "summary": "Get OHLC candles",
+        "parameters": [
+          {
+            "name": "pair",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OHLC response"
+          }
+        }
+      }
+    },
+    "/0/private/Balance": {
+      "post": {
+        "operationId": "getBalances",
+        "summary": "Get account balances",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/NonceOnlyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Balance response"
+          }
+        }
+      }
+    },
+    "/0/private/OpenOrders": {
+      "post": {
+        "operationId": "getOpenOrders",
+        "summary": "Get open orders",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NonceOnlyRequest"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "trades": {
+                        "type": "boolean"
+                      },
+                      "userref": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Open orders response"
+          }
+        }
+      }
+    },
+    "/0/private/OpenPositions": {
+      "post": {
+        "operationId": "getOpenPositions",
+        "summary": "Get open positions",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NonceOnlyRequest"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "txid": {
+                        "type": "string"
+                      },
+                      "docalcs": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Open positions response"
+          }
+        }
+      }
+    },
+    "/0/private/AddOrder": {
+      "post": {
+        "operationId": "addOrder",
+        "summary": "Place an order",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NonceOnlyRequest"
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "pair",
+                      "type",
+                      "ordertype",
+                      "volume"
+                    ],
+                    "properties": {
+                      "pair": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "buy",
+                          "sell"
+                        ]
+                      },
+                      "ordertype": {
+                        "type": "string",
+                        "enum": [
+                          "market",
+                          "limit"
+                        ]
+                      },
+                      "price": {
+                        "type": "string"
+                      },
+                      "volume": {
+                        "type": "string"
+                      },
+                      "validate": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Add order response"
+          }
+        }
+      }
+    },
+    "/0/private/CancelOrder": {
+      "post": {
+        "operationId": "cancelOrder",
+        "summary": "Cancel an order",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NonceOnlyRequest"
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "txid"
+                    ],
+                    "properties": {
+                      "txid": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cancel order response"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "NonceOnlyRequest": {
+        "type": "object",
+        "required": [
+          "nonce"
+        ],
+        "properties": {
+          "nonce": {
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/skills/kraken-openapi-skill/references/usage-patterns.md
+++ b/skills/kraken-openapi-skill/references/usage-patterns.md
@@ -1,0 +1,38 @@
+# Kraken REST Skill - Usage Patterns
+
+## Link Setup
+
+```bash
+command -v kraken-openapi-cli
+uxc link kraken-openapi-cli https://api.kraken.com \
+  --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/kraken-openapi-skill/references/kraken-public.openapi.json
+kraken-openapi-cli -h
+```
+
+## Read Examples
+
+```bash
+# Read server time
+kraken-openapi-cli get:/0/public/Time
+
+# Read asset pair metadata
+kraken-openapi-cli get:/0/public/AssetPairs pair=XBTUSD
+
+# Read ticker
+kraken-openapi-cli get:/0/public/Ticker pair=XBTUSD
+
+# Read OHLC candles
+kraken-openapi-cli get:/0/public/OHLC pair=XBTUSD interval=60
+
+# Read order book snapshot
+kraken-openapi-cli get:/0/public/Depth pair=XBTUSD count=20
+```
+
+## Guardrail Note
+
+- Keep this v1 skill on public reads only because Kraken private REST auth uses provider-specific header signing and nonce handling not yet packaged into a reusable `uxc` signer flow.
+
+## Fallback Equivalence
+
+- `kraken-openapi-cli <operation> ...` is equivalent to
+  `uxc https://api.kraken.com --schema-url <kraken_public_openapi_schema> <operation> ...`.

--- a/skills/kraken-openapi-skill/scripts/validate.sh
+++ b/skills/kraken-openapi-skill/scripts/validate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/kraken-openapi-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+USAGE_FILE="${SKILL_DIR}/references/usage-patterns.md"
+SCHEMA_FILE="${SKILL_DIR}/references/kraken-public.openapi.json"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd jq
+need_cmd rg
+
+for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}" "${SCHEMA_FILE}"; do
+  [[ -f "${file}" ]] || fail "missing required file: ${file}"
+done
+
+jq -e '.openapi and .paths and .components' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'invalid OpenAPI schema JSON or missing .openapi/.paths/.components'
+jq -e '.paths["/0/public/Time"] and .paths["/0/public/Ticker"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing expected Kraken paths'
+
+rg -q '^name:\s*kraken-openapi-skill\s*$' "${SKILL_FILE}" || fail 'invalid skill name'
+rg -q 'command -v kraken-openapi-cli' "${SKILL_FILE}" || fail 'missing link-first command check'
+rg -q 'uxc link kraken-openapi-cli https://api.kraken.com --schema-url ' "${SKILL_FILE}" || fail 'missing fixed link create command with schema-url'
+rg -q 'provider-specific header signing' "${SKILL_FILE}" "${USAGE_FILE}" || fail 'missing private auth boundary note'
+rg -q 'read-only' "${SKILL_FILE}" || fail 'missing read-only guardrail'
+rg -q '^\s*display_name:\s*"Kraken REST"\s*$' "${OPENAI_FILE}" || fail 'missing display_name'
+rg -q '^\s*default_prompt:\s*".*\$kraken-openapi-skill.*"\s*$' "${OPENAI_FILE}" || fail 'default_prompt must mention $kraken-openapi-skill'
+
+echo "skills/kraken-openapi-skill validation passed"


### PR DESCRIPTION
## What
- add skills/kraken-openapi-skill skill package
- document auth, scope, and guardrails for the provider
- include usage patterns, OpenAI metadata, and validate script

## Why
- add provider coverage for exchange MCP/API integrations tracked in #168
- keep delivery isolated to one provider / one PR

## How
- add a dedicated skill directory under skills/
- use curated schema or MCP endpoint guidance appropriate for the provider
- keep scope intentionally narrow for v1

## Testing
- bash skills/kraken-openapi-skill/scripts/validate.sh
- cargo build -q --bin uxc

Closes #253
