### PR TITLE
feat: add mempool.space public api skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -51,6 +51,8 @@ This repository ships one canonical skill for UXC (Universal X-Protocol CLI) and
   - Wrapper for Hive Intelligence official remote MCP workflows via UXC as a broad crypto discovery and convenience layer.
 - `skills/nodit-openapi-skill`
   - Wrapper for Nodit Web3 Data API entity, account, and token reads via UXC + curated OpenAPI schema and API-key auth.
+- `skills/mempool-space-openapi-skill`
+  - Wrapper for mempool.space public Bitcoin fee, mempool, address, transaction, and Lightning explorer reads via UXC + curated OpenAPI schema.
 - `skills/alchemy-openapi-skill`
   - Wrapper for Alchemy Prices API read workflows via UXC + curated OpenAPI schema and path-templated API-key auth.
 - `skills/chainbase-openapi-skill`
@@ -95,7 +97,7 @@ python ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github
   --path skills/deepwiki-mcp-skill
 ```
 
-Replace `skills/deepwiki-mcp-skill` with `skills/context7-mcp-skill`, `skills/okx-mcp-skill`, `skills/dune-mcp-skill`, `skills/thegraph-mcp-skill`, `skills/thegraph-token-mcp-skill`, `skills/etherscan-mcp-skill`, `skills/notion-mcp-skill`, `skills/discord-openapi-skill`, `skills/slack-openapi-skill`, `skills/matrix-openapi-skill`, `skills/line-openapi-skill`, `skills/feishu-openapi-skill`, `skills/whatsapp-openapi-skill`, `skills/dingtalk-openapi-skill`, `skills/coingecko-openapi-skill`, `skills/defillama-openapi-skill`, `skills/blockscout-openapi-skill`, `skills/chainbase-openapi-skill`, `skills/moralis-openapi-skill`, `skills/alchemy-openapi-skill`, `skills/coinapi-openapi-skill`, `skills/dexscreener-openapi-skill`, `skills/helius-openapi-skill`, `skills/blocknative-openapi-skill`, `skills/near-jsonrpc-skill`, `skills/hive-mcp-skill`, `skills/nodit-openapi-skill`, `skills/binance-web3-openapi-skill`, or `skills/binance-spot-openapi-skill` as needed.
+Replace `skills/deepwiki-mcp-skill` with `skills/context7-mcp-skill`, `skills/okx-mcp-skill`, `skills/dune-mcp-skill`, `skills/thegraph-mcp-skill`, `skills/thegraph-token-mcp-skill`, `skills/etherscan-mcp-skill`, `skills/notion-mcp-skill`, `skills/discord-openapi-skill`, `skills/slack-openapi-skill`, `skills/matrix-openapi-skill`, `skills/line-openapi-skill`, `skills/feishu-openapi-skill`, `skills/whatsapp-openapi-skill`, `skills/dingtalk-openapi-skill`, `skills/coingecko-openapi-skill`, `skills/defillama-openapi-skill`, `skills/blockscout-openapi-skill`, `skills/chainbase-openapi-skill`, `skills/moralis-openapi-skill`, `skills/alchemy-openapi-skill`, `skills/coinapi-openapi-skill`, `skills/dexscreener-openapi-skill`, `skills/helius-openapi-skill`, `skills/blocknative-openapi-skill`, `skills/near-jsonrpc-skill`, `skills/hive-mcp-skill`, `skills/nodit-openapi-skill`, `skills/mempool-space-openapi-skill`, `skills/binance-web3-openapi-skill`, or `skills/binance-spot-openapi-skill` as needed.
 
 After installation, restart Codex to load new skills.
 
@@ -230,6 +232,12 @@ bash skills/hive-mcp-skill/scripts/validate.sh
 
 ```bash
 bash skills/nodit-openapi-skill/scripts/validate.sh
