### PR TITLE
feat: support MCP resource snapshots in subscriptions

### DIFF
--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -259,10 +259,7 @@ impl McpStdioClient {
             .await
             .context(format!("Failed to read resource '{}'", uri))?;
 
-        let contents: ResourceContents =
-            serde_json::from_value(result).context("Failed to parse resource contents")?;
-
-        Ok(contents)
+        parse_read_resource_result(result).context("Failed to parse resource contents")
     }
 
     pub async fn subscribe_resource(&mut self, uri: &str) -> Result<()> {
@@ -555,23 +552,9 @@ mod tests {
             .await
             .unwrap();
 
-        // The response structure has a "contents" array, so we need to handle that
-        let result = client
-            .transport
-            .send_request(
-                "resources/read",
-                Some(serde_json::json!({"uri": "test://resource"})),
-            )
-            .await
-            .unwrap();
+        let result = client.read_resource("test://resource").await.unwrap();
 
-        // Parse the contents array
-        let contents_array = result.get("contents").and_then(|v| v.as_array()).unwrap();
-        let first_content = &contents_array[0];
-        assert_eq!(
-            first_content.get("uri").unwrap().as_str().unwrap(),
-            "test://resource"
-        );
+        assert_eq!(result.uri, "test://resource");
     }
 
     #[tokio::test]

--- a/src/adapters/mcp/http_transport.rs
+++ b/src/adapters/mcp/http_transport.rs
@@ -1008,7 +1008,7 @@ impl McpHttpTransport {
 
         let result = self.send_request("resources/read", Some(params)).await?;
 
-        serde_json::from_value(result).context("Failed to parse resources/read result")
+        parse_read_resource_result(result)
     }
 
     pub async fn subscribe_resource(&self, uri: &str) -> Result<()> {
@@ -1487,7 +1487,7 @@ impl LegacySseTransport {
             "uri": uri
         });
         let result = self.send_request("resources/read", Some(params)).await?;
-        serde_json::from_value(result).context("Failed to parse resources/read result")
+        parse_read_resource_result(result)
     }
 
     async fn call_tool(&self, name: &str, arguments: Option<JsonValue>) -> Result<ToolCallResult> {
@@ -2855,6 +2855,37 @@ data: invalid json
 
     #[tokio::test]
     async fn read_resource_succeeds() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "jsonrpc":"2.0",
+                "id":1,
+                "result":{
+                    "contents":[{
+                        "uri":"file:///test.txt",
+                        "text":"Resource content"
+                    }]
+                }
+            }"#,
+            )
+            .create_async()
+            .await;
+
+        let transport = McpHttpTransport::new(server.url()).unwrap();
+
+        let result = transport.read_resource("file:///test.txt").await;
+        assert!(result.is_ok());
+        let resource = result.unwrap();
+        assert_eq!(resource.text, Some("Resource content".to_string()));
+    }
+
+    #[tokio::test]
+    async fn read_resource_accepts_legacy_single_object_shape() {
         let mut server = mockito::Server::new_async().await;
 
         let _mock = server

--- a/src/adapters/mcp/types.rs
+++ b/src/adapters/mcp/types.rs
@@ -2,6 +2,7 @@
 
 #![allow(non_snake_case)]
 
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -206,6 +207,25 @@ pub struct ResourceContents {
     pub text: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blob: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadResourceResponse {
+    pub contents: Vec<ResourceContents>,
+}
+
+pub fn parse_read_resource_result(result: JsonValue) -> Result<ResourceContents> {
+    if let Ok(contents) = serde_json::from_value::<ResourceContents>(result.clone()) {
+        return Ok(contents);
+    }
+
+    let response: ReadResourceResponse =
+        serde_json::from_value(result).context("Failed to parse resources/read result")?;
+    response
+        .contents
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("resources/read response contained no contents"))
 }
 
 /// Prompt definition

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -277,6 +277,35 @@ async fn append_mcp_resource_snapshot(
     .await
 }
 
+async fn append_mcp_resource_read_result(
+    sink: &mut tokio::fs::File,
+    view: &Arc<Mutex<SubscriptionJobView>>,
+    seq: &mut u64,
+    resource_uri: &str,
+    reason: &str,
+    error_context: &str,
+    read_result: Result<ResourceContents>,
+) -> Result<()> {
+    match read_result {
+        Ok(contents) => append_mcp_resource_snapshot(sink, view, seq, reason, contents).await,
+        Err(err) => {
+            let msg = format!("{}: {}", error_context, err);
+            append_subscription_event(
+                sink,
+                view,
+                seq,
+                "mcp_resource",
+                "error",
+                None,
+                Some(json!({ "message": msg, "resource_uri": resource_uri })),
+            )
+            .await?;
+            update_subscription_view(view, None, Some(msg), false).await;
+            Ok(())
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonStatus {
     pub running: bool,
@@ -4132,8 +4161,16 @@ async fn run_mcp_subscription_job(
     )
     .await?;
     if request.read_resource {
-        let contents = client.read_resource(resource_uri).await?;
-        append_mcp_resource_snapshot(&mut sink, &view, &mut seq, "initial_read", contents).await?;
+        append_mcp_resource_read_result(
+            &mut sink,
+            &view,
+            &mut seq,
+            resource_uri,
+            "initial_read",
+            "failed to read initial resource snapshot",
+            client.read_resource(resource_uri).await,
+        )
+        .await?;
     }
 
     loop {
@@ -4170,32 +4207,16 @@ async fn run_mcp_subscription_job(
                         Some(json!({"method": notification.method})),
                     ).await?;
                     if request.read_resource && should_read_mcp_resource_snapshot(&notification) {
-                        match client.read_resource(resource_uri).await {
-                            Ok(contents) => {
-                                append_mcp_resource_snapshot(
-                                    &mut sink,
-                                    &view,
-                                    &mut seq,
-                                    "resource_updated",
-                                    contents,
-                                )
-                                .await?;
-                            }
-                            Err(err) => {
-                                let msg = format!("failed to read resource after update: {}", err);
-                                append_subscription_event(
-                                    &mut sink,
-                                    &view,
-                                    &mut seq,
-                                    "mcp_resource",
-                                    "error",
-                                    None,
-                                    Some(json!({ "message": msg, "resource_uri": resource_uri })),
-                                )
-                                .await?;
-                                update_subscription_view(&view, None, Some(msg), false).await;
-                            }
-                        }
+                        append_mcp_resource_read_result(
+                            &mut sink,
+                            &view,
+                            &mut seq,
+                            resource_uri,
+                            "resource_updated",
+                            "failed to read resource after update",
+                            client.read_resource(resource_uri).await,
+                        )
+                        .await?;
                     }
                 }
             }
@@ -4246,8 +4267,16 @@ async fn run_mcp_http_subscription_job(
     )
     .await?;
     if request.read_resource {
-        let contents = transport.read_resource(resource_uri).await?;
-        append_mcp_resource_snapshot(&mut sink, &view, &mut seq, "initial_read", contents).await?;
+        append_mcp_resource_read_result(
+            &mut sink,
+            &view,
+            &mut seq,
+            resource_uri,
+            "initial_read",
+            "failed to read initial resource snapshot",
+            transport.read_resource(resource_uri).await,
+        )
+        .await?;
     }
 
     loop {
@@ -4288,32 +4317,16 @@ async fn run_mcp_http_subscription_job(
                         Some(json!({"method": notification.method})),
                     ).await?;
                     if request.read_resource && should_read_mcp_resource_snapshot(&notification) {
-                        match transport.read_resource(resource_uri).await {
-                            Ok(contents) => {
-                                append_mcp_resource_snapshot(
-                                    &mut sink,
-                                    &view,
-                                    &mut seq,
-                                    "resource_updated",
-                                    contents,
-                                )
-                                .await?;
-                            }
-                            Err(err) => {
-                                let msg = format!("failed to read resource after update: {}", err);
-                                append_subscription_event(
-                                    &mut sink,
-                                    &view,
-                                    &mut seq,
-                                    "mcp_resource",
-                                    "error",
-                                    None,
-                                    Some(json!({ "message": msg, "resource_uri": resource_uri })),
-                                )
-                                .await?;
-                                update_subscription_view(&view, None, Some(msg), false).await;
-                            }
-                        }
+                        append_mcp_resource_read_result(
+                            &mut sink,
+                            &view,
+                            &mut seq,
+                            resource_uri,
+                            "resource_updated",
+                            "failed to read resource after update",
+                            transport.read_resource(resource_uri).await,
+                        )
+                        .await?;
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3990,6 +3990,12 @@ async fn handle_subscribe_command(
                 )
                 .into());
             }
+            if *read_resource && !matches!(mode, SubscribeModeArg::Stream) {
+                return Err(UxcError::InvalidArguments(
+                    "--read-resource is only valid with --mode stream".to_string(),
+                )
+                .into());
+            }
             let (normalized_args, normalized_input_json) = match transport_operation_id.as_ref() {
                 Some(op) => {
                     let mut explicit_args = Vec::new();

--- a/src/test_server/common.rs
+++ b/src/test_server/common.rs
@@ -23,6 +23,8 @@ pub enum Scenario {
     ToolsListFailAfterFirst,
     /// tools/call returns content + structuredContent payload
     StructuredContent,
+    /// First resources/read fails, later reads succeed
+    ResourceReadFailOnce,
     /// tools/list changes after navigate and emits tools/list_changed notification
     DynamicToolset,
     /// tools/call requires the arguments field to be present as an object, even when empty
@@ -44,11 +46,12 @@ impl Scenario {
             "tool_call_timeout" => Ok(Self::ToolCallTimeout),
             "tools_list_fail_after_first" => Ok(Self::ToolsListFailAfterFirst),
             "structured_content" => Ok(Self::StructuredContent),
+            "resource_read_fail_once" => Ok(Self::ResourceReadFailOnce),
             "dynamic_toolset" => Ok(Self::DynamicToolset),
             "empty_object_required" => Ok(Self::EmptyObjectRequired),
             "sui_pubsub" => Ok(Self::SuiPubSub),
             _ => anyhow::bail!(
-                "Unknown scenario: {}. Use: ok, auth_required, malformed, timeout, legacy, tool_call_timeout, tools_list_fail_after_first, structured_content, dynamic_toolset, empty_object_required, sui_pubsub",
+                "Unknown scenario: {}. Use: ok, auth_required, malformed, timeout, legacy, tool_call_timeout, tools_list_fail_after_first, structured_content, resource_read_fail_once, dynamic_toolset, empty_object_required, sui_pubsub",
                 s
             ),
         }

--- a/src/test_server/graphql.rs
+++ b/src/test_server/graphql.rs
@@ -334,6 +334,7 @@ async fn execute_query(
         | Scenario::ToolsListFailAfterFirst
         | Scenario::ToolCallTimeout
         | Scenario::StructuredContent
+        | Scenario::ResourceReadFailOnce
         | Scenario::DynamicToolset => {
             // Introspection query
             if query.contains("__schema") || query.contains("__type(") {

--- a/src/test_server/grpc.rs
+++ b/src/test_server/grpc.rs
@@ -31,6 +31,7 @@ impl addsvc::add_server::Add for AddService {
             | Scenario::ToolsListFailAfterFirst
             | Scenario::ToolCallTimeout
             | Scenario::StructuredContent
+            | Scenario::ResourceReadFailOnce
             | Scenario::DynamicToolset => {
                 let req = request.into_inner();
                 Ok(Response::new(addsvc::SumReply { v: req.a + req.b }))

--- a/src/test_server/jsonrpc.rs
+++ b/src/test_server/jsonrpc.rs
@@ -321,6 +321,7 @@ async fn execute_method(
         | Scenario::ToolsListFailAfterFirst
         | Scenario::ToolCallTimeout
         | Scenario::StructuredContent
+        | Scenario::ResourceReadFailOnce
         | Scenario::DynamicToolset => {
             let result = match method {
                 "rpc.discover" => schema_value(state.scenario),

--- a/src/test_server/mcp_http.rs
+++ b/src/test_server/mcp_http.rs
@@ -29,6 +29,7 @@ struct ServerState {
     tools_list_calls: Arc<AtomicU64>,
     resource_subscribed: Arc<AtomicBool>,
     resource_event_seq: Arc<AtomicU64>,
+    resource_read_failed_once: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -157,15 +158,27 @@ async fn mcp_handler(
                 .get("uri")
                 .and_then(Value::as_str)
                 .unwrap_or("test://resource");
+            if matches!(state.scenario, Scenario::ResourceReadFailOnce)
+                && !state.resource_read_failed_once.swap(true, Ordering::SeqCst)
+            {
+                return Ok(Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": req.id,
+                    "error": {"code": -32003, "message": "resource read failed once"}
+                }))
+                .into_response());
+            }
             let value = state.resource_event_seq.load(Ordering::SeqCst);
             json!({
-                "uri": uri,
-                "mimeType": "application/json",
-                "text": json!({
+                "contents": [{
                     "uri": uri,
-                    "value": value
-                })
-                .to_string()
+                    "mimeType": "application/json",
+                    "text": json!({
+                        "uri": uri,
+                        "value": value
+                    })
+                    .to_string()
+                }]
             })
         }
         "resources/unsubscribe" => {
@@ -249,6 +262,7 @@ pub async fn run(scenario: Scenario) -> Result<ServerHandle> {
         tools_list_calls: Arc::new(AtomicU64::new(0)),
         resource_subscribed: Arc::new(AtomicBool::new(false)),
         resource_event_seq: Arc::new(AtomicU64::new(0)),
+        resource_read_failed_once: Arc::new(AtomicBool::new(false)),
     });
 
     info!("MCP HTTP test server listening on http://{}", addr);

--- a/src/test_server/mcp_stdio.rs
+++ b/src/test_server/mcp_stdio.rs
@@ -19,6 +19,7 @@ pub fn run(scenario: Scenario) -> Result<()> {
     let mut dynamic_tools_enabled = false;
     let mut resource_subscribed = false;
     let mut resource_value: u64 = 0;
+    let mut resource_read_failed_once = false;
 
     for line in stdin.lock().lines() {
         let line = line?;
@@ -402,19 +403,34 @@ pub fn run(scenario: Scenario) -> Result<()> {
                     .and_then(|v| v.get("uri"))
                     .and_then(Value::as_str)
                     .unwrap_or("test://resource");
+                if matches!(scenario, Scenario::ResourceReadFailOnce) && !resource_read_failed_once
+                {
+                    resource_read_failed_once = true;
+                    respond(
+                        &mut out,
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "error": {"code": -32003, "message": "resource read failed once"}
+                        }),
+                    )?;
+                    continue;
+                }
                 respond(
                     &mut out,
                     json!({
                         "jsonrpc": "2.0",
                         "id": id,
                         "result": {
-                            "uri": uri,
-                            "mimeType": "application/json",
-                            "text": json!({
+                            "contents": [{
                                 "uri": uri,
-                                "value": resource_value
-                            })
-                            .to_string()
+                                "mimeType": "application/json",
+                                "text": json!({
+                                    "uri": uri,
+                                    "value": resource_value
+                                })
+                                .to_string()
+                            }]
                         }
                     }),
                 )?;

--- a/src/test_server/openapi.rs
+++ b/src/test_server/openapi.rs
@@ -244,6 +244,7 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ToolsListFailAfterFirst
             | Scenario::ToolCallTimeout
             | Scenario::StructuredContent
+            | Scenario::ResourceReadFailOnce
             | Scenario::DynamicToolset => Ok(Json(json!({"status": "ok"})).into_response()),
             Scenario::AuthRequired => Err(StatusCode::UNAUTHORIZED),
             Scenario::Malformed => {
@@ -270,6 +271,7 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ToolsListFailAfterFirst
             | Scenario::ToolCallTimeout
             | Scenario::StructuredContent
+            | Scenario::ResourceReadFailOnce
             | Scenario::DynamicToolset => {
                 let users = vec![
                     json!({"id": 1, "name": "Alice", "email": "alice@example.com"}),
@@ -302,6 +304,7 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ToolsListFailAfterFirst
             | Scenario::ToolCallTimeout
             | Scenario::StructuredContent
+            | Scenario::ResourceReadFailOnce
             | Scenario::DynamicToolset => {
                 let name = payload
                     .get("name")
@@ -342,6 +345,7 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ToolsListFailAfterFirst
             | Scenario::ToolCallTimeout
             | Scenario::StructuredContent
+            | Scenario::ResourceReadFailOnce
             | Scenario::DynamicToolset => {
                 if id == 1 {
                     Ok(
@@ -378,6 +382,7 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ToolsListFailAfterFirst
             | Scenario::ToolCallTimeout
             | Scenario::StructuredContent
+            | Scenario::ResourceReadFailOnce
             | Scenario::DynamicToolset => {
                 let body = Body::from_stream(stream::iter(vec![
                     Ok::<Bytes, std::convert::Infallible>(Bytes::from_static(
@@ -424,6 +429,7 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ToolsListFailAfterFirst
             | Scenario::ToolCallTimeout
             | Scenario::StructuredContent
+            | Scenario::ResourceReadFailOnce
             | Scenario::DynamicToolset => {
                 let response = match query.cursor.as_deref() {
                     None => json!({
@@ -470,6 +476,7 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ToolsListFailAfterFirst
             | Scenario::ToolCallTimeout
             | Scenario::StructuredContent
+            | Scenario::ResourceReadFailOnce
             | Scenario::DynamicToolset => {
                 let response = match query.offset {
                     None | Some(0) => json!({

--- a/tests/local_e2e_test.rs
+++ b/tests/local_e2e_test.rs
@@ -1702,6 +1702,54 @@ fn test_mcp_stdio_subscribe_with_read_resource_writes_snapshots() {
 
 #[test]
 #[serial_test::serial]
+fn test_mcp_stdio_subscribe_with_read_resource_initial_failure_keeps_running() {
+    let bin = test_server_binary("mcp-stdio");
+    let endpoint = format!("{} resource_read_fail_once", bin.display());
+    let test_home = fresh_test_home_dir();
+    let sink_path = test_home.join("mcp-subscribe-read-fail-once.ndjson");
+    let sink_spec = format!("file:{}", sink_path.display());
+
+    let start = run_uxc_in_home(
+        &[
+            "subscribe",
+            "start",
+            &endpoint,
+            "--resource-uri",
+            "test://resource",
+            "--read-resource",
+            "--sink",
+            &sink_spec,
+        ],
+        &test_home,
+    );
+    assert!(start.is_ok(), "MCP subscribe start failed: {:?}", start);
+    let start_json: serde_json::Value = serde_json::from_str(&start.unwrap()).unwrap();
+    assert_eq!(start_json["ok"], true);
+    let job_id = start_json["data"]["job_id"].as_str().unwrap().to_string();
+
+    assert!(
+        wait_for_file_contains(
+            &sink_path,
+            "failed to read initial resource snapshot",
+            Duration::from_secs(5)
+        ),
+        "MCP subscribe sink did not capture the initial read error"
+    );
+    assert!(
+        wait_for_file_contains(
+            &sink_path,
+            r#""event_kind":"snapshot""#,
+            Duration::from_secs(5)
+        ),
+        "MCP subscribe sink did not recover with a later snapshot"
+    );
+
+    let stop = run_uxc_in_home(&["subscribe", "stop", &job_id], &test_home);
+    assert!(stop.is_ok(), "MCP subscribe stop failed: {:?}", stop);
+}
+
+#[test]
+#[serial_test::serial]
 fn test_mcp_http_subscribe_start_status_stop_writes_file() {
     let server = start_test_server("mcp-http", "ok");
     let endpoint = mcp_http_endpoint(&server.addr);
@@ -1800,6 +1848,58 @@ fn test_mcp_http_subscribe_with_read_resource_writes_snapshots() {
             Duration::from_secs(5)
         ),
         "MCP HTTP subscribe sink did not capture resource payloads"
+    );
+
+    let stop = run_uxc_in_home(&["subscribe", "stop", &job_id], &test_home);
+    assert!(stop.is_ok(), "MCP HTTP subscribe stop failed: {:?}", stop);
+}
+
+#[test]
+#[serial_test::serial]
+fn test_mcp_http_subscribe_with_read_resource_initial_failure_keeps_running() {
+    let server = start_test_server("mcp-http", "resource_read_fail_once");
+    let endpoint = mcp_http_endpoint(&server.addr);
+    let test_home = fresh_test_home_dir();
+    let sink_path = test_home.join("mcp-http-subscribe-read-fail-once.ndjson");
+    let sink_spec = format!("file:{}", sink_path.display());
+
+    let start = run_uxc_in_home(
+        &[
+            "subscribe",
+            "start",
+            &endpoint,
+            "--resource-uri",
+            "test://resource",
+            "--read-resource",
+            "--sink",
+            &sink_spec,
+        ],
+        &test_home,
+    );
+    assert!(
+        start.is_ok(),
+        "MCP HTTP subscribe start failed: {:?}",
+        start
+    );
+    let start_json: serde_json::Value = serde_json::from_str(&start.unwrap()).unwrap();
+    assert_eq!(start_json["ok"], true);
+    let job_id = start_json["data"]["job_id"].as_str().unwrap().to_string();
+
+    assert!(
+        wait_for_file_contains(
+            &sink_path,
+            "failed to read initial resource snapshot",
+            Duration::from_secs(5)
+        ),
+        "MCP HTTP subscribe sink did not capture the initial read error"
+    );
+    assert!(
+        wait_for_file_contains(
+            &sink_path,
+            r#""event_kind":"snapshot""#,
+            Duration::from_secs(5)
+        ),
+        "MCP HTTP subscribe sink did not recover with a later snapshot"
     );
 
     let stop = run_uxc_in_home(&["subscribe", "stop", &job_id], &test_home);

--- a/tests/subscribe_cli_test.rs
+++ b/tests/subscribe_cli_test.rs
@@ -112,6 +112,34 @@ fn subscribe_rejects_read_resource_without_resource_uri() {
 
 #[test]
 #[serial]
+fn subscribe_rejects_read_resource_with_poll_mode() {
+    let (temp, mut command) = isolated_uxc_command();
+    let sink = format!("file:{}", temp.path().join("events.ndjson").display());
+    let output = command
+        .arg("subscribe")
+        .arg("start")
+        .arg("https://example.com/mcp")
+        .arg("--resource-uri")
+        .arg("test://resource")
+        .arg("--read-resource")
+        .arg("--mode")
+        .arg("poll")
+        .arg("--sink")
+        .arg(&sink)
+        .output()
+        .expect("subscribe start should run");
+    assert!(!output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "INVALID_ARGUMENT");
+    assert!(json["error"]["message"]
+        .as_str()
+        .is_some_and(|msg| msg.contains("--read-resource is only valid with --mode stream")));
+}
+
+#[test]
+#[serial]
 fn subscribe_rejects_websocket_transport_with_operation_id() {
     let (temp, mut command) = isolated_uxc_command();
     let sink = format!("file:{}", temp.path().join("events.ndjson").display());


### PR DESCRIPTION
## Summary
- add an optional `--read-resource` mode for MCP resource subscriptions
- emit `snapshot` sink events by calling `resources/read` after initial subscribe and after each `notifications/resources/updated`
- extend the MCP HTTP transport abstraction so both streamable HTTP and legacy SSE paths can read resources
- add CLI and local e2e coverage for stdio and MCP HTTP resource snapshots while preserving the existing default notification-only behavior

## Testing
- `cargo test --test subscribe_cli_test subscribe_rejects_read_resource_without_resource_uri -- --nocapture`
- `cargo test --test local_e2e_test test_mcp_stdio_subscribe_with_read_resource_writes_snapshots -- --nocapture`
- `cargo test --test local_e2e_test test_mcp_http_subscribe_with_read_resource_writes_snapshots -- --nocapture`
- `cargo test --test local_e2e_test test_mcp_stdio_subscribe_start_status_stop_writes_file -- --nocapture`
- `cargo test --test local_e2e_test test_mcp_http_subscribe_start_status_stop_writes_file -- --nocapture`

## Context
This is a prerequisite for the `holon-host` inbox/subscription path. With this change, `holon-host` can consume MCP resource subscriptions from `uxc` as a combined notification-plus-snapshot stream instead of reimplementing `resources/read` handling itself.
