### PR TITLE
feat: add Feishu long-connection subscribe support

### DIFF
--- a/docs/subscribe-validation-status.md
+++ b/docs/subscribe-validation-status.md
@@ -294,14 +294,29 @@ Skill:
 
 - [skills/feishu-openapi-skill/SKILL.md](../skills/feishu-openapi-skill/SKILL.md)
 
-Current assessment:
+Validation result:
 
-- current skill scope is request/response only
-- platform event delivery exists, but no `uxc subscribe` validation has been completed yet
+- Feishu `app_id + app_secret` bootstrap through `uxc auth bootstrap` succeeded
+- live request/response IM calls succeeded after bootstrap-managed tenant token refresh
+- built-in `feishu_long_connection` transport succeeded against the live Feishu long-connection bootstrap endpoint
+- sink emitted `open` with the temporary Feishu WebSocket URL
+- real `im.message.receive_v1` events were delivered through the subscription job
+- live text messages sent to the bot in a `p2p` chat appeared as `data` events in the sink
+
+Observed runtime notes:
+
+- the transport opens a fresh temporary WebSocket URL from `/callback/ws/endpoint` on each connect attempt
+- event frames arrive as Feishu protobuf binary frames, not plain text JSON WebSocket messages
+- the runtime sends binary event acknowledgements and periodic ping control frames
+- validated live payloads included:
+  - `header.event_type = "im.message.receive_v1"`
+  - `event.message.chat_type = "p2p"`
+  - `event.message.message_type = "text"`
+  - `event.message.content`
 
 Status:
 
-- **not yet validated for subscribe**
+- **validated successfully**
 
 #### DingTalk Messaging
 
@@ -328,6 +343,7 @@ Current real-world status is uneven by provider:
 - Bitquery now proves the GraphQL WebSocket runtime works against a live provider, but provider-specific selection shape still matters
 - GoldRush shows that MCP tools and MCP resource subscriptions must be treated separately
 - Matrix now validates the room-scoped `/sync` polling path; remaining UX work is mainly around linked-command ergonomics
+- Feishu now validates a provider-aware long-connection transport for IM message intake
 
 ## Recommended Next Validation Order
 
@@ -341,4 +357,5 @@ Current documentation status after validation work:
 - Telegram skill can now describe daemon-backed polling subscribe as validated behavior
 - Matrix skill can now describe direct daemon-backed `/sync` polling subscribe as validated behavior
 - Bitquery skill can now describe `subscription/EVM` as validated, while still warning that subscriptions need an explicit `_select` and provider-appropriate shape
+- Feishu skill can now describe `feishu-long-connection` subscribe as validated behavior
 - GoldRush skill should not imply that current live MCP resources are subscribable unless upstream capability changes

--- a/skills/feishu-openapi-skill/SKILL.md
+++ b/skills/feishu-openapi-skill/SKILL.md
@@ -30,7 +30,6 @@ This skill covers an IM-focused request/response surface:
 
 This skill does **not** cover:
 
-- inbound event subscription receiver runtime
 - docs, bitable, approval, or non-IM product families
 - the full Feishu or Lark Open Platform surface
 
@@ -40,10 +39,16 @@ Feishu and Lark expose event-delivery models beyond plain request/response APIs,
 
 Current `uxc subscribe` status:
 
-- this skill is validated only for request/response IM operations
-- inbound event/message intake is **not** currently validated through `uxc subscribe`
+- request/response IM operations are validated
+- inbound message intake is validated through the built-in `feishu-long-connection` transport
+- live validation confirmed real `im.message.receive_v1` events delivered into the subscribe sink for a `p2p` bot chat
 
-Treat Feishu / Lark as future subscribe targets that will need provider-aware session behavior beyond this v1 OpenAPI wrapper.
+Important runtime notes:
+
+- `feishu-long-connection` is a provider-aware transport inside `uxc subscribe`; it is not a plain raw WebSocket stream
+- the runtime opens a temporary WebSocket URL from `/callback/ws/endpoint`
+- frames are protobuf binary messages, not text JSON
+- the runtime sends required event acknowledgements and ping control frames automatically
 
 ## Endpoint Choice
 
@@ -87,6 +92,8 @@ uxc auth binding add \
 ```
 
 For Lark, use the same bootstrap shape against the Lark host and bind the credential to `open.larksuite.com`.
+
+To use long-connection subscribe, the credential still needs `app_id` and `app_secret` fields because the transport opens its own temporary event URL outside the normal bearer-token request path.
 
 Manual fallback if you already have a tenant token:
 
@@ -169,6 +176,10 @@ uxc auth binding match https://open.feishu.cn/open-apis
    - positional JSON:
      `feishu-openapi-cli post:/im/v1/messages receive_id_type=chat_id '{"receive_id":"oc_xxx","msg_type":"text","content":"{\"text\":\"Hello from UXC\"}"}'`
 
+5. For inbound message intake, use `uxc subscribe` directly:
+   - `uxc subscribe start https://open.feishu.cn/open-apis --transport feishu-long-connection --auth feishu-tenant --sink file:$HOME/.uxc/subscriptions/feishu.ndjson`
+   - send a bot-visible message, then inspect the sink for `header.event_type = "im.message.receive_v1"`
+
 ## Operation Groups
 
 ### Chat Reads
@@ -194,10 +205,11 @@ uxc auth binding match https://open.feishu.cn/open-apis
 - Keep automation on the JSON output envelope; do not use `--text`.
 - Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
 - Prefer `uxc auth bootstrap` over manual token management. Manual `tenant_access_token` setup is still supported as a fallback.
+- `feishu-long-connection` requires the app credential fields `app_id` and `app_secret`; a plain bearer-only credential is not enough for event intake.
 - `post:/im/v1/messages` requires the `receive_id_type` query parameter and the body `content` field is a JSON-encoded string, not a nested JSON object.
 - `post:/im/v1/messages/{message_id}/reply` is for explicit replies to an existing message. Treat it as a high-risk write.
 - History reads only return chats and messages visible to the bot/app configuration. Auth success does not imply access to every chat.
-- Event subscription and callback verification are intentionally out of scope for this v1 skill.
+- Long-connection message intake is validated for Feishu bot chats; webhook-style callbacks and non-IM products are still out of scope.
 - `feishu-openapi-cli <operation> ...` is equivalent to `uxc https://open.feishu.cn/open-apis --schema-url <feishu_openapi_schema> <operation> ...`.
 
 ## References

--- a/skills/feishu-openapi-skill/references/usage-patterns.md
+++ b/skills/feishu-openapi-skill/references/usage-patterns.md
@@ -33,6 +33,8 @@ uxc auth bootstrap set feishu-tenant \
 uxc auth bootstrap info feishu-tenant
 ```
 
+For long-connection subscribe, keep this same credential because the transport needs the stored `app_id` and `app_secret` fields to open a fresh temporary WebSocket URL.
+
 Manual fallback:
 
 For Feishu tenants:
@@ -103,6 +105,30 @@ feishu-openapi-cli post:/im/v1/messages receive_id_type=open_id '{"receive_id":"
 # Reply to a message
 feishu-openapi-cli post:/im/v1/messages/{message_id}/reply '{"message_id":"om_xxx","content":"{\"text\":\"Reply from UXC\"}","msg_type":"text"}'
 ```
+
+## Long-Connection Subscribe
+
+Use `uxc subscribe` directly for inbound Feishu/Lark message intake:
+
+```bash
+uxc subscribe start https://open.feishu.cn/open-apis \
+  --transport feishu-long-connection \
+  --auth feishu-tenant \
+  --sink file:$HOME/.uxc/subscriptions/feishu.ndjson
+```
+
+What to expect:
+
+- the sink starts with an `open` event containing the temporary Feishu WebSocket URL
+- inbound bot-visible messages arrive as `data` events
+- real Feishu IM events use `data.header.event_type`, for example:
+  - `im.message.receive_v1`
+
+Important notes:
+
+- this transport is provider-aware; it is not a generic raw WebSocket JSON stream
+- the runtime handles temporary URL bootstrap, protobuf binary frames, event acknowledgements, and ping control frames automatically
+- use a credential that still has `app_id` and `app_secret` fields, even if request/response calls are already using bootstrap-managed bearer auth
 
 ## Fallback Equivalence
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -13,6 +13,11 @@ use crate::subscription_discord::{
     DiscordGatewayBotResponse, DiscordGatewayHandler, DiscordGatewayRuntimeConfig,
     DiscordIdentifyProperties, DISCORD_DEFAULT_MESSAGE_INTENTS,
 };
