### PR TITLE
feat: add DexScreener public OpenAPI skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -39,6 +39,8 @@ This repository ships one canonical skill for UXC (Universal X-Protocol CLI) and
   - Wrapper for DingTalk v1.0 messaging workflows via UXC + curated OpenAPI schema and app-token bearer auth.
 - `skills/coinapi-openapi-skill`
   - Wrapper for CoinAPI REST market data reads via UXC + curated OpenAPI schema and API-key auth.
+- `skills/dexscreener-openapi-skill`
+  - Wrapper for DexScreener public market data and DEX pair reads via UXC + curated OpenAPI schema and no-auth setup.
 - `skills/alchemy-openapi-skill`
   - Wrapper for Alchemy Prices API read workflows via UXC + curated OpenAPI schema and path-templated API-key auth.
 - `skills/chainbase-openapi-skill`
@@ -83,7 +85,7 @@ python ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github
   --path skills/deepwiki-mcp-skill
 ```
 
-Replace `skills/deepwiki-mcp-skill` with `skills/context7-mcp-skill`, `skills/okx-mcp-skill`, `skills/dune-mcp-skill`, `skills/thegraph-mcp-skill`, `skills/thegraph-token-mcp-skill`, `skills/etherscan-mcp-skill`, `skills/notion-mcp-skill`, `skills/discord-openapi-skill`, `skills/slack-openapi-skill`, `skills/matrix-openapi-skill`, `skills/line-openapi-skill`, `skills/feishu-openapi-skill`, `skills/whatsapp-openapi-skill`, `skills/dingtalk-openapi-skill`, `skills/coingecko-openapi-skill`, `skills/defillama-openapi-skill`, `skills/blockscout-openapi-skill`, `skills/chainbase-openapi-skill`, `skills/moralis-openapi-skill`, `skills/alchemy-openapi-skill`, `skills/coinapi-openapi-skill`, `skills/binance-web3-openapi-skill`, or `skills/binance-spot-openapi-skill` as needed.
+Replace `skills/deepwiki-mcp-skill` with `skills/context7-mcp-skill`, `skills/okx-mcp-skill`, `skills/dune-mcp-skill`, `skills/thegraph-mcp-skill`, `skills/thegraph-token-mcp-skill`, `skills/etherscan-mcp-skill`, `skills/notion-mcp-skill`, `skills/discord-openapi-skill`, `skills/slack-openapi-skill`, `skills/matrix-openapi-skill`, `skills/line-openapi-skill`, `skills/feishu-openapi-skill`, `skills/whatsapp-openapi-skill`, `skills/dingtalk-openapi-skill`, `skills/coingecko-openapi-skill`, `skills/defillama-openapi-skill`, `skills/blockscout-openapi-skill`, `skills/chainbase-openapi-skill`, `skills/moralis-openapi-skill`, `skills/alchemy-openapi-skill`, `skills/coinapi-openapi-skill`, `skills/dexscreener-openapi-skill`, `skills/binance-web3-openapi-skill`, or `skills/binance-spot-openapi-skill` as needed.
 
 After installation, restart Codex to load new skills.
 
@@ -182,6 +184,12 @@ bash skills/dingtalk-openapi-skill/scripts/validate.sh
 
 ```bash
 bash skills/coinapi-openapi-skill/scripts/validate.sh
