### PR TITLE
feat: add Helius Wallet API skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -41,6 +41,8 @@ This repository ships one canonical skill for UXC (Universal X-Protocol CLI) and
   - Wrapper for CoinAPI REST market data reads via UXC + curated OpenAPI schema and API-key auth.
 - `skills/dexscreener-openapi-skill`
   - Wrapper for DexScreener public market data and DEX pair reads via UXC + curated OpenAPI schema and no-auth setup.
+- `skills/helius-openapi-skill`
+  - Wrapper for Helius Wallet API wallet intelligence reads via UXC + curated OpenAPI schema and API-key auth.
 - `skills/alchemy-openapi-skill`
   - Wrapper for Alchemy Prices API read workflows via UXC + curated OpenAPI schema and path-templated API-key auth.
 - `skills/chainbase-openapi-skill`
@@ -85,7 +87,7 @@ python ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github
   --path skills/deepwiki-mcp-skill
 ```
 
-Replace `skills/deepwiki-mcp-skill` with `skills/context7-mcp-skill`, `skills/okx-mcp-skill`, `skills/dune-mcp-skill`, `skills/thegraph-mcp-skill`, `skills/thegraph-token-mcp-skill`, `skills/etherscan-mcp-skill`, `skills/notion-mcp-skill`, `skills/discord-openapi-skill`, `skills/slack-openapi-skill`, `skills/matrix-openapi-skill`, `skills/line-openapi-skill`, `skills/feishu-openapi-skill`, `skills/whatsapp-openapi-skill`, `skills/dingtalk-openapi-skill`, `skills/coingecko-openapi-skill`, `skills/defillama-openapi-skill`, `skills/blockscout-openapi-skill`, `skills/chainbase-openapi-skill`, `skills/moralis-openapi-skill`, `skills/alchemy-openapi-skill`, `skills/coinapi-openapi-skill`, `skills/dexscreener-openapi-skill`, `skills/binance-web3-openapi-skill`, or `skills/binance-spot-openapi-skill` as needed.
+Replace `skills/deepwiki-mcp-skill` with `skills/context7-mcp-skill`, `skills/okx-mcp-skill`, `skills/dune-mcp-skill`, `skills/thegraph-mcp-skill`, `skills/thegraph-token-mcp-skill`, `skills/etherscan-mcp-skill`, `skills/notion-mcp-skill`, `skills/discord-openapi-skill`, `skills/slack-openapi-skill`, `skills/matrix-openapi-skill`, `skills/line-openapi-skill`, `skills/feishu-openapi-skill`, `skills/whatsapp-openapi-skill`, `skills/dingtalk-openapi-skill`, `skills/coingecko-openapi-skill`, `skills/defillama-openapi-skill`, `skills/blockscout-openapi-skill`, `skills/chainbase-openapi-skill`, `skills/moralis-openapi-skill`, `skills/alchemy-openapi-skill`, `skills/coinapi-openapi-skill`, `skills/dexscreener-openapi-skill`, `skills/helius-openapi-skill`, `skills/binance-web3-openapi-skill`, or `skills/binance-spot-openapi-skill` as needed.
 
 After installation, restart Codex to load new skills.
 
@@ -190,6 +192,12 @@ bash skills/coinapi-openapi-skill/scripts/validate.sh
 
 ```bash
 bash skills/dexscreener-openapi-skill/scripts/validate.sh
