### PR TITLE
feat: add Hive Intelligence MCP skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -47,6 +47,8 @@ This repository ships one canonical skill for UXC (Universal X-Protocol CLI) and
   - Wrapper for Blocknative gas price and fee intelligence reads via UXC + curated OpenAPI schema and API-key auth.
 - `skills/near-jsonrpc-skill`
   - Wrapper for NEAR JSON-RPC reads via UXC + provider-aware public RPC default and deprecated-endpoint guardrails.
+- `skills/hive-mcp-skill`
+  - Wrapper for Hive Intelligence official remote MCP workflows via UXC as a broad crypto discovery and convenience layer.
 - `skills/alchemy-openapi-skill`
   - Wrapper for Alchemy Prices API read workflows via UXC + curated OpenAPI schema and path-templated API-key auth.
 - `skills/chainbase-openapi-skill`
@@ -91,7 +93,7 @@ python ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github
   --path skills/deepwiki-mcp-skill
 ```
 
-Replace `skills/deepwiki-mcp-skill` with `skills/context7-mcp-skill`, `skills/okx-mcp-skill`, `skills/dune-mcp-skill`, `skills/thegraph-mcp-skill`, `skills/thegraph-token-mcp-skill`, `skills/etherscan-mcp-skill`, `skills/notion-mcp-skill`, `skills/discord-openapi-skill`, `skills/slack-openapi-skill`, `skills/matrix-openapi-skill`, `skills/line-openapi-skill`, `skills/feishu-openapi-skill`, `skills/whatsapp-openapi-skill`, `skills/dingtalk-openapi-skill`, `skills/coingecko-openapi-skill`, `skills/defillama-openapi-skill`, `skills/blockscout-openapi-skill`, `skills/chainbase-openapi-skill`, `skills/moralis-openapi-skill`, `skills/alchemy-openapi-skill`, `skills/coinapi-openapi-skill`, `skills/dexscreener-openapi-skill`, `skills/helius-openapi-skill`, `skills/blocknative-openapi-skill`, `skills/near-jsonrpc-skill`, `skills/binance-web3-openapi-skill`, or `skills/binance-spot-openapi-skill` as needed.
+Replace `skills/deepwiki-mcp-skill` with `skills/context7-mcp-skill`, `skills/okx-mcp-skill`, `skills/dune-mcp-skill`, `skills/thegraph-mcp-skill`, `skills/thegraph-token-mcp-skill`, `skills/etherscan-mcp-skill`, `skills/notion-mcp-skill`, `skills/discord-openapi-skill`, `skills/slack-openapi-skill`, `skills/matrix-openapi-skill`, `skills/line-openapi-skill`, `skills/feishu-openapi-skill`, `skills/whatsapp-openapi-skill`, `skills/dingtalk-openapi-skill`, `skills/coingecko-openapi-skill`, `skills/defillama-openapi-skill`, `skills/blockscout-openapi-skill`, `skills/chainbase-openapi-skill`, `skills/moralis-openapi-skill`, `skills/alchemy-openapi-skill`, `skills/coinapi-openapi-skill`, `skills/dexscreener-openapi-skill`, `skills/helius-openapi-skill`, `skills/blocknative-openapi-skill`, `skills/near-jsonrpc-skill`, `skills/hive-mcp-skill`, `skills/binance-web3-openapi-skill`, or `skills/binance-spot-openapi-skill` as needed.
 
 After installation, restart Codex to load new skills.
 
@@ -214,6 +216,12 @@ bash skills/blocknative-openapi-skill/scripts/validate.sh
 
 ```bash
 bash skills/near-jsonrpc-skill/scripts/validate.sh