+use crate::subscription_feishu::{
+    derive_feishu_ws_config_endpoint, parse_feishu_long_connection_open_response,
+    resolve_feishu_long_connection_runtime_config, FeishuLongConnectionHandler,
+    FeishuLongConnectionOpenResponse,
+};
 use crate::subscription_graphql::{
     derive_graphql_websocket_endpoint, graphql_transport_init_message, GraphQLProfileFallback,
     GraphQLSubscriptionConfig, GraphQLSubscriptionHandler, GraphQLWebSocketProfile,
@@ -182,6 +187,7 @@ pub enum SubscriptionTransportHint {
     Websocket,
     DiscordGateway,
     SlackSocketMode,
+    FeishuLongConnection,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -804,6 +810,14 @@ fn resolve_stream_subscription_protocol(request: &SubscribeStartRequest) -> Resu
                 }
                 return Ok("slack_socket_mode".to_string());
             }
+            SubscriptionTransportHint::FeishuLongConnection => {
+                if !lower.starts_with("http://") && !lower.starts_with("https://") {
+                    bail!(
+                        "feishu-long-connection transport requires an http:// or https:// Feishu/Lark API endpoint"
+                    );
+                }
+                return Ok("feishu_long_connection".to_string());
+            }
         }
     }
 
@@ -1005,6 +1019,22 @@ impl SubscriptionManager {
             if !request.subprotocols.is_empty() || !request.initial_text_frames.is_empty() {
                 bail!("slack-socket-mode transport manages its own websocket setup and does not accept --subprotocol or --init-frame");
             }
+        } else if matches!(
+            request.transport_hint,
+            Some(SubscriptionTransportHint::FeishuLongConnection)
+        ) {
+            if request.operation_id.is_some() {
+                bail!("feishu-long-connection transport cannot be combined with an operation_id");
+            }
+            if request.resource_uri.is_some() {
+                bail!("feishu-long-connection transport cannot be combined with --resource-uri");
+            }
+            if request.mode != SubscriptionMode::Stream {
+                bail!("feishu-long-connection transport is only valid with stream mode");
+            }
+            if !request.subprotocols.is_empty() || !request.initial_text_frames.is_empty() {
+                bail!("feishu-long-connection transport manages its own websocket setup and does not accept --subprotocol or --init-frame");
+            }
         } else if !request.subprotocols.is_empty() || !request.initial_text_frames.is_empty() {
             bail!("websocket subprotocols and init frames require websocket transport");
         }