+```
+
+- Validate Helius wrapper docs when touched:
+
+```bash
+bash skills/helius-openapi-skill/scripts/validate.sh
 ```
 
 - Validate Alchemy wrapper docs when touched:

--- a/skills/helius-openapi-skill/SKILL.md
+++ b/skills/helius-openapi-skill/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: helius-openapi-skill
+description: Operate Helius Wallet API reads through UXC with a curated OpenAPI schema, API-key auth, and read-first guardrails.
+---
+
+# Helius Wallet API Skill
+
+Use this skill to run Helius Wallet API operations through `uxc` + OpenAPI.
+
+Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- Network access to `https://api.helius.xyz`.
+- Access to the curated OpenAPI schema URL:
+  - `https://raw.githubusercontent.com/holon-run/uxc/main/skills/helius-openapi-skill/references/helius-wallet.openapi.json`
+- A Helius API key.
+
+## Scope
+
+This skill covers a read-first Helius Wallet API surface:
+
+- wallet identity lookup
+- batch identity lookup
+- wallet balances
+- wallet history
+- wallet transfers
+- wallet funding source lookup
+
+This skill does **not** cover:
+
+- Helius RPC, DAS, or WebSocket surfaces
+- transaction submission
+- webhook setup
+- the broader Helius platform beyond the selected wallet intelligence endpoints
+
+## Authentication
+
+Helius accepts API keys by query parameter or header. This skill standardizes on `X-Api-Key` header auth.
+
+Configure one API-key credential and bind it to `api.helius.xyz`:
+
+```bash
+uxc auth credential set helius \
+  --auth-type api_key \
+  --api-key-header X-Api-Key \
+  --secret-env HELIUS_API_KEY
+
+uxc auth binding add \
+  --id helius \
+  --host api.helius.xyz \
+  --scheme https \
+  --credential helius \
+  --priority 100
+```
+
+Validate the active mapping when auth looks wrong:
+
+```bash
+uxc auth binding match https://api.helius.xyz
+```
+
+## Core Workflow
+
+1. Use the fixed link command by default:
+   - `command -v helius-openapi-cli`
+   - If missing, create it:
+     `uxc link helius-openapi-cli https://api.helius.xyz --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/helius-openapi-skill/references/helius-wallet.openapi.json`
+   - `helius-openapi-cli -h`
+
+2. Inspect operation schema first:
+   - `helius-openapi-cli get:/v1/wallet/{wallet}/identity -h`
+   - `helius-openapi-cli post:/v1/wallet/batch-identity -h`
+   - `helius-openapi-cli get:/v1/wallet/{wallet}/balances -h`
+
+3. Prefer narrow validation before broader reads:
+   - `helius-openapi-cli get:/v1/wallet/{wallet}/identity wallet=HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664`
+   - `helius-openapi-cli get:/v1/wallet/{wallet}/funded-by wallet=HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664`
+   - `helius-openapi-cli get:/v1/wallet/{wallet}/balances wallet=HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664 page=1 limit=20 showNative=true`
+
+4. Execute with key/value parameters:
+   - `helius-openapi-cli post:/v1/wallet/batch-identity addresses:='["HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664"]'`
+   - `helius-openapi-cli get:/v1/wallet/{wallet}/history wallet=HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664 limit=20`
+   - `helius-openapi-cli get:/v1/wallet/{wallet}/transfers wallet=HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664 limit=20`
+
+## Operation Groups
+
+### Wallet Identity
+
+- `get:/v1/wallet/{wallet}/identity`
+- `post:/v1/wallet/batch-identity`
+- `get:/v1/wallet/{wallet}/funded-by`
+
+### Wallet Activity
+
+- `get:/v1/wallet/{wallet}/balances`
+- `get:/v1/wallet/{wallet}/history`
+- `get:/v1/wallet/{wallet}/transfers`
+
+## Guardrails
+
+- Keep automation on the JSON output envelope; do not use `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- Treat this v1 skill as read-only. Do not imply RPC write methods, transaction sending, or webhooks.
+- Helius labels the Wallet API as beta. Expect response shape drift and keep parsers focused on stable fields.
+- Start with small `limit` values before paginating large histories or transfer crawls.
+- Identity and funded-by lookups can return 404-style misses for unknown wallets; treat that as a data absence case before assuming auth failure.
+- `helius-openapi-cli <operation> ...` is equivalent to `uxc https://api.helius.xyz --schema-url <helius_openapi_schema> <operation> ...`.
+
+## References
+
+- Usage patterns: `references/usage-patterns.md`
+- Curated OpenAPI schema: `references/helius-wallet.openapi.json`
+- Helius authentication docs: https://www.helius.dev/docs/api-reference/authentication
+- Helius Wallet API docs: https://www.helius.dev/docs/api-reference/wallet-api

--- a/skills/helius-openapi-skill/agents/openai.yaml
+++ b/skills/helius-openapi-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Helius Wallet API"
+  short_description: "Operate Helius Solana wallet intelligence reads via UXC + curated OpenAPI schema"
+  default_prompt: "Use $helius-openapi-skill to discover and execute Helius Wallet API read-only operations through UXC with X-Api-Key auth and beta-surface guardrails."