+```
+
+- Validate DexScreener wrapper docs when touched:
+
+```bash
+bash skills/dexscreener-openapi-skill/scripts/validate.sh
 ```
 
 - Validate Alchemy wrapper docs when touched:

--- a/skills/dexscreener-openapi-skill/SKILL.md
+++ b/skills/dexscreener-openapi-skill/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: dexscreener-openapi-skill
+description: Operate DexScreener public market data APIs through UXC with a curated OpenAPI schema, no-auth setup, and read-first guardrails.
+---
+
+# DexScreener API Skill
+
+Use this skill to run DexScreener public market data operations through `uxc` + OpenAPI.
+
+Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- Network access to `https://api.dexscreener.com`.
+- Access to the curated OpenAPI schema URL:
+  - `https://raw.githubusercontent.com/holon-run/uxc/main/skills/dexscreener-openapi-skill/references/dexscreener-public.openapi.json`
+
+## Scope
+
+This skill covers a read-first DexScreener surface for:
+
+- token profile discovery
+- latest and top token boosts
+- pair search by free-text query
+- pair lookup by chain and pair address
+- token market lookup by chain and token address list
+
+This skill does **not** cover:
+
+- write operations
+- private or authenticated workflows
+- every DexScreener endpoint
+- trading or wallet execution
+
+## Authentication
+
+DexScreener public reads in this skill do not require authentication.
+
+## Core Workflow
+
+1. Use the fixed link command by default:
+   - `command -v dexscreener-openapi-cli`
+   - If missing, create it:
+     `uxc link dexscreener-openapi-cli https://api.dexscreener.com --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/dexscreener-openapi-skill/references/dexscreener-public.openapi.json`
+   - `dexscreener-openapi-cli -h`
+
+2. Inspect operation schema first:
+   - `dexscreener-openapi-cli get:/token-profiles/latest/v1 -h`
+   - `dexscreener-openapi-cli get:/latest/dex/search -h`
+   - `dexscreener-openapi-cli get:/latest/dex/pairs/{chainId}/{pairId} -h`
+   - `dexscreener-openapi-cli get:/tokens/v1/{chainId}/{tokenAddresses} -h`
+
+3. Prefer narrow reads before broader scans:
+   - `dexscreener-openapi-cli get:/token-profiles/latest/v1`
+   - `dexscreener-openapi-cli get:/token-boosts/latest/v1`
+   - `dexscreener-openapi-cli get:/latest/dex/search q=solana`
+
+4. Execute with key/value parameters:
+   - `dexscreener-openapi-cli get:/latest/dex/pairs/{chainId}/{pairId} chainId=solana pairId=GgzbfpKtozV6Hyiahkh2yNVZBZsJa4pcetCmjNtgEXiM`
+   - `dexscreener-openapi-cli get:/tokens/v1/{chainId}/{tokenAddresses} chainId=solana tokenAddresses=So11111111111111111111111111111111111111112`
+
+## Operations
+
+- `get:/token-profiles/latest/v1`
+- `get:/token-boosts/latest/v1`
+- `get:/token-boosts/top/v1`
+- `get:/latest/dex/search`
+- `get:/latest/dex/pairs/{chainId}/{pairId}`
+- `get:/tokens/v1/{chainId}/{tokenAddresses}`
+
+## Guardrails
+
+- Keep automation on the JSON output envelope; do not use `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- Treat this v1 skill as read-only. Do not imply order entry, swaps, or wallet operations.
+- Keep `q` focused to a token, pair, chain, or symbol rather than broad crawler-style searches.
+- For `tokenAddresses`, start with a single address or a short comma-separated list before scaling up.
+- DexScreener data is market-observation oriented and may be noisier on long-tail tokens than curated exchange-only feeds.
+- `dexscreener-openapi-cli <operation> ...` is equivalent to `uxc https://api.dexscreener.com --schema-url <dexscreener_openapi_schema> <operation> ...`.
+
+## References
+
+- Usage patterns: `references/usage-patterns.md`
+- Curated OpenAPI schema: `references/dexscreener-public.openapi.json`
+- DexScreener API reference: https://docs.dexscreener.com/api/reference

--- a/skills/dexscreener-openapi-skill/agents/openai.yaml
+++ b/skills/dexscreener-openapi-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DexScreener API"
+  short_description: "Operate DexScreener public market and DEX pair reads via UXC + curated OpenAPI schema"
+  default_prompt: "Use $dexscreener-openapi-skill to discover and execute DexScreener public read-only market data operations through UXC with a curated OpenAPI schema and no-auth setup."