@@ -1013,6 +1043,7 @@ impl SubscriptionManager {
             && !matches!(
                 request.transport_hint,
                 Some(SubscriptionTransportHint::DiscordGateway)
+                    | Some(SubscriptionTransportHint::FeishuLongConnection)
             )
         {
             bail!("subscribe start cannot accept args without an operation_id");
@@ -2431,6 +2462,15 @@ async fn run_stream_subscription_job(
         return run_slack_socket_mode_subscription_job(job_id, request, sink_path, view, stop_rx)
             .await;
     }
+    if matches!(
+        request.transport_hint,
+        Some(SubscriptionTransportHint::FeishuLongConnection)
+    ) {
+        return run_feishu_long_connection_subscription_job(
+            job_id, request, sink_path, view, stop_rx,
+        )
+        .await;
+    }
 
     if request.operation_id.is_some() {
         if request
@@ -2667,6 +2707,49 @@ async fn open_slack_socket_mode_websocket_url(request: &SubscribeStartRequest) -
     let body = response.json::<Value>().await?;
     let parsed = parse_socket_mode_open_response(&body)?;
     Ok(parsed.websocket_url)
+}
+
+async fn open_feishu_long_connection_websocket_url(
+    request: &SubscribeStartRequest,
+) -> Result<FeishuLongConnectionOpenResponse> {
+    let auth_profile = auth::resolve_auth_for_endpoint(
+        &request.endpoint,
+        request.options.auth.clone(),
+    )?
+    .ok_or_else(|| {
+        anyhow!("Feishu long-connection requires an auth credential with app_id/app_secret fields")
+    })?;
+    let runtime_config = resolve_feishu_long_connection_runtime_config(&auth_profile)?;
+    let open_endpoint = derive_feishu_ws_config_endpoint(&request.endpoint)?;
+    let client = crate::http_client::build_resilient_http_client(
+        Duration::from_secs(10),
+        "Feishu long-connection open",
+    )?;
+    let response = client
+        .post(&open_endpoint)
+        .header("Content-Type", "application/json; charset=utf-8")
+        .header("locale", "zh")
+        .json(&json!({
+            "AppID": runtime_config.app_id,
+            "AppSecret": runtime_config.app_secret,
+        }))
+        .send()
+        .await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "<failed to read response body>".to_string());
+        let body = truncate_error_body(&body, 512);
+        bail!(
+            "Feishu long-connection open request failed with status {}: {}",
+            status,
+            body
+        );
+    }
+    let body = response.json::<Value>().await?;
+    parse_feishu_long_connection_open_response(&body)
 }
 
 fn truncate_error_body(body: &str, max_chars: usize) -> String {
@@ -2910,6 +2993,155 @@ async fn run_slack_socket_mode_subscription_job(
                 if wait_for_stop_or_timeout(&mut stop_rx, Duration::from_secs(delay_secs)).await {
                     close_subscription_as_stopped(&mut sink, &view, &mut seq, "slack_socket_mode")
                         .await?;
+                    return Ok(());
+                }
+                delay_secs =
+                    (delay_secs.saturating_mul(2)).min(SUBSCRIPTION_MAX_RECONNECT_DELAY_SECS);
+            }
+        }
+    }
+}
+
+async fn run_feishu_long_connection_subscription_job(
+    _job_id: &str,
+    request: &SubscribeStartRequest,
+    sink_path: PathBuf,
+    view: Arc<Mutex<SubscriptionJobView>>,
+    mut stop_rx: watch::Receiver<bool>,
+) -> Result<()> {
+    let mut sink = open_subscription_sink(&sink_path).await?;
+    let mut seq = 0u64;
+    let mut delay_secs = SUBSCRIPTION_INITIAL_RECONNECT_DELAY_SECS;
+
+    loop {
+        if *stop_rx.borrow() {
+            close_subscription_as_stopped(&mut sink, &view, &mut seq, "feishu_long_connection")
+                .await?;
+            return Ok(());
+        }
+
+        let open = match open_feishu_long_connection_websocket_url(request).await {
+            Ok(open) => open,
+            Err(err) => {
+                let message = err.to_string();
+                append_subscription_event(
+                    &mut sink,
+                    &view,
+                    &mut seq,
+                    "feishu_long_connection",
+                    "error",
+                    None,
+                    Some(json!({ "message": message })),
+                )
+                .await?;
+                update_subscription_view(&view, Some("reconnecting"), Some(message), true).await;
+                append_subscription_event(
+                    &mut sink,
+                    &view,
+                    &mut seq,
+                    "feishu_long_connection",
+                    "reconnect",
+                    None,
+                    Some(json!({ "delay_secs": delay_secs, "phase": "open_url" })),
+                )
+                .await?;
+                if wait_for_stop_or_timeout(&mut stop_rx, Duration::from_secs(delay_secs)).await {
+                    close_subscription_as_stopped(
+                        &mut sink,
+                        &view,
+                        &mut seq,
+                        "feishu_long_connection",
+                    )
+                    .await?;
+                    return Ok(());
+                }
+                delay_secs =
+                    (delay_secs.saturating_mul(2)).min(SUBSCRIPTION_MAX_RECONNECT_DELAY_SECS);
+                continue;
+            }
+        };
+
+        let config = WebSocketRuntimeConfig {
+            endpoint: open.websocket_url.clone(),
+            auth_profile: None,
+            subprotocols: Vec::new(),
+            initial_text_frames: Vec::new(),
+            first_message_timeout_secs: None,
+            initial_reconnect_delay_secs: SUBSCRIPTION_INITIAL_RECONNECT_DELAY_SECS,
+            max_reconnect_delay_secs: SUBSCRIPTION_MAX_RECONNECT_DELAY_SECS,
+        };
+        let mut handler =
+            FeishuLongConnectionHandler::new(open.service_id, open.ping_interval_secs);
+
+        let result = {
+            let mut observer = DaemonWebSocketObserver {
+                sink: &mut sink,
+                view: &view,
+                seq: &mut seq,
+                source_kind: "feishu_long_connection",
+            };
+            subscription_websocket::run_websocket_subscription_session_once(
+                &config,
+                &mut handler,
+                &mut observer,
+                &mut stop_rx,
+            )
+            .await
+        };
+
+        match result {
+            Ok(()) => return Ok(()),
+            Err(WebSocketRunError::Fatal(err)) => {
+                append_subscription_event(
+                    &mut sink,
+                    &view,
+                    &mut seq,
+                    "feishu_long_connection",
+                    "error",
+                    None,
+                    Some(json!({ "message": err.to_string() })),
+                )
+                .await?;
+                return Err(err);
+            }
+            Err(WebSocketRunError::Retry(err)) => {
+                let message = err.to_string();
+                append_subscription_event(
+                    &mut sink,
+                    &view,
+                    &mut seq,
+                    "feishu_long_connection",
+                    "error",
+                    None,
+                    Some(json!({ "message": message })),
+                )
+                .await?;
+                update_subscription_view(&view, Some("reconnecting"), Some(err.to_string()), true)
+                    .await;
+                append_subscription_event(
+                    &mut sink,
+                    &view,
+                    &mut seq,
+                    "feishu_long_connection",
+                    "reconnect",
+                    None,
+                    Some(json!({
+                        "delay_secs": delay_secs,
+                        "ping_interval_secs": open.ping_interval_secs,
+                        "reconnect_count": open.reconnect_count,
+                        "reconnect_interval_secs": open.reconnect_interval_secs,
+                        "reconnect_nonce_secs": open.reconnect_nonce_secs,
+                    })),
+                )
+                .await?;
+                if wait_for_stop_or_timeout(&mut stop_rx, Duration::from_secs(delay_secs)).await {
+                    close_subscription_as_stopped(
+                        &mut sink,
+                        &view,
+                        &mut seq,
+                        "feishu_long_connection",
+                    )
+                    .await?;
                     return Ok(());
                 }
                 delay_secs =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod output;
 pub mod protocol;
 pub mod schema_mapping;
 pub mod subscription_discord;
+pub mod subscription_feishu;
 pub mod subscription_graphql;
 pub mod subscription_jsonrpc;
 pub mod subscription_poll;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod http_client;
 mod output;
 mod schema_mapping;
 mod subscription_discord;
+mod subscription_feishu;
 mod subscription_graphql;
 mod subscription_jsonrpc;
 mod subscription_poll;
@@ -62,6 +63,7 @@ enum SubscribeTransportArg {
     Websocket,
     DiscordGateway,
     SlackSocketMode,
+    FeishuLongConnection,
 }
 
 #[derive(Parser)]
@@ -1702,6 +1704,7 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
                 "uxc subscribe start wss://stream.binance.com:9443/ws/btcusdt@trade --transport websocket --sink file:/tmp/binance.ndjson".to_string(),
                 "uxc subscribe start https://discord.com/api/v10 --transport discord-gateway --auth discord-bot --sink file:/tmp/discord.ndjson".to_string(),
                 "uxc subscribe start https://slack.com/api --transport slack-socket-mode --auth slack-app --sink file:/tmp/slack.ndjson".to_string(),
+                "uxc subscribe start https://open.feishu.cn/open-apis --transport feishu-long-connection --auth feishu-tenant --sink file:/tmp/feishu.ndjson".to_string(),
                 "uxc subscribe start https://example.com/graphql subscription/messageAdded '{\"roomId\":\"abc\"}' --sink file:/tmp/graphql.ndjson".to_string(),
                 "uxc subscribe start wss://example.com/ws eth_subscribe '{\"params\":[\"newHeads\"]}' --sink file:/tmp/heads.ndjson".to_string(),
                 "uxc subscribe start https://example.com/api get:/events --mode poll --poll-config '{\"interval_secs\":5,\"extract_items_pointer\":\"/items\",\"request_cursor_arg\":\"cursor\",\"response_cursor_pointer\":\"/next_cursor\",\"checkpoint_strategy\":{\"type\":\"cursor_only\"}}' --sink file:/tmp/poll.ndjson".to_string(),
@@ -1716,13 +1719,14 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
         ["subscribe", "start"] => HelpData {
             path: "uxc subscribe start".to_string(),
             about: "Start a background subscription job".to_string(),
-            usage: "uxc subscribe start <endpoint> [<operation_id> [key=value ... | '{...}']] --sink file:<path> [--ephemeral] [--transport websocket|discord-gateway|slack-socket-mode] [--subprotocol <value> ...] [--init-frame <text-or-json> ...] [--mode <stream|poll>] [--poll-config <json>] [--resource-uri <uri>]".to_string(),
+            usage: "uxc subscribe start <endpoint> [<operation_id> [key=value ... | '{...}']] --sink file:<path> [--ephemeral] [--transport websocket|discord-gateway|slack-socket-mode|feishu-long-connection] [--subprotocol <value> ...] [--init-frame <text-or-json> ...] [--mode <stream|poll>] [--poll-config <json>] [--resource-uri <uri>]".to_string(),
             commands: vec![],
             notes: vec![
                 "For raw HTTP streams, omit <operation_id> and use <endpoint> as the final stream URL.".to_string(),
                 "For generic raw WebSocket streams, pass --transport websocket plus a ws:// or wss:// endpoint; --subprotocol and --init-frame are optional and can be repeated independently.".to_string(),
                 "For Discord Gateway, pass --transport discord-gateway plus a Discord REST API base such as https://discord.com/api/v10 and a bot token via --auth; optional config may be provided as positional JSON or via --input-json to set intents, os, browser, or device.".to_string(),
                 "For Slack Socket Mode, pass --transport slack-socket-mode plus a Slack Web API base endpoint such as https://slack.com/api and an app-level xapp token via --auth; the runtime opens a fresh temporary WebSocket URL on each connect attempt.".to_string(),
+                "For Feishu or Lark long connection, pass --transport feishu-long-connection plus an Open Platform base endpoint such as https://open.feishu.cn/open-apis and a credential whose fields include app_id and app_secret; the runtime opens a fresh temporary WebSocket URL on each connect attempt.".to_string(),
                 "Raw WebSocket sink events preserve frame type in meta: JSON text frames populate data, plain text frames populate meta.text, and binary frames populate meta.base64.".to_string(),
                 "For GraphQL subscriptions, pass subscription/<field>; the runtime derives ws(s) from the HTTP endpoint, reuses auth/cache behavior, and automatically falls back between modern and legacy GraphQL websocket profiles.".to_string(),
                 "For JSON-RPC pubsub, pass a ws:// or wss:// endpoint plus a method ending in _subscribe; send raw JSON-RPC params through '{\"params\":...}'.".to_string(),
@@ -1737,6 +1741,7 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
                 "uxc subscribe start wss://ws.okx.com:8443/ws/v5/public --transport websocket --init-frame '{\"op\":\"subscribe\",\"args\":[{\"channel\":\"tickers\",\"instId\":\"BTC-USDT\"}]}' --sink file:/tmp/okx.ndjson".to_string(),
                 "uxc subscribe start https://discord.com/api/v10 --transport discord-gateway --auth discord-bot '{\"intents\":37377}' --sink file:/tmp/discord.ndjson".to_string(),
                 "uxc subscribe start https://slack.com/api --transport slack-socket-mode --auth slack-app --sink file:/tmp/slack.ndjson".to_string(),
+                "uxc subscribe start https://open.feishu.cn/open-apis --transport feishu-long-connection --auth feishu-tenant --sink file:/tmp/feishu.ndjson".to_string(),
                 "uxc subscribe start https://example.com/graphql subscription/messageAdded '{\"roomId\":\"abc\",\"_select\":\"id body\"}' --sink file:/tmp/graphql.ndjson".to_string(),
                 "uxc subscribe start wss://example.com/ws eth_subscribe '{\"params\":[\"logs\",{\"address\":\"0xabc\"}]}' --sink file:/tmp/logs.ndjson".to_string(),
                 "uxc subscribe start https://example.com/api get:/events --mode poll --poll-config '{\"interval_secs\":5,\"extract_items_pointer\":\"/items\",\"checkpoint_strategy\":{\"type\":\"item_key\",\"item_key_pointer\":\"/id\"}}' --sink file:/tmp/events.ndjson".to_string(),
@@ -3684,6 +3689,9 @@ async fn handle_subscribe_command(
                 SubscribeTransportArg::SlackSocketMode => {
                     daemon::SubscriptionTransportHint::SlackSocketMode
                 }
+                SubscribeTransportArg::FeishuLongConnection => {
+                    daemon::SubscriptionTransportHint::FeishuLongConnection
+                }
             });
             let mut transport_operation_id = operation_id.clone();
             let mut transport_input_json = input_json.clone();
@@ -3793,6 +3801,32 @@ async fn handle_subscribe_command(
                     .into());
                 }
             }
+            if matches!(
+                transport_hint,
+                Some(daemon::SubscriptionTransportHint::FeishuLongConnection)
+            ) {
+                if operation_id.is_some() {
+                    return Err(UxcError::InvalidArguments(
+                        "--transport feishu-long-connection cannot be combined with an operation_id"
+                            .to_string(),
+                    )
+                    .into());
+                }
+                if resource_uri.is_some() {
+                    return Err(UxcError::InvalidArguments(
+                        "--transport feishu-long-connection cannot be combined with --resource-uri"
+                            .to_string(),
+                    )
+                    .into());
+                }
+                if !matches!(mode, SubscribeModeArg::Stream) {
+                    return Err(UxcError::InvalidArguments(
+                        "--transport feishu-long-connection is only valid with --mode stream"
+                            .to_string(),
+                    )
+                    .into());
+                }
+            }
             let (normalized_args, normalized_input_json) = match transport_operation_id.as_ref() {
                 Some(op) => {
                     let mut explicit_args = Vec::new();
@@ -3831,6 +3865,25 @@ async fn handle_subscribe_command(
                             transport_input_json.clone(),
                             &positional,
                         )?
+                    } else if matches!(
+                        transport_hint,
+                        Some(daemon::SubscriptionTransportHint::FeishuLongConnection)
+                    ) {
+                        let mut explicit_args = Vec::new();
+                        let mut positional = Vec::new();
+                        for arg in args {
+                            if arg.contains('=') {
+                                explicit_args.push(arg.clone());
+                            } else {
+                                positional.push(arg.clone());
+                            }
+                        }
+                        normalize_operation_inputs(
+                            "feishu-long-connection",
+                            explicit_args,
+                            transport_input_json.clone(),
+                            &positional,
+                        )?
                     } else if transport_input_json.is_some() || !args.is_empty() {
                         return Err(UxcError::InvalidArguments(
                             "subscribe start only accepts operation arguments when <operation_id> is provided".to_string(),
@@ -3859,6 +3912,19 @@ async fn handle_subscribe_command(
                     parse_arguments(normalized_args, normalized_input_json).map_err(|err| {
                         UxcError::InvalidArguments(format!(
                             "Invalid arguments for subscribe transport 'discord-gateway': {}",
+                            err
+                        ))
+                    })?,
+                )
+            } else if matches!(
+                transport_hint,
+                Some(daemon::SubscriptionTransportHint::FeishuLongConnection)
+            ) && (normalized_input_json.is_some() || !normalized_args.is_empty())
+            {
+                Some(
+                    parse_arguments(normalized_args, normalized_input_json).map_err(|err| {
+                        UxcError::InvalidArguments(format!(
+                            "Invalid arguments for subscribe transport 'feishu-long-connection': {}",
                             err
                         ))
                     })?,

--- a/src/subscription_discord.rs
+++ b/src/subscription_discord.rs
@@ -167,6 +167,7 @@ impl DiscordGatewayHandler {
                     "message_type": "heartbeat_timeout",
                 })),
                 outbound_text_frames: Vec::new(),
+                outbound_binary_frames: Vec::new(),
                 stop_reason: Some("heartbeat_timeout".to_string()),
             });
         }
@@ -184,6 +185,7 @@ impl DiscordGatewayHandler {
                 "d": self.sequence
             })
             .to_string()],
+            outbound_binary_frames: Vec::new(),
             stop_reason: None,
         })
     }