+```
+
+- Validate Hive wrapper docs when touched:
+
+```bash
+bash skills/hive-mcp-skill/scripts/validate.sh
 ```
 
 - Validate Alchemy wrapper docs when touched:

--- a/skills/hive-mcp-skill/SKILL.md
+++ b/skills/hive-mcp-skill/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: hive-mcp-skill
+description: Use Hive Intelligence MCP through UXC for broad crypto market, onchain, portfolio, and risk workflows with help-first discovery and convenience-layer guardrails.
+---
+
+# Hive Intelligence MCP Skill
+
+Use this skill to run Hive Intelligence MCP operations through `uxc`.
+
+Reuse the `uxc` skill for shared protocol discovery, output parsing, and generic auth handling.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- Network access to `https://hiveintelligence.xyz/mcp`.
+- Access to the official Hive MCP documentation:
+  - `https://hiveintelligence.xyz/crypto-market-data-mcp`
+
+## Scope
+
+This skill covers the official remote Hive MCP surface for:
+
+- category-level endpoint discovery
+- crypto market and onchain data discovery
+- wallet and portfolio lookup workflows
+- security and risk endpoint discovery
+- schema inspection for underlying API endpoints
+- endpoint invocation through Hive's MCP tool layer
+
+This skill does **not** cover:
+
+- direct replacement of first-party provider integrations
+- assuming one Hive endpoint has the same data quality as the underlying provider skill
+- write operations without separate explicit review
+
+## Positioning
+
+Hive is an official remote MCP convenience layer.
+
+Use it when a user wants one broad crypto MCP entrypoint quickly.
+
+Do not treat Hive as a substitute for direct provider integrations like `DexScreener`, `Helius`, `Blocknative`, or other first-party skills where long-term provider coverage quality matters.
+
+## Endpoint
+
+Use the official Hive MCP endpoint:
+
+- `https://hiveintelligence.xyz/mcp`
+
+## Authentication
+
+The public help-first flow for this skill works without a local auth bootstrap.
+
+If Hive later introduces auth for higher-tier access, verify the runtime error and bind credentials before extending this skill.
+
+## Core Workflow
+
+1. Use the fixed link command by default:
+   - `command -v hive-mcp-cli`
+   - If missing, create it:
+     `uxc link hive-mcp-cli https://hiveintelligence.xyz/mcp`
+   - `hive-mcp-cli -h`
+
+2. Discover categories first:
+   - `hive-mcp-cli get_market_and_price_endpoints`
+   - `hive-mcp-cli get_onchain_dex_pool_endpoints`
+   - `hive-mcp-cli get_portfolio_wallet_endpoints`
+   - `hive-mcp-cli get_security_risk_endpoints`
+
+3. Inspect endpoint schema before invoking:
+   - `hive-mcp-cli get_api_endpoint_schema endpoint=get_token_price`
+   - `hive-mcp-cli get_api_endpoint_schema endpoint=get_wallet_portfolio`
+
+4. Invoke only after confirming the schema:
+   - `hive-mcp-cli invoke_api_endpoint endpoint_name=get_token_price args:='{"symbol":"BTC"}'`
+   - `hive-mcp-cli invoke_api_endpoint endpoint_name=get_wallet_portfolio args:='{"address":"0xd8da6bf26964af9d7eed9e03e53415d37aa96045"}'`
+
+## Recommended Discovery Operations
+
+- `get_market_and_price_endpoints`
+- `get_onchain_dex_pool_endpoints`
+- `get_portfolio_wallet_endpoints`
+- `get_token_contract_endpoints`
+- `get_security_risk_endpoints`
+- `get_network_infrastructure_endpoints`
+
+## Guardrails
+
+- Keep automation on the JSON output envelope; do not rely on `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- Treat Hive as a convenience aggregation layer, not as the canonical source when a direct provider skill already exists.
+- Always inspect a target endpoint schema with `get_api_endpoint_schema` before calling `invoke_api_endpoint`.
+- Keep `invoke_api_endpoint` payloads narrow and explicit; do not guess large nested arg objects.
+- If a workflow becomes repetitive on one underlying provider surface, prefer a dedicated first-party skill over routing everything through Hive indefinitely.
+- `hive-mcp-cli <operation> ...` is equivalent to `uxc https://hiveintelligence.xyz/mcp <operation> ...`.
+
+## References
+
+- Usage patterns: `references/usage-patterns.md`
+- Hive MCP docs: https://hiveintelligence.xyz/crypto-market-data-mcp

--- a/skills/hive-mcp-skill/agents/openai.yaml
+++ b/skills/hive-mcp-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Hive Intelligence MCP"
+  short_description: "Use Hive's official remote crypto MCP as a broad discovery and convenience layer via UXC"
+  default_prompt: "Use $hive-mcp-skill to discover and execute Hive Intelligence MCP operations through UXC as a broad crypto convenience layer, inspecting endpoint schemas before invocation."