--- a/skills/dexscreener-openapi-skill/references/dexscreener-public.openapi.json
+++ b/skills/dexscreener-openapi-skill/references/dexscreener-public.openapi.json
@@ -1,0 +1,354 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "DexScreener Public API",
+    "version": "1.0.0",
+    "description": "Curated public DexScreener market data operations for UXC."
+  },
+  "servers": [
+    {
+      "url": "https://api.dexscreener.com"
+    }
+  ],
+  "paths": {
+    "/token-profiles/latest/v1": {
+      "get": {
+        "operationId": "getTokenProfilesLatestV1",
+        "summary": "Get latest token profiles",
+        "responses": {
+          "200": {
+            "description": "Latest token profiles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TokenProfile"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token-boosts/latest/v1": {
+      "get": {
+        "operationId": "getTokenBoostsLatestV1",
+        "summary": "Get latest token boosts",
+        "responses": {
+          "200": {
+            "description": "Latest token boosts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TokenBoost"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token-boosts/top/v1": {
+      "get": {
+        "operationId": "getTokenBoostsTopV1",
+        "summary": "Get top token boosts",
+        "responses": {
+          "200": {
+            "description": "Top token boosts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TokenBoost"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/latest/dex/search": {
+      "get": {
+        "operationId": "getLatestDexSearch",
+        "summary": "Search pairs by query",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Free-text token, symbol, or pair query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pair search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/latest/dex/pairs/{chainId}/{pairId}": {
+      "get": {
+        "operationId": "getLatestDexPairsByChainAndPair",
+        "summary": "Get pair market data by chain and pair address",
+        "parameters": [
+          {
+            "name": "chainId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pairId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pair lookup result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tokens/v1/{chainId}/{tokenAddresses}": {
+      "get": {
+        "operationId": "getTokensV1ByChainAndAddresses",
+        "summary": "Get token market rows by chain and token addresses",
+        "parameters": [
+          {
+            "name": "chainId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tokenAddresses",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "One token address or a comma-separated list of token addresses"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token market rows",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pair"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Link": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "TokenRef": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          }
+        }
+      },
+      "TokenProfile": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "chainId": {
+            "type": "string"
+          },
+          "tokenAddress": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "header": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            }
+          }
+        }
+      },
+      "TokenBoost": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "chainId": {
+            "type": "string"
+          },
+          "tokenAddress": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "header": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "amount": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "totalAmount": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            }
+          }
+        }
+      },
+      "Pair": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "chainId": {
+            "type": "string"
+          },
+          "dexId": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "pairAddress": {
+            "type": "string"
+          },
+          "baseToken": {
+            "$ref": "#/components/schemas/TokenRef"
+          },
+          "quoteToken": {
+            "$ref": "#/components/schemas/TokenRef"
+          },
+          "priceNative": {
+            "type": "string"
+          },
+          "priceUsd": {
+            "type": "string"
+          },
+          "liquidity": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "fdv": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "marketCap": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "boosts": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "PairListResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "schemaVersion": {
+            "type": "string"
+          },
+          "pairs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Pair"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/skills/dexscreener-openapi-skill/references/usage-patterns.md
+++ b/skills/dexscreener-openapi-skill/references/usage-patterns.md
@@ -1,0 +1,41 @@
+# DexScreener API Skill - Usage Patterns
+
+## Link Setup
+
+```bash
+command -v dexscreener-openapi-cli
+uxc link dexscreener-openapi-cli https://api.dexscreener.com \
+  --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/dexscreener-openapi-skill/references/dexscreener-public.openapi.json
+dexscreener-openapi-cli -h
+```
+
+## Read Examples
+
+```bash
+# Read the latest token profile feed
+dexscreener-openapi-cli get:/token-profiles/latest/v1
+
+# Read latest boosted tokens
+dexscreener-openapi-cli get:/token-boosts/latest/v1
+
+# Read top boosted tokens
+dexscreener-openapi-cli get:/token-boosts/top/v1
+
+# Search pairs by query
+dexscreener-openapi-cli get:/latest/dex/search q=solana
+
+# Read a specific pair on one chain
+dexscreener-openapi-cli get:/latest/dex/pairs/{chainId}/{pairId} \
+  chainId=solana \
+  pairId=GgzbfpKtozV6Hyiahkh2yNVZBZsJa4pcetCmjNtgEXiM
+
+# Read token market rows for one token address on one chain
+dexscreener-openapi-cli get:/tokens/v1/{chainId}/{tokenAddresses} \
+  chainId=solana \
+  tokenAddresses=So11111111111111111111111111111111111111112
+```
+
+## Fallback Equivalence
+
+- `dexscreener-openapi-cli <operation> ...` is equivalent to
+  `uxc https://api.dexscreener.com --schema-url <dexscreener_openapi_schema> <operation> ...`.

--- a/skills/dexscreener-openapi-skill/scripts/validate.sh
+++ b/skills/dexscreener-openapi-skill/scripts/validate.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/dexscreener-openapi-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+USAGE_FILE="${SKILL_DIR}/references/usage-patterns.md"
+SCHEMA_FILE="${SKILL_DIR}/references/dexscreener-public.openapi.json"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd jq
+need_cmd rg
+
+for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}" "${SCHEMA_FILE}"; do
+  [[ -f "${file}" ]] || fail "missing required file: ${file}"
+done
+
+jq -e '.openapi and .paths and .components' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'invalid OpenAPI schema JSON or missing .openapi/.paths/.components'
+jq -e '.paths["/token-profiles/latest/v1"] and .paths["/latest/dex/search"] and .paths["/tokens/v1/{chainId}/{tokenAddresses}"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing expected DexScreener paths'
+jq -e '.paths["/latest/dex/pairs/{chainId}/{pairId}"].get and .paths["/token-boosts/top/v1"].get' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema must expose expected GET operations'
+
+rg -q '^name:\s*dexscreener-openapi-skill\s*$' "${SKILL_FILE}" || fail 'invalid skill name'
+rg -q '^description:\s*.+' "${SKILL_FILE}" || fail 'missing description'
+
+rg -q 'command -v dexscreener-openapi-cli' "${SKILL_FILE}" || fail 'missing link-first command check'
+rg -q 'uxc link dexscreener-openapi-cli https://api.dexscreener.com --schema-url ' "${SKILL_FILE}" || fail 'missing fixed link create command with schema-url'
+rg -F -q 'dexscreener-openapi-cli get:/latest/dex/search -h' "${SKILL_FILE}" || fail 'missing operation-level help example'
+rg -q 'no-auth setup' "${OPENAI_FILE}" || fail 'missing no-auth prompt guidance'
+rg -q 'read-only' "${SKILL_FILE}" || fail 'missing read-only guardrail'
+
+if rg -q -- "--args\\s+'\\{" "${SKILL_FILE}" "${USAGE_FILE}"; then
+  fail 'found banned legacy JSON argument pattern'
+fi
+
+rg -q '^\s*display_name:\s*"DexScreener API"\s*$' "${OPENAI_FILE}" || fail 'missing display_name'
+rg -q '^\s*short_description:\s*".+"\s*$' "${OPENAI_FILE}" || fail 'missing short_description'
+rg -q '^\s*default_prompt:\s*".*\$dexscreener-openapi-skill.*"\s*$' "${OPENAI_FILE}" || fail 'default_prompt must mention $dexscreener-openapi-skill'
+
+echo "skills/dexscreener-openapi-skill validation passed"


### PR DESCRIPTION
## What
- add `skills/dexscreener-openapi-skill`
- add a curated OpenAPI schema for a narrow public DexScreener read surface
- update `docs/skills.md`

## Why
`DexScreener` is the best next direct-provider addition from the refreshed `#168` backlog:
- clear DEX pair and long-tail token discovery value
- public read-only API with no auth bootstrap in v1
- stable enough to package as a curated UXC wrapper without depending on a third-party MCP layer

## How
- package the standard skill files: `SKILL.md`, `agents/openai.yaml`, `references/usage-patterns.md`, `scripts/validate.sh`
- scope v1 to token profiles, token boosts, pair search, pair lookup, and token market lookup
- keep the skill read-only and no-auth

## Testing
- `bash skills/dexscreener-openapi-skill/scripts/validate.sh`
- `cargo fmt --check`

Closes #304
Refs #168