--- a/skills/helius-openapi-skill/references/helius-wallet.openapi.json
+++ b/skills/helius-openapi-skill/references/helius-wallet.openapi.json
@@ -1,0 +1,422 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Helius Wallet API",
+    "version": "1.0.0",
+    "description": "Curated Helius Wallet API beta operations for UXC."
+  },
+  "servers": [
+    {
+      "url": "https://api.helius.xyz"
+    }
+  ],
+  "paths": {
+    "/v1/wallet/{wallet}/identity": {
+      "get": {
+        "operationId": "getWalletIdentity",
+        "summary": "Get wallet identity",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Wallet identity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Identity"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/wallet/batch-identity": {
+      "post": {
+        "operationId": "postWalletBatchIdentity",
+        "summary": "Batch wallet identity lookup",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "addresses"
+                ],
+                "properties": {
+                  "addresses": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Wallet identities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Identity"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/wallet/{wallet}/balances": {
+      "get": {
+        "operationId": "getWalletBalances",
+        "summary": "Get wallet balances",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "showZeroBalance",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "showNative",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "showNfts",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Wallet balances",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BalancesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/wallet/{wallet}/history": {
+      "get": {
+        "operationId": "getWalletHistory",
+        "summary": "Get wallet history",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tokenAccounts",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Wallet history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedDataResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/wallet/{wallet}/transfers": {
+      "get": {
+        "operationId": "getWalletTransfers",
+        "summary": "Get wallet transfers",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Wallet transfers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedDataResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/wallet/{wallet}/funded-by": {
+      "get": {
+        "operationId": "getWalletFundedBy",
+        "summary": "Get wallet funding source",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Wallet funding source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundedBy"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "XApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Api-Key"
+      }
+    },
+    "schemas": {
+      "Identity": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "BalanceRow": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "mint": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "balance": {
+            "type": [
+              "number",
+              "string",
+              "null"
+            ]
+          },
+          "usdValue": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "pricePerToken": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        }
+      },
+      "BalancesResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "wallet": {
+            "type": "string"
+          },
+          "totalUsdValue": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "page": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "balances": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BalanceRow"
+            }
+          }
+        }
+      },
+      "PaginatedDataResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "pagination": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "FundedBy": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "funder": {
+            "type": "string"
+          },
+          "funderName": {
+            "type": "string"
+          },
+          "funderType": {
+            "type": "string"
+          },
+          "amount": {
+            "type": [
+              "number",
+              "string",
+              "null"
+            ]
+          },
+          "timestamp": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "signature": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "XApiKey": []
+    }
+  ]
+}

--- a/skills/helius-openapi-skill/references/usage-patterns.md
+++ b/skills/helius-openapi-skill/references/usage-patterns.md
@@ -1,0 +1,70 @@
+# Helius Wallet API Skill - Usage Patterns
+
+## Link Setup
+
+```bash
+command -v helius-openapi-cli
+uxc link helius-openapi-cli https://api.helius.xyz \
+  --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/helius-openapi-skill/references/helius-wallet.openapi.json
+helius-openapi-cli -h
+```
+
+## Auth Setup
+
+```bash
+uxc auth credential set helius \
+  --auth-type api_key \
+  --api-key-header X-Api-Key \
+  --secret-env HELIUS_API_KEY
+
+uxc auth binding add \
+  --id helius \
+  --host api.helius.xyz \
+  --scheme https \
+  --credential helius \
+  --priority 100
+```
+
+Validate the binding:
+
+```bash
+uxc auth binding match https://api.helius.xyz
+```
+
+## Read Examples
+
+```bash
+# Identify a wallet with a known label
+helius-openapi-cli get:/v1/wallet/{wallet}/identity \
+  wallet=HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664
+
+# Batch identity lookup for one or more addresses
+helius-openapi-cli post:/v1/wallet/batch-identity \
+  addresses:='["HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664"]'
+
+# Read balances with a small page size first
+helius-openapi-cli get:/v1/wallet/{wallet}/balances \
+  wallet=HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664 \
+  page=1 \
+  limit=20 \
+  showNative=true
+
+# Read recent wallet history
+helius-openapi-cli get:/v1/wallet/{wallet}/history \
+  wallet=HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664 \
+  limit=20
+
+# Read recent transfers
+helius-openapi-cli get:/v1/wallet/{wallet}/transfers \
+  wallet=HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664 \
+  limit=20
+
+# Discover the wallet's original funding source
+helius-openapi-cli get:/v1/wallet/{wallet}/funded-by \
+  wallet=HXsKP7wrBWaQ8T2Vtjry3Nj3oUgwYcqq9vrHDM12G664
+```
+
+## Fallback Equivalence
+
+- `helius-openapi-cli <operation> ...` is equivalent to
+  `uxc https://api.helius.xyz --schema-url <helius_openapi_schema> <operation> ...`.