@@ -270,6 +272,7 @@ impl WebSocketSessionHandler for DiscordGatewayHandler {
                     data: Some(value),
                     meta: Some(meta),
                     outbound_text_frames: outbound,
+                    outbound_binary_frames: Vec::new(),
                     stop_reason: None,
                 })
             }
@@ -296,6 +299,7 @@ impl WebSocketSessionHandler for DiscordGatewayHandler {
                     data: Some(value),
                     meta: Some(meta),
                     outbound_text_frames: Vec::new(),
+                    outbound_binary_frames: Vec::new(),
                     stop_reason: None,
                 })
             }
@@ -310,6 +314,7 @@ impl WebSocketSessionHandler for DiscordGatewayHandler {
                         "d": self.sequence
                     })
                     .to_string()],
+                    outbound_binary_frames: Vec::new(),
                     stop_reason: None,
                 })
             }
@@ -321,6 +326,7 @@ impl WebSocketSessionHandler for DiscordGatewayHandler {
                     data: None,
                     meta: Some(meta),
                     outbound_text_frames: Vec::new(),
+                    outbound_binary_frames: Vec::new(),
                     stop_reason: None,
                 })
             }
@@ -331,6 +337,7 @@ impl WebSocketSessionHandler for DiscordGatewayHandler {
                     data: Some(value),
                     meta: Some(meta),
                     outbound_text_frames: Vec::new(),
+                    outbound_binary_frames: Vec::new(),
                     stop_reason: Some("gateway_reconnect".to_string()),
                 })
             }
@@ -348,6 +355,7 @@ impl WebSocketSessionHandler for DiscordGatewayHandler {
                     data: Some(value),
                     meta: Some(meta),
                     outbound_text_frames: Vec::new(),
+                    outbound_binary_frames: Vec::new(),
                     stop_reason: Some("invalid_session".to_string()),
                 })
             }
@@ -356,6 +364,7 @@ impl WebSocketSessionHandler for DiscordGatewayHandler {
                 data: Some(value),
                 meta: Some(meta),
                 outbound_text_frames: Vec::new(),
+                outbound_binary_frames: Vec::new(),
                 stop_reason: None,
             }),
         }
@@ -372,6 +381,7 @@ impl WebSocketSessionHandler for DiscordGatewayHandler {
                 "base64": base64::engine::general_purpose::STANDARD.encode(bytes),
             })),
             outbound_text_frames: Vec::new(),
+            outbound_binary_frames: Vec::new(),
             stop_reason: None,
         })
     }
