### PR TITLE
feat: add daemon can_reap contract for stdio sessions

### DIFF
--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -5,10 +5,32 @@ use super::transport::{
 };
 use super::types::*;
 use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct CanReapState {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interactive: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owns_external_resource: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub waiting_for_human: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CanReapProbeResult {
+    pub can_reap: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_after_secs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<CanReapState>,
+}
 
 /// MCP stdio client
 pub struct McpStdioClient {
@@ -139,6 +161,26 @@ impl McpStdioClient {
 
     pub async fn drain_notifications(&mut self) -> Vec<JsonRpcNotification> {
         self.transport.drain_notifications().await
+    }
+
+    pub async fn probe_can_reap(
+        &mut self,
+        idle_for_secs: u64,
+        idle_ttl_secs: u64,
+        timeout: Duration,
+    ) -> Result<CanReapProbeResult> {
+        let params = json!({
+            "idle_for_secs": idle_for_secs,
+            "idle_ttl_secs": idle_ttl_secs,
+        });
+        let result = self
+            .transport
+            .send_request_with_timeout("uxc/can_reap", Some(params), timeout)
+            .await
+            .context("Failed to probe uxc/can_reap")?;
+        let probe: CanReapProbeResult =
+            serde_json::from_value(result).context("Failed to parse can_reap probe result")?;
+        Ok(probe)
     }
 
     /// List available tools
@@ -334,6 +376,7 @@ impl McpStdioClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::structured_error_from_anyhow;
 
     #[tokio::test]
     async fn client_requires_tools_capability() {
@@ -663,5 +706,61 @@ mod tests {
         assert!(init.serverInfo.is_some());
         assert!(init.instructions.is_some());
         assert_eq!(init.instructions.unwrap(), "Use this server");
+    }
+
+    #[tokio::test]
+    async fn probe_can_reap_parses_successful_response() {
+        let script = r#"
+            read line
+            echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"test","version":"1.0"}}}'
+            read line
+            echo '{"jsonrpc":"2.0","id":2,"result":{"can_reap":false,"reason":"interactive_session","retry_after_secs":30,"state":{"interactive":true,"owns_external_resource":true}}}'
+        "#;
+
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
+
+        let result = client
+            .probe_can_reap(123, 600, Duration::from_millis(50))
+            .await
+            .unwrap();
+        assert!(!result.can_reap);
+        assert_eq!(result.reason.as_deref(), Some("interactive_session"));
+        assert_eq!(result.retry_after_secs, Some(30));
+        assert_eq!(
+            result.state,
+            Some(CanReapState {
+                interactive: Some(true),
+                owns_external_resource: Some(true),
+                waiting_for_human: None,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_can_reap_surfaces_method_not_found_code() {
+        let script = r#"
+            read line
+            echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"test","version":"1.0"}}}'
+            read line
+            echo '{"jsonrpc":"2.0","id":2,"error":{"code":-32601,"message":"Method not found"}}'
+        "#;
+
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
+
+        let err = client
+            .probe_can_reap(123, 600, Duration::from_millis(50))
+            .await
+            .unwrap_err();
+        let structured = structured_error_from_anyhow(&err).expect("structured error");
+        let jsonrpc_code = structured
+            .details
+            .as_ref()
+            .and_then(|details| details.get("jsonrpc_code"))
+            .and_then(|value| value.as_i64());
+        assert_eq!(jsonrpc_code, Some(-32601));
     }
 }

--- a/src/adapters/mcp/mod.rs
+++ b/src/adapters/mcp/mod.rs
@@ -12,7 +12,7 @@ use crate::auth::Profile;
 use crate::error::UxcError;
 use anyhow::{bail, Result};
 use async_trait::async_trait;
-pub use client::McpStdioClient;
+pub use client::{CanReapState, McpStdioClient};
 pub use http_transport::{McpHttpTransport, McpRemoteTransport, ResolvedMcpHttpTransport};
 use serde_json::Value;
 use std::collections::HashMap;

--- a/src/adapters/mcp/transport.rs
+++ b/src/adapters/mcp/transport.rs
@@ -480,6 +480,17 @@ impl McpStdioTransport {
         method: &str,
         params: Option<JsonValue>,
     ) -> Result<JsonValue> {
+        self.send_request_with_timeout(method, params, stdio_request_timeout())
+            .await
+    }
+
+    /// Send a request and wait for the response using a caller-specified timeout.
+    pub async fn send_request_with_timeout(
+        &mut self,
+        method: &str,
+        params: Option<JsonValue>,
+        timeout: Duration,
+    ) -> Result<JsonValue> {
         // Get the next ID
         let id = {
             let mut id_guard = self.next_id.lock().await;
@@ -528,7 +539,6 @@ impl McpStdioTransport {
 
         // Wait for the response with timeout so a stuck MCP server/tool call
         // does not block the caller indefinitely.
-        let timeout = stdio_request_timeout();
         let mut response_rx = response_rx;
         let response = match tokio::select! {
             biased;
@@ -1356,6 +1366,26 @@ mod tests {
 
         // Either timeout or error is acceptable
         assert!(result.is_err() || result.unwrap().is_err());
+    }
+
+    #[tokio::test]
+    async fn send_request_with_timeout_uses_caller_timeout() {
+        let script = "read line; sleep 10";
+        let mut transport =
+            McpStdioTransport::connect("sh", &["-c".to_string(), script.to_string()])
+                .await
+                .unwrap();
+
+        let start = tokio::time::Instant::now();
+        let err = transport
+            .send_request_with_timeout("timeout_test", None, Duration::from_millis(25))
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(start.elapsed() < Duration::from_millis(250));
+        assert!(err.contains("timed out"));
+        assert!(err.contains("timeout_test"));
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -67,6 +67,8 @@ const STOP_POLL_INTERVAL_MS: u64 = 100;
 const START_LOCK_STALE_SECS: u64 = 30;
 const STDIO_INIT_LOCK_STALE_SECS: u64 = 30;
 const MCP_IDLE_TTL_SECS: u64 = 600;
+const MCP_CAN_REAP_PROBE_TIMEOUT_MS: u64 = 1_000;
+const MCP_CAN_REAP_RETRY_AFTER_SECS: u64 = 30;
 // Five seconds is long enough for cooperative stdio servers to notice stdin EOF
 // and release external resources, while still bounding daemon-side eviction stalls.
 const MCP_STDIO_EXIT_TIMEOUT_SECS: u64 = 5;
@@ -387,10 +389,38 @@ pub struct DaemonSessionView {
     /// Current liveness state for the live daemon cache entry.
     pub state: String,
     pub reuse_eligible: bool,
+    pub can_reap_contract: CanReapContractView,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error_summary: Option<String>,
     #[serde(default)]
     pub recent_stderr: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CanReapContractSupport {
+    #[default]
+    Unknown,
+    Supported,
+    Unsupported,
+    Error,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CanReapContractView {
+    pub support: CanReapContractSupport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checked_at_unix: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub can_reap: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_after_secs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<adapters::mcp::CanReapState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error_summary: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -476,6 +506,8 @@ struct McpStdioSession {
     link_name: Option<String>,
     endpoint: String,
     daemon_exclusive: Vec<String>,
+    can_reap_contract: CanReapContractView,
+    next_can_reap_probe_after: Option<Instant>,
 }
 
 #[derive(Debug, Clone)]
@@ -490,6 +522,7 @@ struct McpStdioSessionSnapshot {
     daemon_exclusive: Vec<String>,
     in_flight_requests: u64,
     reuse_eligible: bool,
+    can_reap_contract: CanReapContractView,
     last_error_summary: Option<String>,
     recent_stderr: Vec<String>,
 }
@@ -858,6 +891,7 @@ impl McpStdioSessionSnapshot {
                 "ready".to_string()
             },
             reuse_eligible: self.reuse_eligible,
+            can_reap_contract: self.can_reap_contract.clone(),
             last_error_summary: self.last_error_summary.clone(),
             recent_stderr: self.recent_stderr.clone(),
         }
@@ -904,6 +938,17 @@ fn redact_recent_stderr(lines: Vec<String>) -> Vec<String> {
         .into_iter()
         .map(|line| truncate_for_session_summary(&redact_sensitive(&line)))
         .collect()
+}
+
+fn can_reap_error_summary(err: &anyhow::Error) -> String {
+    truncate_for_session_summary(&redact_sensitive(&err.to_string()))
+}
+
+fn can_reap_method_not_found(err: &anyhow::Error) -> bool {
+    structured_error_from_anyhow(err)
+        .and_then(|payload| payload.details)
+        .and_then(|details| details.get("jsonrpc_code").and_then(Value::as_i64))
+        == Some(-32601)
 }
 
 impl McpSessionManager {
@@ -957,6 +1002,43 @@ impl McpSessionManager {
         let _ = logger.log(&entry).await;
     }
 
+    async fn log_stdio_reap_deferred(
+        &self,
+        session_key: &str,
+        snapshot: &McpStdioSessionSnapshot,
+        contract: &CanReapContractView,
+    ) {
+        let Some(logger) = self.logger.as_ref() else {
+            return;
+        };
+        let mut meta = json!({
+            "session_key": display_session_key(session_key),
+            "link_name": snapshot.link_name.clone(),
+            "command_summary": snapshot.command_summary.clone(),
+            "daemon_exclusive": snapshot.daemon_exclusive.clone(),
+            "child_pid": snapshot.child_pid,
+            "idle_ttl_secs": snapshot.idle_ttl_secs,
+            "idle_for_secs": now_unix_secs().saturating_sub(snapshot.last_used_at_unix),
+            "reason": contract.reason.clone(),
+            "retry_after_secs": contract.retry_after_secs,
+            "state": contract.state.clone(),
+        });
+        if let Some(can_reap) = contract.can_reap {
+            meta["can_reap"] = json!(can_reap);
+        }
+        if let Some(checked_at_unix) = contract.checked_at_unix {
+            meta["checked_at_unix"] = json!(checked_at_unix);
+        }
+        let mut entry = DaemonLogEntry::new(DaemonEventType::DaemonSessionReapDeferred)
+            .with_endpoint(snapshot.endpoint.clone())
+            .with_protocol("mcp_stdio".to_string())
+            .with_meta(meta);
+        if let Some(error) = &contract.last_error_summary {
+            entry = entry.with_error(error.clone());
+        }
+        let _ = logger.log(&entry).await;
+    }
+
     async fn upsert_stdio_snapshot<F>(&self, session_key: &str, update: F)
     where
         F: FnOnce(&mut McpStdioSessionSnapshot),
@@ -1003,8 +1085,80 @@ impl McpSessionManager {
                 if guard.idle_ttl_secs == 0 {
                     continue;
                 }
-                let cutoff = Instant::now() - Duration::from_secs(guard.idle_ttl_secs);
+                let now = Instant::now();
+                let cutoff = now - Duration::from_secs(guard.idle_ttl_secs);
                 if guard.last_used < cutoff {
+                    if guard
+                        .next_can_reap_probe_after
+                        .is_some_and(|next_probe_after| next_probe_after > now)
+                    {
+                        continue;
+                    }
+                    let checked_at_unix = now_unix_secs();
+                    let idle_for_secs = checked_at_unix.saturating_sub(guard.last_used_at_unix);
+                    let idle_ttl_secs = guard.idle_ttl_secs;
+                    match guard
+                        .client
+                        .probe_can_reap(
+                            idle_for_secs,
+                            idle_ttl_secs,
+                            Duration::from_millis(MCP_CAN_REAP_PROBE_TIMEOUT_MS),
+                        )
+                        .await
+                    {
+                        Ok(result) => {
+                            guard.can_reap_contract = CanReapContractView {
+                                support: CanReapContractSupport::Supported,
+                                checked_at_unix: Some(checked_at_unix),
+                                can_reap: Some(result.can_reap),
+                                reason: result.reason.clone(),
+                                retry_after_secs: result.retry_after_secs,
+                                state: result.state.clone(),
+                                last_error_summary: None,
+                            };
+                            if result.can_reap {
+                                guard.next_can_reap_probe_after = None;
+                            } else {
+                                let retry_after_secs = result
+                                    .retry_after_secs
+                                    .unwrap_or(MCP_CAN_REAP_RETRY_AFTER_SECS);
+                                guard.next_can_reap_probe_after =
+                                    Some(now + Duration::from_secs(retry_after_secs));
+                                let contract = guard.can_reap_contract.clone();
+                                drop(guard);
+                                self.upsert_stdio_snapshot(key, |snapshot| {
+                                    snapshot.can_reap_contract = contract.clone();
+                                })
+                                .await;
+                                if let Some(snapshot) = {
+                                    let snapshots = self.stdio_snapshots.lock().await;
+                                    snapshots.get(key).cloned()
+                                } {
+                                    self.log_stdio_reap_deferred(key, &snapshot, &contract)
+                                        .await;
+                                }
+                                continue;
+                            }
+                        }
+                        Err(err) => {
+                            guard.next_can_reap_probe_after = None;
+                            guard.can_reap_contract = CanReapContractView {
+                                support: if can_reap_method_not_found(&err) {
+                                    CanReapContractSupport::Unsupported
+                                } else {
+                                    CanReapContractSupport::Error
+                                },
+                                checked_at_unix: Some(checked_at_unix),
+                                can_reap: None,
+                                reason: None,
+                                retry_after_secs: None,
+                                state: None,
+                                last_error_summary: (!can_reap_method_not_found(&err))
+                                    .then(|| can_reap_error_summary(&err)),
+                            };
+                        }
+                    }
+                    let contract = guard.can_reap_contract.clone();
                     // Idle cleanup is best-effort: even if shutdown waiting fails, we still drop
                     // the cached session so cleanup can make forward progress on the next cycle.
                     if let Err(err) = guard
@@ -1018,6 +1172,11 @@ impl McpSessionManager {
                             "Failed waiting for idle MCP stdio session to exit after kill"
                         );
                     }
+                    drop(guard);
+                    self.upsert_stdio_snapshot(key, |snapshot| {
+                        snapshot.can_reap_contract = contract;
+                    })
+                    .await;
                     stdio_remove.push(key.clone());
                 }
             }
@@ -1172,6 +1331,8 @@ impl McpSessionManager {
             link_name: metadata.link_name.map(str::to_string),
             endpoint: metadata.endpoint.to_string(),
             daemon_exclusive: exclusive_keys.clone(),
+            can_reap_contract: CanReapContractView::default(),
+            next_can_reap_probe_after: None,
         }));
 
         {
@@ -1191,6 +1352,7 @@ impl McpSessionManager {
                 daemon_exclusive: exclusive_keys.clone(),
                 in_flight_requests: 0,
                 reuse_eligible: true,
+                can_reap_contract: CanReapContractView::default(),
                 last_error_summary: None,
                 recent_stderr: Vec::new(),
             },
@@ -1263,6 +1425,7 @@ impl McpSessionManager {
         let idle_ttl_secs = guard.idle_ttl_secs;
         let last_used_at_unix = guard.last_used_at_unix;
         let daemon_exclusive = guard.daemon_exclusive.clone();
+        let can_reap_contract = guard.can_reap_contract.clone();
         drop(guard);
         self.upsert_stdio_snapshot(session_key, |snapshot| {
             snapshot.endpoint = endpoint;
@@ -1271,6 +1434,7 @@ impl McpSessionManager {
             snapshot.idle_ttl_secs = idle_ttl_secs;
             snapshot.last_used_at_unix = last_used_at_unix;
             snapshot.daemon_exclusive = daemon_exclusive;
+            snapshot.can_reap_contract = can_reap_contract;
             snapshot.recent_stderr = recent_stderr;
         })
         .await;
@@ -1628,6 +1792,7 @@ impl McpSessionManager {
                     snapshot.last_used_at_unix = guard.last_used_at_unix;
                     snapshot.idle_ttl_secs = guard.idle_ttl_secs;
                     snapshot.daemon_exclusive = guard.daemon_exclusive.clone();
+                    snapshot.can_reap_contract = guard.can_reap_contract.clone();
                     snapshot.recent_stderr = recent_stderr;
                     if child_exited {
                         snapshot.reuse_eligible = false;

--- a/src/daemon_log.rs
+++ b/src/daemon_log.rs
@@ -49,6 +49,7 @@ pub enum DaemonEventType {
     DaemonSessionCreated,
     DaemonSessionReused,
     DaemonSessionUnhealthy,
+    DaemonSessionReapDeferred,
     DaemonSessionRemoved,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1781,7 +1781,7 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
             usage: "uxc daemon sessions".to_string(),
             commands: vec![],
             notes: vec![
-                "Shows live stdio daemon session metadata including command summary, reuse eligibility, recent stderr, and per-session idle TTL where 0 disables idle reaping."
+                "Shows live stdio daemon session metadata including command summary, reuse eligibility, recent stderr, per-session idle TTL where 0 disables idle reaping, and the latest uxc/can_reap contract state."
                     .to_string(),
             ],
             examples: vec!["uxc daemon sessions".to_string()],

--- a/src/test_server/common.rs
+++ b/src/test_server/common.rs
@@ -35,6 +35,12 @@ pub enum Scenario {
     SuiPubSub,
     /// Resource state is scoped to a single MCP session/instance
     SessionScopedResource,
+    /// uxc/can_reap returns can_reap=false with structured state
+    CanReapKeepAlive,
+    /// uxc/can_reap returns can_reap=true
+    CanReapAllowReap,
+    /// uxc/can_reap times out
+    CanReapTimeout,
 }
 
 impl Scenario {
@@ -56,8 +62,11 @@ impl Scenario {
             "empty_object_required" => Ok(Self::EmptyObjectRequired),
             "sui_pubsub" => Ok(Self::SuiPubSub),
             "session_scoped_resource" => Ok(Self::SessionScopedResource),
+            "can_reap_keep_alive" => Ok(Self::CanReapKeepAlive),
+            "can_reap_allow_reap" => Ok(Self::CanReapAllowReap),
+            "can_reap_timeout" => Ok(Self::CanReapTimeout),
             _ => anyhow::bail!(
-                "Unknown scenario: {}. Use: ok, auth_required, malformed, timeout, legacy, tool_call_timeout, tools_list_fail_after_first, structured_content, tool_structured_error, resource_read_fail_once, dynamic_toolset, empty_object_required, sui_pubsub, session_scoped_resource",
+                "Unknown scenario: {}. Use: ok, auth_required, malformed, timeout, legacy, tool_call_timeout, tools_list_fail_after_first, structured_content, tool_structured_error, resource_read_fail_once, dynamic_toolset, empty_object_required, sui_pubsub, session_scoped_resource, can_reap_keep_alive, can_reap_allow_reap, can_reap_timeout",
                 s
             ),
         }

--- a/src/test_server/graphql.rs
+++ b/src/test_server/graphql.rs
@@ -337,7 +337,10 @@ async fn execute_query(
         | Scenario::StructuredContent
         | Scenario::ResourceReadFailOnce
         | Scenario::SessionScopedResource
-        | Scenario::DynamicToolset => {
+        | Scenario::DynamicToolset
+        | Scenario::CanReapKeepAlive
+        | Scenario::CanReapAllowReap
+        | Scenario::CanReapTimeout => {
             // Introspection query
             if query.contains("__schema") || query.contains("__type(") {
                 return Ok(GraphQLResponse {

--- a/src/test_server/grpc.rs
+++ b/src/test_server/grpc.rs
@@ -34,7 +34,10 @@ impl addsvc::add_server::Add for AddService {
             | Scenario::StructuredContent
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
-            | Scenario::DynamicToolset => {
+            | Scenario::DynamicToolset
+            | Scenario::CanReapKeepAlive
+            | Scenario::CanReapAllowReap
+            | Scenario::CanReapTimeout => {
                 let req = request.into_inner();
                 Ok(Response::new(addsvc::SumReply { v: req.a + req.b }))
             }

--- a/src/test_server/jsonrpc.rs
+++ b/src/test_server/jsonrpc.rs
@@ -58,7 +58,11 @@ enum JsonRpcPubSubProfile {
 
 fn pubsub_profile(scenario: Scenario) -> Option<JsonRpcPubSubProfile> {
     match scenario {
-        Scenario::Ok | Scenario::Legacy => Some(JsonRpcPubSubProfile::DerivedUnsubscribe),
+        Scenario::Ok
+        | Scenario::Legacy
+        | Scenario::CanReapKeepAlive
+        | Scenario::CanReapAllowReap
+        | Scenario::CanReapTimeout => Some(JsonRpcPubSubProfile::DerivedUnsubscribe),
         Scenario::SuiPubSub => Some(JsonRpcPubSubProfile::CloseOnly),
         _ => None,
     }
@@ -324,7 +328,10 @@ async fn execute_method(
         | Scenario::StructuredContent
         | Scenario::ResourceReadFailOnce
         | Scenario::SessionScopedResource
-        | Scenario::DynamicToolset => {
+        | Scenario::DynamicToolset
+        | Scenario::CanReapKeepAlive
+        | Scenario::CanReapAllowReap
+        | Scenario::CanReapTimeout => {
             let result = match method {
                 "rpc.discover" => schema_value(state.scenario),
                 "health" => json!({"status": "ok"}),

--- a/src/test_server/mcp_stdio.rs
+++ b/src/test_server/mcp_stdio.rs
@@ -94,6 +94,53 @@ pub fn run(scenario: Scenario) -> Result<()> {
                     }),
                 )?;
             }
+            "uxc/can_reap" => {
+                if matches!(scenario, Scenario::CanReapTimeout) {
+                    std::thread::sleep(super::common::timeout_duration());
+                }
+                if matches!(scenario, Scenario::CanReapKeepAlive) {
+                    respond(
+                        &mut out,
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "result": {
+                                "can_reap": false,
+                                "reason": "interactive_session",
+                                "retry_after_secs": 30,
+                                "state": {
+                                    "interactive": true,
+                                    "owns_external_resource": true,
+                                    "waiting_for_human": false
+                                }
+                            }
+                        }),
+                    )?;
+                    continue;
+                }
+                if matches!(scenario, Scenario::CanReapAllowReap) {
+                    respond(
+                        &mut out,
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "result": {
+                                "can_reap": true,
+                                "reason": "idle_session"
+                            }
+                        }),
+                    )?;
+                    continue;
+                }
+                respond(
+                    &mut out,
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "error": {"code": -32601, "message": "Method not found"}
+                    }),
+                )?;
+            }
             "tools/list" => {
                 tools_list_calls = tools_list_calls.saturating_add(1);
                 if matches!(scenario, Scenario::ToolsListFailAfterFirst) && tools_list_calls > 1 {

--- a/src/test_server/openapi.rs
+++ b/src/test_server/openapi.rs
@@ -247,7 +247,10 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::StructuredContent
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
-            | Scenario::DynamicToolset => Ok(Json(json!({"status": "ok"})).into_response()),
+            | Scenario::DynamicToolset
+            | Scenario::CanReapKeepAlive
+            | Scenario::CanReapAllowReap
+            | Scenario::CanReapTimeout => Ok(Json(json!({"status": "ok"})).into_response()),
             Scenario::AuthRequired => Err(StatusCode::UNAUTHORIZED),
             Scenario::Malformed => {
                 // Return invalid JSON
@@ -276,7 +279,10 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::StructuredContent
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
-            | Scenario::DynamicToolset => {
+            | Scenario::DynamicToolset
+            | Scenario::CanReapKeepAlive
+            | Scenario::CanReapAllowReap
+            | Scenario::CanReapTimeout => {
                 let users = vec![
                     json!({"id": 1, "name": "Alice", "email": "alice@example.com"}),
                     json!({"id": 2, "name": "Bob", "email": "bob@example.com"}),
@@ -311,7 +317,10 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::StructuredContent
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
-            | Scenario::DynamicToolset => {
+            | Scenario::DynamicToolset
+            | Scenario::CanReapKeepAlive
+            | Scenario::CanReapAllowReap
+            | Scenario::CanReapTimeout => {
                 let name = payload
                     .get("name")
                     .and_then(|v| v.as_str())
@@ -354,7 +363,10 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::StructuredContent
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
-            | Scenario::DynamicToolset => {
+            | Scenario::DynamicToolset
+            | Scenario::CanReapKeepAlive
+            | Scenario::CanReapAllowReap
+            | Scenario::CanReapTimeout => {
                 if id == 1 {
                     Ok(
                         Json(json!({"id": 1, "name": "Alice", "email": "alice@example.com"}))
@@ -393,7 +405,10 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::StructuredContent
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
-            | Scenario::DynamicToolset => {
+            | Scenario::DynamicToolset
+            | Scenario::CanReapKeepAlive
+            | Scenario::CanReapAllowReap
+            | Scenario::CanReapTimeout => {
                 let body = Body::from_stream(stream::iter(vec![
                     Ok::<Bytes, std::convert::Infallible>(Bytes::from_static(
                         br#"{"type":"tick","value":1}
@@ -442,7 +457,10 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::StructuredContent
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
-            | Scenario::DynamicToolset => {
+            | Scenario::DynamicToolset
+            | Scenario::CanReapKeepAlive
+            | Scenario::CanReapAllowReap
+            | Scenario::CanReapTimeout => {
                 let response = match query.cursor.as_deref() {
                     None => json!({
                         "items": [
@@ -491,7 +509,10 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::StructuredContent
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
-            | Scenario::DynamicToolset => {
+            | Scenario::DynamicToolset
+            | Scenario::CanReapKeepAlive
+            | Scenario::CanReapAllowReap
+            | Scenario::CanReapTimeout => {
                 let response = match query.offset {
                     None | Some(0) => json!({
                         "ok": true,

--- a/tests/daemon_logging_test.rs
+++ b/tests/daemon_logging_test.rs
@@ -230,6 +230,76 @@ fn daemon_log_contains_stdio_session_lifecycle_events() {
     let _ = fs::remove_file(&log_file);
 }
 
+#[test]
+#[serial]
+fn daemon_log_contains_reap_deferred_event_when_can_reap_is_false() {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::thread;
+    use std::time::Duration;
+
+    let _ = uxc_command().arg("daemon").arg("stop").output();
+
+    let log_dir = if let Some(dir) = std::env::var_os("XDG_RUNTIME_DIR") {
+        PathBuf::from(dir).join("uxc")
+    } else if let Some(home) = std::env::var_os("HOME") {
+        PathBuf::from(home).join(".uxc").join("daemon")
+    } else {
+        return;
+    };
+
+    let log_file = log_dir.join("daemon.log");
+    if log_file.exists() {
+        let _ = fs::remove_file(&log_file);
+    }
+
+    let start = uxc_command()
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("daemon start should run");
+    assert!(start.status.success());
+
+    let bin = test_server_binary("mcp-stdio");
+    let endpoint = format!("{} can_reap_keep_alive", bin.display());
+    let first = uxc_command()
+        .arg("--daemon-idle-ttl")
+        .arg("1")
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"seed"}"#)
+        .output()
+        .expect("first call should run");
+    assert!(first.status.success());
+
+    thread::sleep(Duration::from_millis(1500));
+
+    let second = uxc_command()
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"trigger"}"#)
+        .output()
+        .expect("second call should run");
+    assert!(second.status.success());
+
+    thread::sleep(Duration::from_millis(200));
+
+    let content = fs::read_to_string(&log_file).expect("should be able to read daemon log");
+    assert!(
+        content.contains("daemon_session_reap_deferred"),
+        "log should contain daemon_session_reap_deferred event"
+    );
+    assert!(
+        content.contains("interactive_session"),
+        "log should include the can_reap defer reason"
+    );
+
+    let _ = uxc_command().arg("daemon").arg("stop").output();
+    let _ = fs::remove_file(&log_file);
+}
+
 #[allow(deprecated)]
 fn uxc_command() -> assert_cmd::Command {
     assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()

--- a/tests/daemon_reuse_test.rs
+++ b/tests/daemon_reuse_test.rs
@@ -221,6 +221,148 @@ fn daemon_sessions_lists_live_stdio_session_diagnostics() {
 
 #[test]
 #[serial]
+fn daemon_sessions_expose_supported_can_reap_contract_when_idle_reap_is_deferred() {
+    daemon_stop_best_effort();
+
+    let bin = test_server_binary("mcp-stdio");
+    let endpoint = format!("{} can_reap_keep_alive", bin.display());
+
+    let start = uxc_command()
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("daemon start should run");
+    assert!(start.status.success());
+
+    let first = uxc_command()
+        .arg("--daemon-idle-ttl")
+        .arg("1")
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"seed"}"#)
+        .output()
+        .expect("first call should run");
+    assert!(first.status.success());
+
+    std::thread::sleep(Duration::from_millis(1500));
+
+    let second = uxc_command()
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"reuse"}"#)
+        .output()
+        .expect("second call should run");
+    assert!(second.status.success());
+
+    let second_json: serde_json::Value =
+        serde_json::from_slice(&second.stdout).expect("second stdout should be valid JSON");
+    assert_eq!(second_json["meta"]["daemon_session_reused"], true);
+
+    let sessions = uxc_command()
+        .arg("daemon")
+        .arg("sessions")
+        .output()
+        .expect("daemon sessions should run");
+    assert!(sessions.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&sessions.stdout).expect("valid daemon sessions json");
+    let sessions = json["data"]
+        .as_array()
+        .expect("session list should be an array");
+    assert_eq!(sessions.len(), 1, "expected one stdio session");
+    let contract = &sessions[0]["can_reap_contract"];
+    assert_eq!(contract["support"], "supported");
+    assert_eq!(contract["can_reap"], false);
+    assert_eq!(contract["reason"], "interactive_session");
+    assert_eq!(contract["retry_after_secs"], 30);
+    assert_eq!(contract["state"]["interactive"], true);
+    assert_eq!(contract["state"]["owns_external_resource"], true);
+    assert_eq!(contract["state"]["waiting_for_human"], false);
+
+    daemon_stop_best_effort();
+}
+
+#[test]
+#[serial]
+fn can_reap_true_allows_idle_session_to_be_reaped_before_reuse() {
+    daemon_stop_best_effort();
+
+    let bin = test_server_binary("mcp-stdio");
+    let endpoint = format!("{} can_reap_allow_reap", bin.display());
+
+    let start = uxc_command()
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("daemon start should run");
+    assert!(start.status.success());
+
+    let first = uxc_command()
+        .arg("--daemon-idle-ttl")
+        .arg("1")
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"seed"}"#)
+        .output()
+        .expect("first call should run");
+    assert!(first.status.success());
+
+    let first_sessions = uxc_command()
+        .arg("daemon")
+        .arg("sessions")
+        .output()
+        .expect("daemon sessions should run");
+    assert!(first_sessions.status.success());
+    let first_json: serde_json::Value =
+        serde_json::from_slice(&first_sessions.stdout).expect("valid daemon sessions json");
+    let first_pid = first_json["data"][0]["child_pid"]
+        .as_u64()
+        .expect("child pid should be present");
+
+    std::thread::sleep(Duration::from_millis(1500));
+
+    let second = uxc_command()
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"seed-again"}"#)
+        .output()
+        .expect("second call should run");
+    assert!(second.status.success());
+
+    let second_json: serde_json::Value =
+        serde_json::from_slice(&second.stdout).expect("second stdout should be valid JSON");
+    assert!(
+        second_json["meta"]["daemon_session_reused"] != true,
+        "expected second call to use a fresh session after can_reap=true"
+    );
+
+    let second_sessions = uxc_command()
+        .arg("daemon")
+        .arg("sessions")
+        .output()
+        .expect("daemon sessions should run");
+    assert!(second_sessions.status.success());
+    let second_sessions_json: serde_json::Value =
+        serde_json::from_slice(&second_sessions.stdout).expect("valid daemon sessions json");
+    let second_pid = second_sessions_json["data"][0]["child_pid"]
+        .as_u64()
+        .expect("child pid should be present");
+    assert_ne!(first_pid, second_pid, "expected a new MCP child process");
+    assert_eq!(
+        second_sessions_json["data"][0]["can_reap_contract"]["support"],
+        "unknown"
+    );
+
+    daemon_stop_best_effort();
+}
+
+#[test]
+#[serial]
 fn daemon_sessions_reports_active_state_for_busy_stdio_session() {
     daemon_stop_best_effort();
 


### PR DESCRIPTION
## What

- add a private `uxc/can_reap` probe for MCP stdio child processes
- teach daemon idle cleanup to consult the probe before reaping idle stdio sessions
- expose the latest `can_reap` contract state in `daemon.sessions` / `uxc daemon sessions`
- add test-server scenarios and daemon/logging coverage for deferred reap and explicit reap

## Why

Long-lived MCP processes can now switch runtime mode after startup, so link-level idle TTL alone is no longer enough to decide when a daemon-managed process is safe to reap. This change gives child processes an explicit way to tell the daemon whether an idle process is reclaimable while preserving TTL as the fallback for legacy servers.

Closes #327

## How

- add `send_request_with_timeout` to the MCP stdio transport
- add `probe_can_reap(...)` to the MCP stdio client
- cache the latest `can_reap` result on daemon stdio sessions and snapshots
- defer idle reap when the probe returns `can_reap=false`, with a retry window
- fall back to legacy TTL behavior for unsupported methods, timeouts, and probe errors
- log `daemon_session_reap_deferred` when a child process explicitly refuses reap

## Testing

- `cargo test --test daemon_reuse_test -- --test-threads=1`
- `cargo test --test daemon_logging_test -- --test-threads=1`
- `cargo test can_reap --lib`
- `cargo test send_request_with_timeout_uses_caller_timeout --lib`