+```
+
+- Validate mempool.space wrapper docs when touched:
+
+```bash
+bash skills/mempool-space-openapi-skill/scripts/validate.sh
 ```
 
 - Validate Alchemy wrapper docs when touched:

--- a/skills/mempool-space-openapi-skill/SKILL.md
+++ b/skills/mempool-space-openapi-skill/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: mempool-space-openapi-skill
+description: Operate mempool.space public Bitcoin and Lightning explorer APIs through UXC with a curated OpenAPI schema, no-auth setup, and read-first guardrails.
+---
+
+# mempool.space API Skill
+
+Use this skill to run mempool.space public Bitcoin and Lightning explorer operations through `uxc` + OpenAPI.
+
+Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- Network access to `https://mempool.space/api`.
+- Access to the curated OpenAPI schema URL:
+  - `https://raw.githubusercontent.com/holon-run/uxc/main/skills/mempool-space-openapi-skill/references/mempool-space-public.openapi.json`
+
+## Scope
+
+This skill covers a read-first mempool.space surface for:
+
+- Bitcoin fee estimation and mempool state reads
+- block tip height checks
+- address and transaction status reads
+- Lightning network search, statistics, node rankings, node detail, and channel reads
+
+This skill does **not** cover:
+
+- transaction broadcast or package submission
+- websocket subscriptions
+- internal or admin routes
+- every Esplora-compatible endpoint exposed by mempool.space
+
+## Authentication
+
+mempool.space public reads in this skill do not require authentication.
+
+## Core Workflow
+
+1. Use the fixed link command by default:
+   - `command -v mempool-space-openapi-cli`
+   - If missing, create it:
+     `uxc link mempool-space-openapi-cli https://mempool.space/api --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/mempool-space-openapi-skill/references/mempool-space-public.openapi.json`
+   - `mempool-space-openapi-cli -h`
+
+2. Inspect operation schema first:
+   - `mempool-space-openapi-cli get:/v1/fees/recommended -h`
+   - `mempool-space-openapi-cli get:/mempool -h`
+   - `mempool-space-openapi-cli get:/address/{address} -h`
+   - `mempool-space-openapi-cli get:/v1/lightning/search -h`
+   - `mempool-space-openapi-cli get:/v1/lightning/channels/{short_id} -h`
+
+3. Prefer narrow reads before broader scans:
+   - `mempool-space-openapi-cli get:/v1/fees/recommended`
+   - `mempool-space-openapi-cli get:/blocks/tip/height`
+   - `mempool-space-openapi-cli get:/v1/lightning/statistics/latest`
+
+4. Execute with key/value parameters:
+   - `mempool-space-openapi-cli get:/address/{address} address=bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh`
+   - `mempool-space-openapi-cli get:/tx/{txid}/status txid=4d5d7f2d5dc69aa68a51887db07dd6d906f31f9141320f9f0b4bab76d735a47f`
+   - `mempool-space-openapi-cli get:/v1/lightning/search searchText=bfx`
+   - `mempool-space-openapi-cli get:/v1/lightning/channels public_key=033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025 status=active`
+   - `mempool-space-openapi-cli get:/v1/lightning/channels/{short_id} short_id=835866331763769345`
+
+## Operations
+
+- `get:/v1/fees/recommended`
+- `get:/mempool`
+- `get:/blocks/tip/height`
+- `get:/address/{address}`
+- `get:/tx/{txid}/status`
+- `get:/v1/lightning/statistics/latest`
+- `get:/v1/lightning/search`
+- `get:/v1/lightning/nodes/rankings`
+- `get:/v1/lightning/nodes/{public_key}`
+- `get:/v1/lightning/channels`
+- `get:/v1/lightning/channels/{short_id}`
+
+## Guardrails
+
+- Keep automation on the JSON output envelope; do not use `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- Treat this v1 skill as read-only. Do not use `tx/push`, package submission, or internal routes.
+- Prefer the curated fee, mempool, and Lightning reads here before dropping to the much larger generic Esplora surface.
+- `mempool.space` is a public explorer service, so mempool state and Lightning rankings can move quickly. Re-query instead of assuming cached values remain current.
+- For `get:/v1/lightning/channels/{short_id}`, mempool.space currently accepts the channel `id` string even though the route label says `short_id`; prefer values returned by search or node channel listing.
+- `mempool-space-openapi-cli <operation> ...` is equivalent to `uxc https://mempool.space/api --schema-url <mempool_space_openapi_schema> <operation> ...`.
+
+## References
+
+- Usage patterns: `references/usage-patterns.md`
+- Curated OpenAPI schema: `references/mempool-space-public.openapi.json`
+- Official mempool repository: https://github.com/mempool/mempool