@@ -400,6 +410,7 @@ impl WebSocketSessionHandler for DiscordGatewayHandler {
     async fn on_stop_requested(&mut self) -> Result<WebSocketStopOutput> {
         Ok(WebSocketStopOutput {
             outbound_text_frames: Vec::new(),
+            outbound_binary_frames: Vec::new(),
             stop_reason: Some("stopped".to_string()),
         })
     }

--- a/src/subscription_feishu.rs
+++ b/src/subscription_feishu.rs
@@ -1,0 +1,547 @@
+use crate::auth::Profile;
+use crate::subscription_websocket::{
+    WebSocketHandlerAction, WebSocketHandlerOutput, WebSocketOpenMeta, WebSocketSessionHandler,
+    WebSocketStopOutput,
+};
+use anyhow::{anyhow, bail, Context, Result};
+use async_trait::async_trait;
+use prost::Message;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+const FEISHU_FRAME_METHOD_CONTROL: i32 = 0;
+const FEISHU_FRAME_METHOD_DATA: i32 = 1;
+const FEISHU_TYPE_EVENT: &str = "event";
+const FEISHU_TYPE_PING: &str = "ping";
+const FEISHU_TYPE_PONG: &str = "pong";
+const FEISHU_HEADER_TYPE: &str = "type";
+const FEISHU_HEADER_MESSAGE_ID: &str = "message_id";
+const FEISHU_HEADER_SUM: &str = "sum";
+const FEISHU_HEADER_SEQ: &str = "seq";
+const FEISHU_HEADER_TRACE_ID: &str = "trace_id";
+const FEISHU_HEADER_BIZ_RT: &str = "biz_rt";
+
+#[derive(Debug, Clone)]
+pub struct FeishuLongConnectionOpenResponse {
+    pub websocket_url: String,
+    pub ping_interval_secs: u64,
+    pub reconnect_count: i64,
+    pub reconnect_interval_secs: u64,
+    pub reconnect_nonce_secs: u64,
+    pub service_id: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeishuLongConnectionRuntimeConfig {
+    pub app_id: String,
+    pub app_secret: String,
+}
+
+pub fn derive_feishu_ws_config_endpoint(endpoint: &str) -> Result<String> {
+    let mut url = url::Url::parse(endpoint).context("invalid Feishu long-connection endpoint")?;
+    match url.scheme() {
+        "http" | "https" => {}
+        other => bail!(
+            "feishu-long-connection transport requires an http:// or https:// Feishu/Lark API endpoint, got '{}'",
+            other
+        ),
+    }
+    url.set_path("/callback/ws/endpoint");
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url.to_string())
+}
+
+pub fn parse_feishu_long_connection_open_response(
+    body: &Value,
+) -> Result<FeishuLongConnectionOpenResponse> {
+    if body.get("code").and_then(Value::as_i64) != Some(0) {
+        let message = body
+            .get("msg")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown_error");
+        bail!("Feishu long-connection open failed: {}", message);
+    }
+    let data = body
+        .get("data")
+        .ok_or_else(|| anyhow!("Feishu long-connection open response missing data"))?;
+    let websocket_url = data
+        .get("URL")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("Feishu long-connection open response missing data.URL"))?;
+    let client_config = data
+        .get("ClientConfig")
+        .ok_or_else(|| anyhow!("Feishu long-connection open response missing data.ClientConfig"))?;
+    let ping_interval_secs = client_config
+        .get("PingInterval")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| anyhow!("Feishu long-connection open response missing PingInterval"))?;
+    let reconnect_count = client_config
+        .get("ReconnectCount")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| anyhow!("Feishu long-connection open response missing ReconnectCount"))?;
+    let reconnect_interval_secs = client_config
+        .get("ReconnectInterval")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| anyhow!("Feishu long-connection open response missing ReconnectInterval"))?;
+    let reconnect_nonce_secs = client_config
+        .get("ReconnectNonce")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| anyhow!("Feishu long-connection open response missing ReconnectNonce"))?;
+    let parsed_url =
+        url::Url::parse(websocket_url).context("invalid Feishu long-connection websocket url")?;
+    let service_id = parsed_url
+        .query_pairs()
+        .find(|(key, _)| key == "service_id")
+        .map(|(_, value)| value.into_owned())
+        .ok_or_else(|| anyhow!("Feishu long-connection websocket URL missing service_id"))?
+        .parse::<i32>()
+        .context("invalid Feishu long-connection service_id")?;
+    Ok(FeishuLongConnectionOpenResponse {
+        websocket_url: websocket_url.to_string(),
+        ping_interval_secs,
+        reconnect_count,
+        reconnect_interval_secs,
+        reconnect_nonce_secs,
+        service_id,
+    })
+}
+
+pub fn resolve_feishu_long_connection_runtime_config(
+    auth_profile: &Profile,
+) -> Result<FeishuLongConnectionRuntimeConfig> {
+    let app_id = auth_profile
+        .resolve_field_value("app_id")?
+        .ok_or_else(|| anyhow!("feishu-long-connection requires credential field 'app_id'"))?;
+    let app_secret = auth_profile
+        .resolve_field_value("app_secret")?
+        .ok_or_else(|| anyhow!("feishu-long-connection requires credential field 'app_secret'"))?;
+    Ok(FeishuLongConnectionRuntimeConfig { app_id, app_secret })
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct FeishuPbHeader {
+    #[prost(string, tag = "1")]
+    key: String,
+    #[prost(string, tag = "2")]
+    value: String,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct FeishuPbFrame {
+    #[prost(uint64, tag = "1")]
+    seq_id: u64,
+    #[prost(uint64, tag = "2")]
+    log_id: u64,
+    #[prost(int32, tag = "3")]
+    service: i32,
+    #[prost(int32, tag = "4")]
+    method: i32,
+    #[prost(message, repeated, tag = "5")]
+    headers: Vec<FeishuPbHeader>,
+    #[prost(string, tag = "6")]
+    payload_encoding: String,
+    #[prost(string, tag = "7")]
+    payload_type: String,
+    #[prost(bytes = "vec", tag = "8")]
+    payload: Vec<u8>,
+    #[prost(string, tag = "9")]
+    log_id_new: String,
+}
+
+#[derive(Debug, Clone)]
+struct FeishuFrameChunk {
+    frame: FeishuPbFrame,
+    headers: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+struct FeishuEventAssembly {
+    created_at: Instant,
+    trace_id: Option<String>,
+    total_parts: usize,
+    parts: Vec<Option<Vec<u8>>>,
+}
+
+pub struct FeishuLongConnectionHandler {
+    service_id: i32,
+    ping_interval: Duration,
+    next_ping_at: Option<Instant>,
+    event_cache: HashMap<String, FeishuEventAssembly>,
+}
+
+impl FeishuLongConnectionHandler {
+    pub fn new(service_id: i32, ping_interval_secs: u64) -> Self {
+        Self {
+            service_id,
+            ping_interval: Duration::from_secs(ping_interval_secs.max(1)),
+            next_ping_at: None,
+            event_cache: HashMap::new(),
+        }
+    }
+
+    fn make_control_frame(&self, message_type: &str, payload: Vec<u8>) -> Vec<u8> {
+        FeishuPbFrame {
+            seq_id: 0,
+            log_id: 0,
+            service: self.service_id,
+            method: FEISHU_FRAME_METHOD_CONTROL,
+            headers: vec![FeishuPbHeader {
+                key: FEISHU_HEADER_TYPE.to_string(),
+                value: message_type.to_string(),
+            }],
+            payload_encoding: String::new(),
+            payload_type: String::new(),
+            payload,
+            log_id_new: String::new(),
+        }
+        .encode_to_vec()
+    }
+
+    fn parse_binary_frame(bytes: &[u8]) -> Result<FeishuFrameChunk> {
+        let frame = FeishuPbFrame::decode(bytes).context("invalid Feishu protobuf frame")?;
+        let headers = frame
+            .headers
+            .iter()
+            .map(|header| (header.key.clone(), header.value.clone()))
+            .collect::<HashMap<_, _>>();
+        Ok(FeishuFrameChunk { frame, headers })
+    }
+
+    fn type_header(headers: &HashMap<String, String>) -> Option<&str> {
+        headers.get(FEISHU_HEADER_TYPE).map(String::as_str)
+    }
+
+    fn handle_control_frame(&mut self, chunk: FeishuFrameChunk) -> Result<WebSocketHandlerOutput> {
+        let message_type = Self::type_header(&chunk.headers).unwrap_or_default();
+        match message_type {
+            FEISHU_TYPE_PONG => {
+                if !chunk.frame.payload.is_empty() {
+                    if let Ok(value) = serde_json::from_slice::<Value>(&chunk.frame.payload) {
+                        if let Some(seconds) = value.get("PingInterval").and_then(Value::as_u64) {
+                            self.ping_interval = Duration::from_secs(seconds.max(1));
+                        }
+                    }
+                }
+                self.next_ping_at = Some(Instant::now() + self.ping_interval);
+                Ok(WebSocketHandlerOutput::continue_empty())
+            }
+            FEISHU_TYPE_PING => Ok(WebSocketHandlerOutput {
+                action: WebSocketHandlerAction::Continue,
+                data: None,
+                meta: None,
+                outbound_text_frames: Vec::new(),
+                outbound_binary_frames: vec![self.make_control_frame(FEISHU_TYPE_PONG, vec![])],
+                stop_reason: None,
+            }),
+            _ => Ok(WebSocketHandlerOutput::continue_empty()),
+        }
+    }
+
+    fn merge_event_payload(
+        &mut self,
+        headers: &HashMap<String, String>,
+        payload: Vec<u8>,
+    ) -> Result<Option<(Value, String, Option<String>, usize)>> {
+        let message_id = headers
+            .get(FEISHU_HEADER_MESSAGE_ID)
+            .cloned()
+            .ok_or_else(|| anyhow!("Feishu event frame missing message_id"))?;
+        let total_parts = headers
+            .get(FEISHU_HEADER_SUM)
+            .ok_or_else(|| anyhow!("Feishu event frame missing sum"))?
+            .parse::<usize>()
+            .context("invalid Feishu event frame sum")?;
+        let seq = headers
+            .get(FEISHU_HEADER_SEQ)
+            .ok_or_else(|| anyhow!("Feishu event frame missing seq"))?
+            .parse::<usize>()
+            .context("invalid Feishu event frame seq")?;
+        let trace_id = headers.get(FEISHU_HEADER_TRACE_ID).cloned();
+
+        self.event_cache
+            .retain(|_, entry| entry.created_at.elapsed() < Duration::from_secs(10));
+
+        let entry = self
+            .event_cache
+            .entry(message_id.clone())
+            .or_insert_with(|| FeishuEventAssembly {
+                created_at: Instant::now(),
+                trace_id: trace_id.clone(),
+                total_parts,
+                parts: vec![None; total_parts],
+            });
+        if entry.total_parts != total_parts {
+            bail!("Feishu event frame changed total part count mid-stream");
+        }
+        if seq >= entry.parts.len() {
+            bail!(
+                "Feishu event frame seq {} out of range {}",
+                seq,
+                entry.parts.len()
+            );
+        }
+        entry.parts[seq] = Some(payload);
+
+        if entry.parts.iter().all(|part| part.is_some()) {
+            let mut merged = Vec::new();
+            for part in &entry.parts {
+                merged.extend_from_slice(part.as_ref().expect("parts checked above"));
+            }
+            let value: Value =
+                serde_json::from_slice(&merged).context("invalid Feishu event payload JSON")?;
+            let trace_id = entry.trace_id.clone();
+            self.event_cache.remove(&message_id);
+            Ok(Some((value, message_id, trace_id, total_parts)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn make_event_ack_frame(
+        &self,
+        frame: &FeishuPbFrame,
+        _headers: &HashMap<String, String>,
+        elapsed_ms: u128,
+    ) -> Vec<u8> {
+        let mut response_headers = frame.headers.clone();
+        response_headers.push(FeishuPbHeader {
+            key: FEISHU_HEADER_BIZ_RT.to_string(),
+            value: elapsed_ms.to_string(),
+        });
+        FeishuPbFrame {
+            seq_id: frame.seq_id,
+            log_id: frame.log_id,
+            service: frame.service,
+            method: frame.method,
+            headers: response_headers,
+            payload_encoding: frame.payload_encoding.clone(),
+            payload_type: frame.payload_type.clone(),
+            payload: br#"{"code":200}"#.to_vec(),
+            log_id_new: frame.log_id_new.clone(),
+        }
+        .encode_to_vec()
+    }
+}
+
+#[async_trait]
+impl WebSocketSessionHandler for FeishuLongConnectionHandler {
+    async fn on_open(&mut self, _meta: &WebSocketOpenMeta) -> Result<WebSocketHandlerAction> {
+        self.next_ping_at = Some(Instant::now() + self.ping_interval);
+        Ok(WebSocketHandlerAction::Continue)
+    }
+
+    async fn on_text_frame(&mut self, text: String) -> Result<WebSocketHandlerOutput> {
+        Ok(WebSocketHandlerOutput {
+            action: WebSocketHandlerAction::Continue,
+            data: None,
+            meta: Some(json!({
+                "frame_type": "unexpected_text",
+                "text": text,
+            })),
+            outbound_text_frames: Vec::new(),
+            outbound_binary_frames: Vec::new(),
+            stop_reason: None,
+        })
+    }
+
+    async fn on_binary_frame(&mut self, bytes: Vec<u8>) -> Result<WebSocketHandlerOutput> {
+        let started_at = Instant::now();
+        let chunk = Self::parse_binary_frame(&bytes)?;
+        match chunk.frame.method {
+            FEISHU_FRAME_METHOD_CONTROL => self.handle_control_frame(chunk),
+            FEISHU_FRAME_METHOD_DATA => {
+                if Self::type_header(&chunk.headers) != Some(FEISHU_TYPE_EVENT) {
+                    return Ok(WebSocketHandlerOutput::continue_empty());
+                }
+                let ack = self.make_event_ack_frame(
+                    &chunk.frame,
+                    &chunk.headers,
+                    started_at.elapsed().as_millis(),
+                );
+                let Some((value, message_id, trace_id, total_parts)) =
+                    self.merge_event_payload(&chunk.headers, chunk.frame.payload.clone())?
+                else {
+                    return Ok(WebSocketHandlerOutput {
+                        action: WebSocketHandlerAction::Continue,
+                        data: None,
+                        meta: Some(json!({
+                            "frame_type": "event_chunk",
+                            "message_id": chunk.headers.get(FEISHU_HEADER_MESSAGE_ID).cloned(),
+                            "trace_id": chunk.headers.get(FEISHU_HEADER_TRACE_ID).cloned(),
+                        })),
+                        outbound_text_frames: Vec::new(),
+                        outbound_binary_frames: vec![ack],
+                        stop_reason: None,
+                    });
+                };
+                let event_type = value
+                    .get("event_type")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string);
+                let meta = json!({
+                    "frame_type": "protobuf_event",
+                    "message_type": FEISHU_TYPE_EVENT,
+                    "message_id": message_id,
+                    "trace_id": trace_id,
+                    "event_type": event_type,
+                    "parts": total_parts,
+                });
+                Ok(WebSocketHandlerOutput {
+                    action: WebSocketHandlerAction::Continue,
+                    data: Some(value),
+                    meta: Some(meta),
+                    outbound_text_frames: Vec::new(),
+                    outbound_binary_frames: vec![ack],
+                    stop_reason: None,
+                })
+            }
+            other => bail!("unsupported Feishu frame method {}", other),
+        }
+    }
+
+    fn next_wakeup_at(&self) -> Option<tokio::time::Instant> {
+        self.next_ping_at.map(tokio::time::Instant::from_std)
+    }
+
+    async fn on_wakeup(&mut self) -> Result<WebSocketHandlerOutput> {
+        self.next_ping_at = Some(Instant::now() + self.ping_interval);
+        Ok(WebSocketHandlerOutput {
+            action: WebSocketHandlerAction::Continue,
+            data: None,
+            meta: None,
+            outbound_text_frames: Vec::new(),
+            outbound_binary_frames: vec![self.make_control_frame(FEISHU_TYPE_PING, vec![])],
+            stop_reason: None,
+        })
+    }
+
+    async fn on_stop_requested(&mut self) -> Result<WebSocketStopOutput> {
+        Ok(WebSocketStopOutput {
+            outbound_text_frames: Vec::new(),
+            outbound_binary_frames: Vec::new(),
+            stop_reason: Some("stopped".to_string()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event_frame(payload: Value) -> Vec<u8> {
+        FeishuPbFrame {
+            seq_id: 1,
+            log_id: 2,
+            service: 3,
+            method: FEISHU_FRAME_METHOD_DATA,
+            headers: vec![
+                FeishuPbHeader {
+                    key: FEISHU_HEADER_TYPE.to_string(),
+                    value: FEISHU_TYPE_EVENT.to_string(),
+                },
+                FeishuPbHeader {
+                    key: FEISHU_HEADER_MESSAGE_ID.to_string(),
+                    value: "mid".to_string(),
+                },
+                FeishuPbHeader {
+                    key: FEISHU_HEADER_SUM.to_string(),
+                    value: "1".to_string(),
+                },
+                FeishuPbHeader {
+                    key: FEISHU_HEADER_SEQ.to_string(),
+                    value: "0".to_string(),
+                },
+                FeishuPbHeader {
+                    key: FEISHU_HEADER_TRACE_ID.to_string(),
+                    value: "trace".to_string(),
+                },
+            ],
+            payload_encoding: String::new(),
+            payload_type: String::new(),
+            payload: serde_json::to_vec(&payload).unwrap(),
+            log_id_new: String::new(),
+        }
+        .encode_to_vec()
+    }
+
+    #[test]
+    fn derives_feishu_ws_config_endpoint_from_api_base() {
+        assert_eq!(
+            derive_feishu_ws_config_endpoint("https://open.feishu.cn/open-apis").unwrap(),
+            "https://open.feishu.cn/callback/ws/endpoint"
+        );
+    }
+
+    #[test]
+    fn parses_feishu_open_response() {
+        let parsed = parse_feishu_long_connection_open_response(&json!({
+            "code": 0,
+            "data": {
+                "URL": "wss://msg-frontier.feishu.cn/ws/v2?service_id=33554678",
+                "ClientConfig": {
+                    "PingInterval": 90,
+                    "ReconnectCount": -1,
+                    "ReconnectInterval": 90,
+                    "ReconnectNonce": 25
+                }
+            }
+        }))
+        .unwrap();
+        assert_eq!(parsed.service_id, 33_554_678);
+        assert_eq!(parsed.ping_interval_secs, 90);
+    }
+
+    #[tokio::test]
+    async fn handler_emits_event_and_binary_ack() {
+        let mut handler = FeishuLongConnectionHandler::new(3, 90);
+        let output = handler
+            .on_binary_frame(event_frame(json!({
+                "event_type": "im.message.receive_v1",
+                "message": { "message_id": "om_1" }
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(output.action, WebSocketHandlerAction::Continue);
+        assert_eq!(
+            output.data.as_ref().unwrap()["event_type"],
+            "im.message.receive_v1"
+        );
+        assert_eq!(output.meta.as_ref().unwrap()["trace_id"], "trace");
+        assert_eq!(output.outbound_binary_frames.len(), 1);
+
+        let ack = FeishuPbFrame::decode(output.outbound_binary_frames[0].as_slice()).unwrap();
+        assert_eq!(ack.method, FEISHU_FRAME_METHOD_DATA);
+        assert!(ack
+            .headers
+            .iter()
+            .any(|header| header.key == FEISHU_HEADER_BIZ_RT));
+        assert_eq!(
+            serde_json::from_slice::<Value>(&ack.payload).unwrap()["code"],
+            200
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_schedules_binary_ping_on_wakeup() {
+        let mut handler = FeishuLongConnectionHandler::new(3, 90);
+        let _ = handler
+            .on_open(&WebSocketOpenMeta {
+                redacted_url: "wss://example.com".to_string(),
+                subprotocol: None,
+            })
+            .await
+            .unwrap();
+
+        let output = handler.on_wakeup().await.unwrap();
+        assert_eq!(output.outbound_binary_frames.len(), 1);
+        let ping = FeishuPbFrame::decode(output.outbound_binary_frames[0].as_slice()).unwrap();
+        assert_eq!(ping.method, FEISHU_FRAME_METHOD_CONTROL);
+        assert!(ping
+            .headers
+            .iter()
+            .any(|header| header.key == FEISHU_HEADER_TYPE && header.value == FEISHU_TYPE_PING));
+    }
+}

--- a/src/subscription_graphql.rs
+++ b/src/subscription_graphql.rs
@@ -182,6 +182,7 @@ impl GraphQLSubscriptionHandler {
             data: None,
             meta: None,
             outbound_text_frames: Vec::new(),
+            outbound_binary_frames: Vec::new(),
             stop_reason: None,
         }
     }
@@ -253,6 +254,7 @@ impl WebSocketSessionHandler for GraphQLSubscriptionHandler {
                     data: None,
                     meta: None,
                     outbound_text_frames: vec![self.subscribe_message()],
+                    outbound_binary_frames: Vec::new(),
                     stop_reason: None,
                 })
             }
@@ -267,6 +269,7 @@ impl WebSocketSessionHandler for GraphQLSubscriptionHandler {
                     data: payload.get("data").cloned(),
                     meta: Some(self.data_meta(&payload)),
                     outbound_text_frames: Vec::new(),
+                    outbound_binary_frames: Vec::new(),
                     stop_reason: None,
                 })
             }
@@ -279,6 +282,7 @@ impl WebSocketSessionHandler for GraphQLSubscriptionHandler {
                     data: None,
                     meta: None,
                     outbound_text_frames: Vec::new(),
+                    outbound_binary_frames: Vec::new(),
                     stop_reason: Some("complete".to_string()),
                 })
             }
@@ -292,6 +296,7 @@ impl WebSocketSessionHandler for GraphQLSubscriptionHandler {
                     "payload": value.get("payload").cloned().unwrap_or(Value::Null),
                 })
                 .to_string()],
+                outbound_binary_frames: Vec::new(),
                 stop_reason: None,
             }),
             "error" => Err(anyhow!(
@@ -312,6 +317,7 @@ impl WebSocketSessionHandler for GraphQLSubscriptionHandler {
     async fn on_stop_requested(&mut self) -> Result<WebSocketStopOutput> {
         Ok(WebSocketStopOutput {
             outbound_text_frames: vec![self.stop_message()],
+            outbound_binary_frames: Vec::new(),
             stop_reason: Some("stopped".to_string()),
         })
     }

--- a/src/subscription_jsonrpc.rs
+++ b/src/subscription_jsonrpc.rs
@@ -101,6 +101,7 @@ impl WebSocketSessionHandler for JsonRpcSubscriptionHandler {
                 data: None,
                 meta: None,
                 outbound_text_frames: Vec::new(),
+                outbound_binary_frames: Vec::new(),
                 stop_reason: None,
             });
         }
@@ -111,6 +112,7 @@ impl WebSocketSessionHandler for JsonRpcSubscriptionHandler {
                 data: None,
                 meta: None,
                 outbound_text_frames: Vec::new(),
+                outbound_binary_frames: Vec::new(),
                 stop_reason: None,
             });
         }
@@ -121,6 +123,7 @@ impl WebSocketSessionHandler for JsonRpcSubscriptionHandler {
                 data: None,
                 meta: None,
                 outbound_text_frames: Vec::new(),
+                outbound_binary_frames: Vec::new(),
                 stop_reason: None,
             });
         };
@@ -131,6 +134,7 @@ impl WebSocketSessionHandler for JsonRpcSubscriptionHandler {
                 data: None,
                 meta: None,
                 outbound_text_frames: Vec::new(),
+                outbound_binary_frames: Vec::new(),
                 stop_reason: None,
             });
         };