--- a/skills/hive-mcp-skill/references/usage-patterns.md
+++ b/skills/hive-mcp-skill/references/usage-patterns.md
@@ -1,0 +1,45 @@
+# Hive Intelligence MCP Skill - Usage Patterns
+
+## Link Setup
+
+```bash
+command -v hive-mcp-cli
+uxc link hive-mcp-cli https://hiveintelligence.xyz/mcp
+hive-mcp-cli -h
+```
+
+## Discovery Examples
+
+```bash
+# Discover market-oriented endpoint groups
+hive-mcp-cli get_market_and_price_endpoints
+
+# Discover onchain DEX and pool analytics endpoints
+hive-mcp-cli get_onchain_dex_pool_endpoints
+
+# Discover wallet and portfolio endpoints
+hive-mcp-cli get_portfolio_wallet_endpoints
+
+# Discover token and contract endpoints
+hive-mcp-cli get_token_contract_endpoints
+
+# Discover risk and security endpoints
+hive-mcp-cli get_security_risk_endpoints
+```
+
+## Schema And Invocation
+
+```bash
+# Inspect schema before invoking an endpoint
+hive-mcp-cli get_api_endpoint_schema endpoint=get_token_price
+
+# Invoke a narrow endpoint after confirming the schema
+hive-mcp-cli invoke_api_endpoint \
+  endpoint_name=get_token_price \
+  args:='{"symbol":"BTC"}'
+```
+
+## Fallback Equivalence
+
+- `hive-mcp-cli <operation> ...` is equivalent to
+  `uxc https://hiveintelligence.xyz/mcp <operation> ...`.

--- a/skills/hive-mcp-skill/scripts/validate.sh
+++ b/skills/hive-mcp-skill/scripts/validate.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/hive-mcp-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+USAGE_FILE="${SKILL_DIR}/references/usage-patterns.md"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd rg
+
+for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}"; do
+  [[ -f "${file}" ]] || fail "missing required file: ${file}"
+done
+
+rg -q '^name:\s*hive-mcp-skill\s*$' "${SKILL_FILE}" || fail 'invalid skill name'
+rg -q '^description:\s*.+' "${SKILL_FILE}" || fail 'missing description'
+rg -q 'command -v hive-mcp-cli' "${SKILL_FILE}" || fail 'missing link-first command check'
+rg -q 'uxc link hive-mcp-cli https://hiveintelligence.xyz/mcp' "${SKILL_FILE}" "${USAGE_FILE}" || fail 'missing fixed link create command'
+rg -q 'get_market_and_price_endpoints' "${SKILL_FILE}" || fail 'missing category discovery guidance'
+rg -q 'get_api_endpoint_schema' "${SKILL_FILE}" || fail 'missing schema inspection guidance'
+rg -q 'invoke_api_endpoint' "${SKILL_FILE}" || fail 'missing invoke guidance'
+rg -q 'convenience aggregation layer' "${SKILL_FILE}" || fail 'missing positioning guardrail'
+
+if rg -q -- "--args\\s+'\\{" "${SKILL_FILE}" "${USAGE_FILE}"; then
+  fail 'found banned legacy JSON argument pattern'
+fi
+
+rg -q '^\s*display_name:\s*"Hive Intelligence MCP"\s*$' "${OPENAI_FILE}" || fail 'missing display_name'
+rg -q '^\s*short_description:\s*".+"\s*$' "${OPENAI_FILE}" || fail 'missing short_description'
+rg -q '^\s*default_prompt:\s*".*\$hive-mcp-skill.*"\s*$' "${OPENAI_FILE}" || fail 'default_prompt must mention $hive-mcp-skill'
+
+echo "skills/hive-mcp-skill validation passed"


### PR DESCRIPTION
## What
- add `skills/hive-mcp-skill`
- add help-first usage guidance for Hive Intelligence's official remote MCP
- update `docs/skills.md`

## Why
`Hive` is an official remote MCP convenience layer with broad crypto coverage and low setup cost.

This PR positions it explicitly as a convenience entrypoint, not as a replacement for direct-provider skills.

## How
- package the standard skill files: `SKILL.md`, `agents/openai.yaml`, `references/usage-patterns.md`, `scripts/validate.sh`
- center the workflow on category discovery, schema inspection, and narrow endpoint invocation
- document convenience-layer guardrails so users do not confuse Hive with first-party provider coverage

## Testing
- `bash skills/hive-mcp-skill/scripts/validate.sh`
- `cargo fmt --check`

Closes #311
Refs #168
