### PR TITLE
feat(skill): add Upbit exchange API skill

### DIFF
--- a/skills/upbit-openapi-skill/SKILL.md
+++ b/skills/upbit-openapi-skill/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: upbit-openapi-skill
+description: Operate Upbit public exchange market APIs through UXC with a curated OpenAPI schema, market-first discovery, and explicit private-auth boundary notes.
+---
+
+# Upbit Open API Skill
+
+Use this skill to run Upbit public market-data operations through `uxc` + OpenAPI.
+
+Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- Network access to the chosen Upbit regional API host.
+- Access to the curated OpenAPI schema URL:
+  - `https://raw.githubusercontent.com/holon-run/uxc/main/skills/upbit-openapi-skill/references/upbit-public.openapi.json`
+
+## Scope
+
+This skill covers a curated Upbit public surface for:
+
+- market discovery
+- ticker reads
+- minute candles
+- order book snapshots
+
+This skill does **not** cover:
+
+- private account or order endpoints in v1
+- region-specific account/trade auth flows
+
+## Endpoint
+
+Upbit uses regional hosts. Pick the right one for the market you need before linking.
+
+Examples:
+
+- `https://sg-api.upbit.com`
+- `https://id-api.upbit.com`
+- `https://th-api.upbit.com`
+
+## Authentication
+
+Public market endpoints in this skill do not require credentials.
+
+Upbit private APIs use provider-specific bearer JWT generation with request-specific claims. Keep this v1 skill public-data-only until a reusable Upbit signer flow exists in `uxc`.
+
+## Core Workflow
+
+1. Choose the correct regional host for the market you need.
+2. Use a fixed link command by default:
+   - `command -v upbit-openapi-cli`
+   - If missing, create it:
+     `uxc link upbit-openapi-cli https://sg-api.upbit.com --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/upbit-openapi-skill/references/upbit-public.openapi.json`
+   - `upbit-openapi-cli -h`
+
+3. Inspect operation help before execution:
+   - `upbit-openapi-cli get:/v1/market/all -h`
+   - `upbit-openapi-cli get:/v1/ticker -h`
+
+4. Prefer narrow market reads first:
+   - `upbit-openapi-cli get:/v1/ticker markets=BTC-SGD`
+   - `upbit-openapi-cli get:/v1/orderbook markets=BTC-SGD`
+
+## Operations
+
+- `get:/v1/market/all`
+- `get:/v1/ticker`
+- `get:/v1/candles/minutes/{unit}`
+- `get:/v1/orderbook`
+
+## Guardrails
+
+- Keep automation on the JSON output envelope; do not use `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- Treat this v1 skill as read-only.
+- Confirm the correct regional host and quote market before execution.
+- `upbit-openapi-cli <operation> ...` is equivalent to `uxc <upbit_region_host> --schema-url <upbit_public_openapi_schema> <operation> ...`.
+
+## References
+
+- Usage patterns: `references/usage-patterns.md`
+- Curated OpenAPI schema: `references/upbit-public.openapi.json`
+- Official Upbit Open API overview: https://global-docs.upbit.com/reference/api-overview

--- a/skills/upbit-openapi-skill/agents/openai.yaml
+++ b/skills/upbit-openapi-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Upbit Open API"
+  short_description: "Upbit public market data via curated regional REST endpoints"
+  default_prompt: "Use $upbit-openapi-skill to discover and execute Upbit public market-data operations through UXC with help-first schema inspection, region-aware host selection, and explicit private-auth boundary notes."

--- a/skills/upbit-openapi-skill/references/upbit-public.openapi.json
+++ b/skills/upbit-openapi-skill/references/upbit-public.openapi.json
@@ -1,0 +1,55 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Upbit Public API",
+    "version": "v1",
+    "description": "Curated Upbit public market-data surface for UXC."
+  },
+  "servers": [
+    { "url": "https://sg-api.upbit.com" }
+  ],
+  "components": {
+    "schemas": {}
+  },
+  "paths": {
+    "/v1/market/all": {
+      "get": {
+        "operationId": "listMarkets",
+        "parameters": [
+          { "name": "isDetails", "in": "query", "schema": { "type": "boolean" } }
+        ],
+        "responses": { "200": { "description": "Markets returned" } }
+      }
+    },
+    "/v1/ticker": {
+      "get": {
+        "operationId": "getTicker",
+        "parameters": [
+          { "name": "markets", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Ticker returned" } }
+      }
+    },
+    "/v1/candles/minutes/{unit}": {
+      "get": {
+        "operationId": "getMinuteCandles",
+        "parameters": [
+          { "name": "unit", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "market", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "count", "in": "query", "schema": { "type": "integer" } },
+          { "name": "to", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Minute candles returned" } }
+      }
+    },
+    "/v1/orderbook": {
+      "get": {
+        "operationId": "getOrderbook",
+        "parameters": [
+          { "name": "markets", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Orderbook returned" } }
+      }
+    }
+  }
+}

--- a/skills/upbit-openapi-skill/references/usage-patterns.md
+++ b/skills/upbit-openapi-skill/references/usage-patterns.md
@@ -1,0 +1,37 @@
+# Upbit Open API Skill - Usage Patterns
+
+## Link Setup
+
+Choose the right regional host first. Example for Singapore:
+
+```bash
+command -v upbit-openapi-cli
+uxc link upbit-openapi-cli https://sg-api.upbit.com \
+  --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/upbit-openapi-skill/references/upbit-public.openapi.json
+upbit-openapi-cli -h
+```
+
+## Read Examples
+
+```bash
+# List markets
+upbit-openapi-cli get:/v1/market/all isDetails=false
+
+# Read ticker
+upbit-openapi-cli get:/v1/ticker markets=BTC-SGD
+
+# Read minute candles
+upbit-openapi-cli get:/v1/candles/minutes/{unit} unit=60 market=BTC-SGD count=24
+
+# Read order book
+upbit-openapi-cli get:/v1/orderbook markets=BTC-SGD
+```
+
+## Guardrail Note
+
+- Keep this v1 skill on public reads only because Upbit private APIs use provider-specific JWT generation with request-specific claims not yet packaged into a reusable `uxc` signer flow.
+
+## Fallback Equivalence
+
+- `upbit-openapi-cli <operation> ...` is equivalent to
+  `uxc <upbit_region_host> --schema-url <upbit_public_openapi_schema> <operation> ...`.

--- a/skills/upbit-openapi-skill/scripts/validate.sh
+++ b/skills/upbit-openapi-skill/scripts/validate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/upbit-openapi-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+USAGE_FILE="${SKILL_DIR}/references/usage-patterns.md"
+SCHEMA_FILE="${SKILL_DIR}/references/upbit-public.openapi.json"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd jq
+need_cmd rg
+
+for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}" "${SCHEMA_FILE}"; do
+  [[ -f "${file}" ]] || fail "missing required file: ${file}"
+done
+
+jq -e '.openapi and .paths and .components' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'invalid OpenAPI schema JSON or missing .openapi/.paths/.components'
+jq -e '.paths["/v1/market/all"] and .paths["/v1/ticker"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing expected Upbit paths'
+
+rg -q '^name:\s*upbit-openapi-skill\s*$' "${SKILL_FILE}" || fail 'invalid skill name'
+rg -q 'command -v upbit-openapi-cli' "${SKILL_FILE}" || fail 'missing link-first command check'
+rg -q 'uxc link upbit-openapi-cli https://sg-api.upbit.com --schema-url ' "${SKILL_FILE}" || fail 'missing fixed link create command with schema-url'
+rg -q 'request-specific claims' "${SKILL_FILE}" "${USAGE_FILE}" || fail 'missing private auth boundary note'
+rg -q 'read-only' "${SKILL_FILE}" || fail 'missing read-only guardrail'
+rg -q '^\s*display_name:\s*"Upbit Open API"\s*$' "${OPENAI_FILE}" || fail 'missing display_name'
+rg -q '^\s*default_prompt:\s*".*\$upbit-openapi-skill.*"\s*$' "${OPENAI_FILE}" || fail 'default_prompt must mention $upbit-openapi-skill'
+
+echo "skills/upbit-openapi-skill validation passed"


### PR DESCRIPTION
## What
- add skills/upbit-openapi-skill skill package
- document auth, scope, and guardrails for the provider
- include usage patterns, OpenAI metadata, and validate script

## Why
- add provider coverage for exchange MCP/API integrations tracked in #168
- keep delivery isolated to one provider / one PR

## How
- add a dedicated skill directory under skills/
- use curated schema or MCP endpoint guidance appropriate for the provider
- keep scope intentionally narrow for v1

## Testing
- bash skills/upbit-openapi-skill/scripts/validate.sh
- cargo build -q --bin uxc

Closes #255