@@ -140,6 +144,7 @@ impl WebSocketSessionHandler for JsonRpcSubscriptionHandler {
                 data: None,
                 meta: None,
                 outbound_text_frames: Vec::new(),
+                outbound_binary_frames: Vec::new(),
                 stop_reason: None,
             });
         }
@@ -156,6 +161,7 @@ impl WebSocketSessionHandler for JsonRpcSubscriptionHandler {
             data,
             meta,
             outbound_text_frames: Vec::new(),
+            outbound_binary_frames: Vec::new(),
             stop_reason: None,
         })
     }
@@ -166,6 +172,7 @@ impl WebSocketSessionHandler for JsonRpcSubscriptionHandler {
             data: None,
             meta: None,
             outbound_text_frames: Vec::new(),
+            outbound_binary_frames: Vec::new(),
             stop_reason: None,
         })
     }
@@ -173,6 +180,7 @@ impl WebSocketSessionHandler for JsonRpcSubscriptionHandler {
     async fn on_stop_requested(&mut self) -> Result<WebSocketStopOutput> {
         Ok(WebSocketStopOutput {
             outbound_text_frames: self.unsubscribe_message().into_iter().collect(),
+            outbound_binary_frames: Vec::new(),
             stop_reason: Some("stopped".to_string()),
         })
     }

--- a/src/subscription_slack.rs
+++ b/src/subscription_slack.rs
@@ -106,6 +106,7 @@ impl WebSocketSessionHandler for SlackSocketModeHandler {
             data: Some(value),
             meta: Some(meta),
             outbound_text_frames,
+            outbound_binary_frames: Vec::new(),
             stop_reason: if action == WebSocketHandlerAction::Reconnect {
                 Some("disconnect".to_string())
             } else {
@@ -123,6 +124,7 @@ impl WebSocketSessionHandler for SlackSocketModeHandler {
                 "base64": base64::engine::general_purpose::STANDARD.encode(bytes),
             })),
             outbound_text_frames: Vec::new(),
+            outbound_binary_frames: Vec::new(),
             stop_reason: None,
         })
     }
