### PR TITLE
fix: support local schema files for schema-url

### DIFF
--- a/src/adapters/openapi.rs
+++ b/src/adapters/openapi.rs
@@ -221,7 +221,15 @@ impl OpenAPIAdapter {
             return Ok(Some(path_like.to_path_buf()));
         }
 
-        if let Ok(parsed) = url::Url::parse(schema_url) {
+        let treat_as_url = schema_url.contains("://")
+            || schema_url.starts_with("file:")
+            || schema_url.starts_with("http:")
+            || schema_url.starts_with("https:");
+
+        if treat_as_url {
+            let parsed = url::Url::parse(schema_url).with_context(|| {
+                format!("Invalid schema URL '{}': expected a valid URL", schema_url)
+            })?;
             return match parsed.scheme() {
                 "http" | "https" => Ok(None),
                 "file" => parsed.to_file_path().map(Some).map_err(|_| {
@@ -1651,6 +1659,20 @@ mod tests {
             .to_string();
 
         let adapter = OpenAPIAdapter::new().with_schema_url_override(Some(schema_url));
+
+        assert!(adapter.can_handle("https://example.com").await.unwrap());
+        let schema = adapter.fetch_schema("https://example.com").await.unwrap();
+        assert_eq!(schema["openapi"], "3.0.0");
+    }
+
+    #[tokio::test]
+    async fn schema_url_override_treats_colon_filename_as_local_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let schema_path = temp_dir.path().join("schema:v1.json");
+        std::fs::write(&schema_path, openapi_doc()).unwrap();
+
+        let adapter =
+            OpenAPIAdapter::new().with_schema_url_override(Some(schema_path.display().to_string()));
 
         assert!(adapter.can_handle("https://example.com").await.unwrap());
         let schema = adapter.fetch_schema("https://example.com").await.unwrap();

--- a/tests/cli_help_regression_test.rs
+++ b/tests/cli_help_regression_test.rs
@@ -1228,7 +1228,7 @@ fn schema_url_override_supports_local_schema_file() {
 
 #[test]
 #[serial]
-fn schema_url_override_supports_file_url_schema_file() {
+fn schema_url_override_supports_file_url_schema() {
     let mut target_server = mockito::Server::new();
     let _call = target_server
         .mock("GET", "/pets")


### PR DESCRIPTION
## What
- add local OpenAPI schema loading for `--schema-url`
- support both filesystem paths and `file://` URLs
- add adapter and CLI regression coverage for local schema overrides

## Why
- local testing is awkward when `--schema-url` only works with remote URLs
- some users do not want to publish their schema documents just to use `uxc`

## How
- route schema loading through a shared helper that reads either local files or remote HTTP(S) URLs
- keep remote schema discovery behavior unchanged for non-override flows
- return clearer errors for invalid local file schema inputs

## Testing
- `cargo fmt --all`
- `cargo test schema_url_override_supports_file_url_schema -- --nocapture`
- `cargo test schema_url_override_supports_local_schema_file -- --nocapture`