--- a/skills/helius-openapi-skill/scripts/validate.sh
+++ b/skills/helius-openapi-skill/scripts/validate.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/helius-openapi-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+USAGE_FILE="${SKILL_DIR}/references/usage-patterns.md"
+SCHEMA_FILE="${SKILL_DIR}/references/helius-wallet.openapi.json"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd jq
+need_cmd rg
+
+for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}" "${SCHEMA_FILE}"; do
+  [[ -f "${file}" ]] || fail "missing required file: ${file}"
+done
+
+jq -e '.openapi and .paths and .components' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'invalid OpenAPI schema JSON or missing .openapi/.paths/.components'
+jq -e '.paths["/v1/wallet/{wallet}/identity"] and .paths["/v1/wallet/batch-identity"] and .paths["/v1/wallet/{wallet}/balances"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing expected Helius wallet paths'
+jq -e '.paths["/v1/wallet/batch-identity"].post and .paths["/v1/wallet/{wallet}/history"].get and .paths["/v1/wallet/{wallet}/funded-by"].get' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema must expose expected GET/POST operations'
+
+rg -q '^name:\s*helius-openapi-skill\s*$' "${SKILL_FILE}" || fail 'invalid skill name'
+rg -q '^description:\s*.+' "${SKILL_FILE}" || fail 'missing description'
+
+rg -q 'command -v helius-openapi-cli' "${SKILL_FILE}" || fail 'missing link-first command check'
+rg -q 'uxc link helius-openapi-cli https://api.helius.xyz --schema-url ' "${SKILL_FILE}" || fail 'missing fixed link create command with schema-url'
+rg -F -q 'helius-openapi-cli post:/v1/wallet/batch-identity -h' "${SKILL_FILE}" || fail 'missing operation-level help example'
+rg -q -- '--api-key-header X-Api-Key' "${SKILL_FILE}" || fail 'missing api key setup'
+rg -q 'uxc auth binding match https://api.helius.xyz' "${SKILL_FILE}" || fail 'missing binding match check'
+rg -q 'beta' "${SKILL_FILE}" || fail 'missing beta surface guardrail'
+
+if rg -q -- "--args\\s+'\\{" "${SKILL_FILE}" "${USAGE_FILE}"; then
+  fail 'found banned legacy JSON argument pattern'
+fi
+
+rg -q '^\s*display_name:\s*"Helius Wallet API"\s*$' "${OPENAI_FILE}" || fail 'missing display_name'
+rg -q '^\s*short_description:\s*".+"\s*$' "${OPENAI_FILE}" || fail 'missing short_description'
+rg -q '^\s*default_prompt:\s*".*\$helius-openapi-skill.*"\s*$' "${OPENAI_FILE}" || fail 'default_prompt must mention $helius-openapi-skill'
+
+echo "skills/helius-openapi-skill validation passed"


### PR DESCRIPTION
## What
- add `skills/helius-openapi-skill`
- add a curated OpenAPI schema for a narrow Helius Wallet API read surface
- update `docs/skills.md`

## Why
`Helius` is the highest-value direct-provider addition after `DexScreener` because it materially expands Solana-native coverage.

This PR intentionally scopes v1 to Wallet API reads so we get immediate agent value without trying to wrap the full Helius platform in one pass.

## How
- package the standard skill files: `SKILL.md`, `agents/openai.yaml`, `references/usage-patterns.md`, `scripts/validate.sh`
- scope v1 to identity, batch identity, balances, history, transfers, and funded-by
- keep the skill read-only and explicitly note the Wallet API beta surface

## Testing
- `bash skills/helius-openapi-skill/scripts/validate.sh`
- `cargo fmt --check`

Closes #306
Refs #168