@@ -130,6 +132,7 @@ impl WebSocketSessionHandler for SlackSocketModeHandler {
     async fn on_stop_requested(&mut self) -> Result<WebSocketStopOutput> {
         Ok(WebSocketStopOutput {
             outbound_text_frames: Vec::new(),
+            outbound_binary_frames: Vec::new(),
             stop_reason: Some("stopped".to_string()),
         })
     }

--- a/src/subscription_websocket.rs
+++ b/src/subscription_websocket.rs
@@ -40,6 +40,7 @@ pub struct WebSocketHandlerOutput {
     pub data: Option<Value>,
     pub meta: Option<Value>,
     pub outbound_text_frames: Vec<String>,
+    pub outbound_binary_frames: Vec<Vec<u8>>,
     pub stop_reason: Option<String>,
 }
 
@@ -50,6 +51,7 @@ impl WebSocketHandlerOutput {
             data: None,
             meta: None,
             outbound_text_frames: Vec::new(),
+            outbound_binary_frames: Vec::new(),
             stop_reason: None,
         }
     }
@@ -58,6 +60,7 @@ impl WebSocketHandlerOutput {
 #[derive(Debug, Clone, Default)]
 pub struct WebSocketStopOutput {
     pub outbound_text_frames: Vec<String>,
+    pub outbound_binary_frames: Vec<Vec<u8>>,
     pub stop_reason: Option<String>,
 }
 
@@ -130,6 +133,7 @@ impl WebSocketSessionHandler for RawFrameHandler {
                 data: Some(value),
                 meta: Some(json!({"frame_type":"text_json"})),
                 outbound_text_frames: Vec::new(),
+                outbound_binary_frames: Vec::new(),
                 stop_reason: None,
             }),
             Err(_) => Ok(WebSocketHandlerOutput {
@@ -137,6 +141,7 @@ impl WebSocketSessionHandler for RawFrameHandler {
                 data: None,
                 meta: Some(json!({"frame_type":"text","text":text})),
                 outbound_text_frames: Vec::new(),
+                outbound_binary_frames: Vec::new(),
                 stop_reason: None,
             }),
         }
