### PR TITLE
feat(skill): add MEXC exchange API skill

### DIFF
--- a/skills/mexc-openapi-skill/SKILL.md
+++ b/skills/mexc-openapi-skill/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: mexc-openapi-skill
+description: Operate MEXC Spot REST APIs through UXC with a curated OpenAPI schema, HMAC query signing, and separate public/signed workflow guardrails.
+---
+
+# MEXC Spot API Skill
+
+Use this skill to run MEXC Spot REST operations through `uxc` + OpenAPI.
+
+Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- Network access to `https://api.mexc.com`.
+- Access to the curated OpenAPI schema URL:
+  - `https://raw.githubusercontent.com/holon-run/uxc/main/skills/mexc-openapi-skill/references/mexc-spot.openapi.json`
+
+## Scope
+
+This skill covers a curated MEXC Spot REST surface for:
+
+- public market reads
+- signed account reads
+- signed order create, cancel, and lookup flows
+
+This skill does **not** cover:
+
+- futures APIs
+- broader platform product families
+
+## Authentication
+
+Public market endpoints do not require credentials.
+
+Signed Spot endpoints require:
+
+- `api_key` field for `X-MEXC-APIKEY`
+- `secret_key` field for HMAC SHA256 query signing
+
+Create one credential:
+
+```bash
+uxc auth credential set mexc-spot \
+  --auth-type api_key \
+  --field api_key=env:MEXC_API_KEY \
+  --field secret_key=env:MEXC_SECRET_KEY
+```
+
+Add one signer binding:
+
+```bash
+uxc auth binding add \
+  --id mexc-spot \
+  --host api.mexc.com \
+  --path-prefix /api/v3 \
+  --scheme https \
+  --credential mexc-spot \
+  --signer-json '{"kind":"hmac_query_v1","algorithm":"hmac_sha256","signing_field":"secret_key","key_field":"api_key","key_placement":"header","key_name":"X-MEXC-APIKEY","signature_param":"signature","signature_encoding":"hex","timestamp_param":"timestamp","timestamp_unit":"milliseconds","canonicalization":{"mode":"preserve_order"}}' \
+  --priority 100
+```
+
+Validate the active mapping when auth looks wrong:
+
+```bash
+uxc auth binding match https://api.mexc.com/api/v3/account
+```
+
+## Core Workflow
+
+1. Use the fixed link command by default:
+   - `command -v mexc-openapi-cli`
+   - If missing, create it:
+     `uxc link mexc-openapi-cli https://api.mexc.com --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/mexc-openapi-skill/references/mexc-spot.openapi.json`
+   - `mexc-openapi-cli -h`
+
+2. Inspect operation help before execution:
+   - `mexc-openapi-cli get:/api/v3/ticker/price -h`
+   - `mexc-openapi-cli get:/api/v3/account -h`
+   - `mexc-openapi-cli post:/api/v3/order -h`
+
+3. Prefer public reads first:
+   - `mexc-openapi-cli get:/api/v3/ticker/price symbol=BTCUSDT`
+   - `mexc-openapi-cli get:/api/v3/depth symbol=BTCUSDT limit=20`
+
+4. Use signed reads before writes:
+   - `mexc-openapi-cli get:/api/v3/account recvWindow=5000`
+   - `mexc-openapi-cli get:/api/v3/openOrders symbol=BTCUSDT recvWindow=5000`
+
+## Operation Groups
+
+### Public Market
+
+- `get:/api/v3/ping`
+- `get:/api/v3/exchangeInfo`
+- `get:/api/v3/ticker/price`
+- `get:/api/v3/ticker/24hr`
+- `get:/api/v3/depth`
+
+### Signed Reads
+
+- `get:/api/v3/account`
+- `get:/api/v3/openOrders`
+- `get:/api/v3/order`
+
+### Signed Writes
+
+- `post:/api/v3/order`
+- `delete:/api/v3/order`
+
+## Guardrails
+
+- Keep automation on the JSON output envelope; do not use `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- Treat signed write operations as high-risk and require explicit confirmation before execution.
+- `timestamp` and `signature` are injected by the signer binding; users normally provide business parameters plus optional `recvWindow`.
+- Query `exchangeInfo` before placing orders so symbol filters and lot sizes are known.
+- `mexc-openapi-cli <operation> ...` is equivalent to `uxc https://api.mexc.com --schema-url <mexc_spot_openapi_schema> <operation> ...`.
+
+## References
+
+- Usage patterns: `references/usage-patterns.md`
+- Curated OpenAPI schema: `references/mexc-spot.openapi.json`
+- Official MEXC Spot v3 docs: https://mexcdevelop.github.io/apidocs/spot_v3_en/