--- a/skills/mempool-space-openapi-skill/agents/openai.yaml
+++ b/skills/mempool-space-openapi-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mempool.space Public API"
+  short_description: "Operate mempool.space Bitcoin fee, mempool, address, transaction, and Lightning explorer reads via UXC + curated OpenAPI schema"
+  default_prompt: "Use $mempool-space-openapi-skill to discover and execute mempool.space public Bitcoin and Lightning read-only operations through UXC with public no-auth access and explorer-focused guardrails."

--- a/skills/mempool-space-openapi-skill/references/mempool-space-public.openapi.json
+++ b/skills/mempool-space-openapi-skill/references/mempool-space-public.openapi.json
@@ -1,0 +1,311 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "mempool.space Public API",
+    "version": "1.0.0",
+    "description": "Curated mempool.space public Bitcoin and Lightning explorer operations for UXC."
+  },
+  "servers": [
+    {
+      "url": "https://mempool.space/api"
+    }
+  ],
+  "paths": {
+    "/v1/fees/recommended": {
+      "get": {
+        "operationId": "getRecommendedFees",
+        "summary": "Get recommended Bitcoin fee rates",
+        "responses": {
+          "200": {
+            "description": "Recommended fee rates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mempool": {
+      "get": {
+        "operationId": "getMempoolSummary",
+        "summary": "Get aggregate mempool state",
+        "responses": {
+          "200": {
+            "description": "Mempool summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/blocks/tip/height": {
+      "get": {
+        "operationId": "getBlockTipHeight",
+        "summary": "Get the current block tip height",
+        "responses": {
+          "200": {
+            "description": "Block tip height",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/address/{address}": {
+      "get": {
+        "operationId": "getAddressSummary",
+        "summary": "Get Bitcoin address summary",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Address summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tx/{txid}/status": {
+      "get": {
+        "operationId": "getTransactionStatus",
+        "summary": "Get Bitcoin transaction confirmation status",
+        "parameters": [
+          {
+            "name": "txid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transaction status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/lightning/statistics/latest": {
+      "get": {
+        "operationId": "getLatestLightningStatistics",
+        "summary": "Get latest Lightning network statistics",
+        "responses": {
+          "200": {
+            "description": "Lightning statistics snapshot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/lightning/search": {
+      "get": {
+        "operationId": "searchLightningNodesAndChannels",
+        "summary": "Search Lightning nodes and channels",
+        "parameters": [
+          {
+            "name": "searchText",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lightning search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/lightning/nodes/rankings": {
+      "get": {
+        "operationId": "getLightningNodeRankings",
+        "summary": "Get top Lightning node rankings",
+        "responses": {
+          "200": {
+            "description": "Lightning node rankings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/lightning/nodes/{public_key}": {
+      "get": {
+        "operationId": "getLightningNode",
+        "summary": "Get one Lightning node by public key",
+        "parameters": [
+          {
+            "name": "public_key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lightning node detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/lightning/channels": {
+      "get": {
+        "operationId": "getLightningChannelsForNode",
+        "summary": "Get Lightning channels for a node",
+        "parameters": [
+          {
+            "name": "public_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "index",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": -1
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "open",
+                "active",
+                "closed"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lightning channels for node",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/lightning/channels/{short_id}": {
+      "get": {
+        "operationId": "getLightningChannel",
+        "summary": "Get one Lightning channel by id",
+        "parameters": [
+          {
+            "name": "short_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lightning channel detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  }
+}

--- a/skills/mempool-space-openapi-skill/references/usage-patterns.md
+++ b/skills/mempool-space-openapi-skill/references/usage-patterns.md
@@ -1,0 +1,59 @@
+# mempool.space API Skill - Usage Patterns
+
+## Link Setup
+
+```bash
+command -v mempool-space-openapi-cli
+uxc link mempool-space-openapi-cli https://mempool.space/api \
+  --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/mempool-space-openapi-skill/references/mempool-space-public.openapi.json
+mempool-space-openapi-cli -h
+```
+
+## Read Examples
+
+```bash
+# Read current public fee recommendations
+mempool-space-openapi-cli get:/v1/fees/recommended
+
+# Read aggregate mempool state
+mempool-space-openapi-cli get:/mempool
+
+# Read the current block tip height
+mempool-space-openapi-cli get:/blocks/tip/height
+
+# Read summary stats for a Bitcoin address
+mempool-space-openapi-cli get:/address/{address} \
+  address=bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh
+
+# Read whether a transaction is confirmed
+mempool-space-openapi-cli get:/tx/{txid}/status \
+  txid=4d5d7f2d5dc69aa68a51887db07dd6d906f31f9141320f9f0b4bab76d735a47f
+
+# Read latest Lightning network statistics
+mempool-space-openapi-cli get:/v1/lightning/statistics/latest
+
+# Search Lightning nodes and channels by alias or id fragment
+mempool-space-openapi-cli get:/v1/lightning/search \
+  searchText=bfx
+
+# Read top Lightning node rankings
+mempool-space-openapi-cli get:/v1/lightning/nodes/rankings
+
+# Read one Lightning node
+mempool-space-openapi-cli get:/v1/lightning/nodes/{public_key} \
+  public_key=033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025
+
+# Read active channels for a Lightning node
+mempool-space-openapi-cli get:/v1/lightning/channels \
+  public_key=033d8656219478701227199cbd6f670335c8d408a92ae88b962c49d4dc0e83e025 \
+  status=active
+
+# Read one Lightning channel by id
+mempool-space-openapi-cli get:/v1/lightning/channels/{short_id} \
+  short_id=835866331763769345
+```
+
+## Fallback Equivalence
+
+- `mempool-space-openapi-cli <operation> ...` is equivalent to
+  `uxc https://mempool.space/api --schema-url <mempool_space_openapi_schema> <operation> ...`.

--- a/skills/mempool-space-openapi-skill/scripts/validate.sh
+++ b/skills/mempool-space-openapi-skill/scripts/validate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/mempool-space-openapi-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+USAGE_FILE="${SKILL_DIR}/references/usage-patterns.md"
+SCHEMA_FILE="${SKILL_DIR}/references/mempool-space-public.openapi.json"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd jq
+need_cmd rg
+
+for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}" "${SCHEMA_FILE}"; do
+  [[ -f "${file}" ]] || fail "missing required file: ${file}"
+done
+
+jq -e '.openapi and .paths and .components' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'invalid OpenAPI schema JSON or missing .openapi/.paths/.components'
+jq -e '.paths["/v1/fees/recommended"] and .paths["/mempool"] and .paths["/blocks/tip/height"] and .paths["/address/{address}"] and .paths["/tx/{txid}/status"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing expected Bitcoin paths'
+jq -e '.paths["/v1/lightning/statistics/latest"] and .paths["/v1/lightning/search"] and .paths["/v1/lightning/nodes/{public_key}"] and .paths["/v1/lightning/channels"] and .paths["/v1/lightning/channels/{short_id}"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing expected Lightning paths'
+
+rg -q '^name:\s*mempool-space-openapi-skill\s*$' "${SKILL_FILE}" || fail 'invalid skill name'
+rg -q '^description:\s*.+' "${SKILL_FILE}" || fail 'missing description'
+rg -q 'command -v mempool-space-openapi-cli' "${SKILL_FILE}" || fail 'missing link-first command check'
+rg -q 'uxc link mempool-space-openapi-cli https://mempool.space/api --schema-url ' "${SKILL_FILE}" || fail 'missing fixed link create command with schema-url'
+rg -F -q 'mempool-space-openapi-cli get:/v1/fees/recommended -h' "${SKILL_FILE}" || fail 'missing operation-level help example'
+rg -q 'Treat this v1 skill as read-only' "${SKILL_FILE}" || fail 'missing read-only guardrail'
+rg -q 'accepts the channel `id` string even though the route label says `short_id`' "${SKILL_FILE}" || fail 'missing channel id guardrail'
+
+if rg -q -- "--args\\s+'\\{" "${SKILL_FILE}" "${USAGE_FILE}"; then
+  fail 'found banned legacy JSON argument pattern'
+fi
+
+rg -q '^\s*display_name:\s*"mempool.space Public API"\s*$' "${OPENAI_FILE}" || fail 'missing display_name'
+rg -q '^\s*short_description:\s*".+"\s*$' "${OPENAI_FILE}" || fail 'missing short_description'
+rg -q '^\s*default_prompt:\s*".*\$mempool-space-openapi-skill.*"\s*$' "${OPENAI_FILE}" || fail 'default_prompt must mention $mempool-space-openapi-skill'
+
+echo "skills/mempool-space-openapi-skill validation passed"


### PR DESCRIPTION
## What
Add a `mempool-space-openapi-skill` wrapper for mempool.space public Bitcoin and Lightning explorer APIs through UXC.

## Why
Issue #168 surfaced a Bitcoin / Lightning coverage gap from follow-up comments. mempool.space gives us a practical no-auth public surface with stable Bitcoin explorer routes plus Lightning network reads, which is a good first provider to close that gap.

Closes #316

## How
Create a thin wrapper skill with a curated OpenAPI schema instead of exposing the full mempool.space explorer surface. Scope v1 to public read-only endpoints for fee recommendations, mempool summary, block tip, address summary, transaction status, and selected Lightning reads.

## Changes
- [x] Add `skills/mempool-space-openapi-skill` with `SKILL.md`, `agents/openai.yaml`, `references/usage-patterns.md`, and `scripts/validate.sh`
- [x] Add a curated `mempool-space-public.openapi.json` schema for public Bitcoin and Lightning reads
- [x] Document explorer-specific guardrails, including the current channel-id route quirk on Lightning channel detail
- [x] Update `docs/skills.md` catalog, install guidance, and validation commands

## Testing
### Unit Tests
- [ ] All existing tests pass
- [ ] New tests added (if applicable)
- [ ] `cargo test` passes

### Manual Testing
- [x] Tested against real APIs
- [x] Tested edge cases
- [x] Tested error conditions

### Test Results
```bash
bash skills/mempool-space-openapi-skill/scripts/validate.sh
cargo fmt --check
/Users/jolestar/opensource/src/github.com/holon-run/uxc/target/debug/uxc \
  https://mempool.space/api \
  --schema-url file:///tmp/uxc-mempool/skills/mempool-space-openapi-skill/references/mempool-space-public.openapi.json \
  get:/v1/fees/recommended
/Users/jolestar/opensource/src/github.com/holon-run/uxc/target/debug/uxc \
  https://mempool.space/api \
  --schema-url file:///tmp/uxc-mempool/skills/mempool-space-openapi-skill/references/mempool-space-public.openapi.json \
  get:/v1/lightning/search searchText=bfx
```

## Checklist
- [x] Code formatted with `cargo fmt`
- [ ] No clippy warnings (`cargo clippy -- -D warnings`)
- [ ] All tests pass (`cargo test`)
- [x] Documentation updated
- [x] Commit messages follow convention
- [x] PR title follows convention (e.g., `feat: add GraphQL support`)

## Breaking Changes
None.

## Additional Notes
The scope intentionally stays smaller than the full Esplora-compatible API. The goal is to cover the highest-value Bitcoin and Lightning public reads without creating a broad overlapping skill that is harder to maintain.