@@ -153,11 +158,35 @@ impl WebSocketSessionHandler for RawFrameHandler {
                 "base64": base64::engine::general_purpose::STANDARD.encode(bytes),
             })),
             outbound_text_frames: Vec::new(),
+            outbound_binary_frames: Vec::new(),
             stop_reason: None,
         })
     }
 }
 
+async fn send_outbound_frames(
+    stream: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    outbound_text_frames: &[String],
+    outbound_binary_frames: &[Vec<u8>],
+) -> std::result::Result<(), WebSocketRunError> {
+    for frame in outbound_text_frames {
+        stream
+            .send(Message::Text(frame.clone()))
+            .await
+            .map_err(|err| WebSocketRunError::Retry(anyhow!("websocket send failed: {}", err)))?;
+    }
+    for frame in outbound_binary_frames {
+        stream
+            .send(Message::Binary(frame.clone()))
+            .await
+            .map_err(|err| WebSocketRunError::Retry(anyhow!("websocket send failed: {}", err)))?;
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
 pub enum WebSocketRunError {
     Retry(anyhow::Error),
     Fatal(anyhow::Error),
@@ -202,11 +231,14 @@ async fn handle_stop_requested<H: WebSocketSessionHandler, O: WebSocketRuntimeOb
         .await
         .map_err(WebSocketRunError::Fatal)?;
     if let Some(stream) = stream {
-        for frame in &stop_output.outbound_text_frames {
-            if let Err(err) = stream.send(Message::Text(frame.clone())).await {
-                tracing::debug!("websocket cleanup send failed: {}", err);
-                break;
-            }
+        if let Err(err) = send_outbound_frames(
+            stream,
+            &stop_output.outbound_text_frames,
+            &stop_output.outbound_binary_frames,
+        )
+        .await
+        {
+            tracing::debug!("websocket cleanup send failed: {:?}", err);
         }
     }
     close_as_stopped(
@@ -332,14 +364,14 @@ async fn run_session_once<H: WebSocketSessionHandler, O: WebSocketRuntimeObserve
         .await
         .map_err(WebSocketRunError::Fatal)?;
 
-    for frame in &config.initial_text_frames {
-        stream
-            .send(Message::Text(frame.clone()))
-            .await
-            .map_err(|err| {
-                WebSocketRunError::Retry(anyhow!("websocket initial send failed: {}", err))
-            })?;
-    }
+    send_outbound_frames(&mut stream, &config.initial_text_frames, &[])
+        .await
+        .map_err(|err| match err {
+            WebSocketRunError::Retry(inner) => {
+                WebSocketRunError::Retry(anyhow!("websocket initial send failed: {}", inner))
+            }
+            other => other,
+        })?;
 
     match handler
         .on_open(&open_meta)
@@ -456,12 +488,12 @@ async fn apply_handler_output<O: WebSocketRuntimeObserver>(
     observer: &mut O,
     output: WebSocketHandlerOutput,
 ) -> std::result::Result<bool, WebSocketRunError> {
-    for frame in &output.outbound_text_frames {
-        stream
-            .send(Message::Text(frame.clone()))
-            .await
-            .map_err(|err| WebSocketRunError::Retry(anyhow!("websocket send failed: {}", err)))?;
-    }
+    send_outbound_frames(
+        stream,
+        &output.outbound_text_frames,
+        &output.outbound_binary_frames,
+    )
+    .await?;
     if output.data.is_some() || output.meta.is_some() {
         observer
             .emit("data", output.data, output.meta)


### PR DESCRIPTION
## What
- add a provider-aware `feishu-long-connection` subscribe transport
- bootstrap Feishu long-connection websocket URLs through `/callback/ws/endpoint`
- handle Feishu protobuf binary frames, chunk assembly, binary ack, and ping control frames
- update Feishu subscribe validation docs and skill guidance

## Why
Feishu/Lark inbound IM events are not plain JSON websocket streams. They require a provider-aware runtime on top of `uxc subscribe` to make long-connection message intake usable.

## How
- add `src/subscription_feishu.rs`
- extend websocket runtime to support outbound binary frames from handlers
- wire `feishu-long-connection` through CLI and daemon subscribe flow
- validate against a live Feishu app with real `im.message.receive_v1` events

## Testing
- `cargo fmt --all --check`
- `cargo test subscription_feishu --lib -- --test-threads=1`
- `cargo test --test subscribe_cli_test -- --test-threads=1`
- `bash skills/feishu-openapi-skill/scripts/validate.sh`
- live validation with `uxc subscribe start https://open.feishu.cn/open-apis --transport feishu-long-connection --auth feishu-tenant ...`
  - confirmed `open`
  - confirmed real `im.message.receive_v1` `data` events in the sink