--- a/skills/mexc-openapi-skill/agents/openai.yaml
+++ b/skills/mexc-openapi-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MEXC Spot"
+  short_description: "MEXC public market, account, and order endpoints via curated Spot REST mapping"
+  default_prompt: "Use $mexc-openapi-skill to discover and execute MEXC Spot REST operations through UXC with public-market reads, HMAC query signer bindings for signed account/order flows, and explicit write guardrails."

--- a/skills/mexc-openapi-skill/references/mexc-spot.openapi.json
+++ b/skills/mexc-openapi-skill/references/mexc-spot.openapi.json
@@ -1,0 +1,129 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "MEXC Spot API",
+    "version": "v1",
+    "description": "Curated MEXC Spot REST surface for public market data and core signed account/order workflows."
+  },
+  "servers": [
+    { "url": "https://api.mexc.com" }
+  ],
+  "components": {
+    "schemas": {
+      "CreateOrderRequest": {
+        "type": "object",
+        "required": ["symbol", "side", "type"],
+        "properties": {
+          "symbol": { "type": "string" },
+          "side": { "type": "string", "enum": ["BUY", "SELL"] },
+          "type": { "type": "string" },
+          "quantity": { "type": "number" },
+          "quoteOrderQty": { "type": "number" },
+          "price": { "type": "number" },
+          "timeInForce": { "type": "string" },
+          "recvWindow": { "type": "integer" }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/v3/ping": {
+      "get": {
+        "operationId": "ping",
+        "responses": { "200": { "description": "Ping returned" } }
+      }
+    },
+    "/api/v3/exchangeInfo": {
+      "get": {
+        "operationId": "getExchangeInfo",
+        "parameters": [
+          { "name": "symbol", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Exchange info returned" } }
+      }
+    },
+    "/api/v3/ticker/price": {
+      "get": {
+        "operationId": "getTickerPrice",
+        "parameters": [
+          { "name": "symbol", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Price ticker returned" } }
+      }
+    },
+    "/api/v3/ticker/24hr": {
+      "get": {
+        "operationId": "getTicker24h",
+        "parameters": [
+          { "name": "symbol", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "24h ticker returned" } }
+      }
+    },
+    "/api/v3/depth": {
+      "get": {
+        "operationId": "getDepth",
+        "parameters": [
+          { "name": "symbol", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Depth returned" } }
+      }
+    },
+    "/api/v3/account": {
+      "get": {
+        "operationId": "getAccount",
+        "parameters": [
+          { "name": "recvWindow", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Account returned" } }
+      }
+    },
+    "/api/v3/openOrders": {
+      "get": {
+        "operationId": "getOpenOrders",
+        "parameters": [
+          { "name": "symbol", "in": "query", "schema": { "type": "string" } },
+          { "name": "recvWindow", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Open orders returned" } }
+      }
+    },
+    "/api/v3/order": {
+      "get": {
+        "operationId": "getOrder",
+        "parameters": [
+          { "name": "symbol", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "orderId", "in": "query", "schema": { "type": "integer" } },
+          { "name": "origClientOrderId", "in": "query", "schema": { "type": "string" } },
+          { "name": "recvWindow", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Order returned" } }
+      },
+      "post": {
+        "operationId": "createOrder",
+        "parameters": [
+          { "name": "symbol", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "side", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "type", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "quantity", "in": "query", "schema": { "type": "number" } },
+          { "name": "quoteOrderQty", "in": "query", "schema": { "type": "number" } },
+          { "name": "price", "in": "query", "schema": { "type": "number" } },
+          { "name": "timeInForce", "in": "query", "schema": { "type": "string" } },
+          { "name": "recvWindow", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Order created" } }
+      },
+      "delete": {
+        "operationId": "cancelOrder",
+        "parameters": [
+          { "name": "symbol", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "orderId", "in": "query", "schema": { "type": "integer" } },
+          { "name": "origClientOrderId", "in": "query", "schema": { "type": "string" } },
+          { "name": "recvWindow", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Order canceled" } }
+      }
+    }
+  }
+}

--- a/skills/mexc-openapi-skill/references/usage-patterns.md
+++ b/skills/mexc-openapi-skill/references/usage-patterns.md
@@ -1,0 +1,77 @@
+# MEXC Spot API Skill - Usage Patterns
+
+## Link Setup
+
+```bash
+command -v mexc-openapi-cli
+uxc link mexc-openapi-cli https://api.mexc.com \
+  --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/mexc-openapi-skill/references/mexc-spot.openapi.json
+mexc-openapi-cli -h
+```
+
+## Auth Setup
+
+```bash
+uxc auth credential set mexc-spot \
+  --auth-type api_key \
+  --field api_key=env:MEXC_API_KEY \
+  --field secret_key=env:MEXC_SECRET_KEY
+
+SIGNER='{"kind":"hmac_query_v1","algorithm":"hmac_sha256","signing_field":"secret_key","key_field":"api_key","key_placement":"header","key_name":"X-MEXC-APIKEY","signature_param":"signature","signature_encoding":"hex","timestamp_param":"timestamp","timestamp_unit":"milliseconds","canonicalization":{"mode":"preserve_order"}}'
+
+uxc auth binding add \
+  --id mexc-spot \
+  --host api.mexc.com \
+  --path-prefix /api/v3 \
+  --scheme https \
+  --credential mexc-spot \
+  --signer-json "$SIGNER" \
+  --priority 100
+```
+
+Validate the binding:
+
+```bash
+uxc auth binding match https://api.mexc.com/api/v3/account
+```
+
+## Read Examples
+
+```bash
+# Read ticker
+mexc-openapi-cli get:/api/v3/ticker/price symbol=BTCUSDT
+
+# Read depth
+mexc-openapi-cli get:/api/v3/depth symbol=BTCUSDT limit=20
+
+# Read account
+mexc-openapi-cli get:/api/v3/account recvWindow=5000
+
+# Read open orders
+mexc-openapi-cli get:/api/v3/openOrders symbol=BTCUSDT recvWindow=5000
+
+# Read one order
+mexc-openapi-cli get:/api/v3/order symbol=BTCUSDT orderId=123456 recvWindow=5000
+```
+
+## Write Examples
+
+```bash
+# Place an order
+mexc-openapi-cli post:/api/v3/order \
+  symbol=BTCUSDT \
+  side=BUY \
+  type=LIMIT \
+  quantity=0.001 \
+  price=25000 \
+  timeInForce=GTC \
+  recvWindow=5000
+
+# Cancel an order
+mexc-openapi-cli delete:/api/v3/order symbol=BTCUSDT orderId=123456 recvWindow=5000
+```
+
+## Fallback Equivalence
+
+- `mexc-openapi-cli <operation> ...` is equivalent to
+  `uxc https://api.mexc.com --schema-url <mexc_spot_openapi_schema> <operation> ...`.

--- a/skills/mexc-openapi-skill/scripts/validate.sh
+++ b/skills/mexc-openapi-skill/scripts/validate.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/mexc-openapi-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+USAGE_FILE="${SKILL_DIR}/references/usage-patterns.md"
+SCHEMA_FILE="${SKILL_DIR}/references/mexc-spot.openapi.json"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd jq
+need_cmd rg
+
+for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}" "${SCHEMA_FILE}"; do
+  [[ -f "${file}" ]] || fail "missing required file: ${file}"
+done
+
+jq -e '.openapi and .paths and .components' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'invalid OpenAPI schema JSON or missing .openapi/.paths/.components'
+jq -e '.paths["/api/v3/ticker/price"] and .paths["/api/v3/account"] and .paths["/api/v3/order"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing expected MEXC paths'
+
+rg -q '^name:\s*mexc-openapi-skill\s*$' "${SKILL_FILE}" || fail 'invalid skill name'
+rg -q 'command -v mexc-openapi-cli' "${SKILL_FILE}" || fail 'missing link-first command check'
+rg -q 'uxc link mexc-openapi-cli https://api.mexc.com --schema-url ' "${SKILL_FILE}" || fail 'missing fixed link create command with schema-url'
+rg -q -- '--signer-json' "${SKILL_FILE}" "${USAGE_FILE}" || fail 'missing signer-json guidance'
+rg -q 'X-MEXC-APIKEY' "${SKILL_FILE}" "${USAGE_FILE}" || fail 'missing API key header guidance'
+rg -q 'high-risk' "${SKILL_FILE}" || fail 'missing write guardrail'
+rg -q 'uxc auth binding match https://api.mexc.com/api/v3/account' "${SKILL_FILE}" || fail 'missing binding match example'
+rg -q '^\s*display_name:\s*"MEXC Spot"\s*$' "${OPENAI_FILE}" || fail 'missing display_name'
+rg -q '^\s*default_prompt:\s*".*\$mexc-openapi-skill.*"\s*$' "${OPENAI_FILE}" || fail 'default_prompt must mention $mexc-openapi-skill'
+
+echo "skills/mexc-openapi-skill validation passed"


### PR DESCRIPTION
## What
- add skills/mexc-openapi-skill skill package
- document auth, scope, and guardrails for the provider
- include usage patterns, OpenAI metadata, and validate script

## Why
- add provider coverage for exchange MCP/API integrations tracked in #168
- keep delivery isolated to one provider / one PR

## How
- add a dedicated skill directory under skills/
- use curated schema or MCP endpoint guidance appropriate for the provider
- keep scope intentionally narrow for v1

## Testing
- bash skills/mexc-openapi-skill/scripts/validate.sh
- cargo build -q --bin uxc

Closes #257
