### PR TITLE
feat: add qmd mcp skill

### DIFF
--- a/docs/operations/skills.md
+++ b/docs/operations/skills.md
@@ -58,6 +58,7 @@ bash skills/playwright-mcp-skill/scripts/validate.sh
 bash skills/chrome-devtools-mcp-skill/scripts/validate.sh
 bash skills/context7-mcp-skill/scripts/validate.sh
 bash skills/deepwiki-mcp-skill/scripts/validate.sh
+bash skills/qmd-mcp-skill/scripts/validate.sh
 bash skills/dune-mcp-skill/scripts/validate.sh
 bash skills/thegraph-mcp-skill/scripts/validate.sh
 bash skills/thegraph-token-mcp-skill/scripts/validate.sh

--- a/skills/README.md
+++ b/skills/README.md
@@ -31,6 +31,7 @@ notes, and maintenance logs.
 - [`chrome-devtools-mcp-skill`](chrome-devtools-mcp-skill/SKILL.md)
 - [`context7-mcp-skill`](context7-mcp-skill/SKILL.md)
 - [`deepwiki-mcp-skill`](deepwiki-mcp-skill/SKILL.md)
+- [`qmd-mcp-skill`](qmd-mcp-skill/SKILL.md)
 
 ### Workspace and Messaging
 
@@ -242,6 +243,9 @@ notes, and maintenance logs.
 
 - [playwright-mcp-skill](./playwright-mcp-skill/)
   Run browser automation through @playwright/mcp over UXC stdio MCP, with daemon-friendly session reuse and safe action guardrails. Use when tasks need deterministic page navigation, DOM snapshots, and scripted browser interaction from CLI.
+
+- [qmd-mcp-skill](./qmd-mcp-skill/)
+  Use a local QMD knowledge base through UXC over MCP stdio, with daemon-backed session reuse and typed retrieval flows that avoid repeated model warmup and unnecessary query-expansion latency.
 
 - [slack-openapi-skill](./slack-openapi-skill/)
   Operate Slack Web API through UXC with a curated OpenAPI schema, bearer-token auth, and messaging-core guardrails.

--- a/skills/qmd-mcp-skill/SKILL.md
+++ b/skills/qmd-mcp-skill/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: qmd-mcp-skill
+description: Use a local QMD knowledge base through UXC over MCP stdio, with daemon-backed session reuse and typed retrieval flows that avoid repeated model warmup and unnecessary query-expansion latency.
+metadata:
+  short-description: Query local QMD indexes via UXC MCP stdio
+---
+
+# QMD MCP Skill
+
+Use this skill to query a local QMD index through `uxc` using a fixed MCP stdio link.
+
+Reuse the `uxc` skill for generic protocol discovery, JSON envelope parsing, and daemon lifecycle basics.
+
+## Prerequisites
+
+- `uxc` is installed and available in `PATH`.
+- `qmd` is installed and available in the runtime `PATH`, or can be launched through a shell wrapper.
+- A QMD index already exists and is healthy:
+  - `qmd status`
+  - `qmd update`
+  - `qmd embed`
+- For GPU-backed setups, the shell used by `qmd mcp` already exports any required runtime environment such as `CUDA_PATH`, `CUDACXX`, `LD_LIBRARY_PATH`, or Node/nvm initialization.
+
+## Core Workflow
+
+1. Verify the local QMD index first:
+   - `qmd status`
+   - Confirm collections, vector count, and device look reasonable before linking MCP.
+2. Use a fixed link command by default:
+   - `command -v qmd-mcp-cli`
+   - If missing and `qmd` already works in the current shell:
+     - `uxc link --daemon-idle-ttl 0 qmd-mcp-cli "qmd mcp"`
+   - If `qmd` depends on `nvm`, CUDA env, or other shell setup, wrap it explicitly:
+     - `uxc link --daemon-idle-ttl 0 qmd-mcp-cli "/bin/bash -lc 'export NVM_DIR=$HOME/.nvm; . $NVM_DIR/nvm.sh; nvm use 23 >/dev/null; export CUDA_PATH=/usr/local/cuda-11.6; export CUDA_HOME=/usr/local/cuda-11.6; export CUDACXX=/usr/local/cuda-11.6/bin/nvcc; export LD_LIBRARY_PATH=/usr/local/cuda-11.6/lib64:${LD_LIBRARY_PATH:-}; export NODE_LLAMA_CPP_CMAKE_OPTION_CMAKE_CUDA_ARCHITECTURES=86; export NODE_LLAMA_CPP_GPU=cuda; qmd mcp'"`
+   - `qmd-mcp-cli -h`
+   - If command conflict is detected and cannot be safely reused, stop and ask skill maintainers to pick another fixed command name.
+3. Confirm the daemon-backed stdio path is active:
+   - `uxc daemon status`
+   - `uxc daemon sessions`
+4. Inspect operation schema before execution:
+   - `qmd-mcp-cli query -h`
+   - `qmd-mcp-cli get -h`
+   - `qmd-mcp-cli multi_get -h`
+   - `qmd-mcp-cli status -h`
+5. Prefer typed retrieval over CLI-style auto expansion:
+   - Start with `query` using explicit `lex` / `vec` / `hyde` searches
+   - Use `get` or `multi_get` only after narrowing candidates
+
+## Recommended Usage Pattern
+
+1. Health check the index:
+   - `qmd-mcp-cli status`
+2. Start with a fast explicit search payload:
+   - `qmd-mcp-cli query '{"searches":[{"type":"lex","query":"\"execution layer\" MCP CLI"},{"type":"vec","query":"What is the missing execution surface between MCP and CLI?"}],"collections":["workspace"],"limit":5,"intent":"Find the article explaining capability description, execution surface, and workflow orchestration"}'`
+3. Retrieve the chosen file:
+   - `qmd-mcp-cli get file=workspace/public/mcp-is-not-the-problem/readme.md`
+4. Use `multi_get` for a short candidate set only:
+   - `qmd-mcp-cli multi_get pattern='workspace/public/*.md,workspace/research/*.md' maxBytes=20480`
+
+## Capability Map
+
+- Search:
+  - `query`
+- Retrieval:
+  - `get`
+  - `multi_get`
+- Health:
+  - `status`
+
+## Guardrails
+
+- Keep automation on JSON output envelope; do not rely on `--text`.
+- Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- Use `qmd-mcp-cli` as the default command path.
+- `qmd-mcp-cli <operation> ...` is equivalent to `uxc "qmd mcp" <operation> ...` when `qmd` already runs correctly in the current shell.
+- If `qmd` requires shell initialization or GPU env exports, use the same wrapped shell command in the link and any direct `uxc "<host>" ...` fallback.
+- Prefer explicit typed `query` payloads over the standalone QMD CLI hybrid mode when latency matters.
+- Treat `lex` as the default fast path:
+  - exact names
+  - quoted phrases
+  - negation
+- Add `vec` when the question is semantic but still bounded.
+- Add `hyde` only for nuanced or sparse topics; it is the most expensive query type.
+- Use `intent` to disambiguate ambiguous search terms instead of over-expanding the query text itself.
+- Keep `limit` and `candidateLimit` modest for interactive use.
+- `--daemon-idle-ttl 0` is recommended for QMD because the first heavy request may warm models and sessions; long-lived reuse makes repeated calls much faster.
+
+## Notes
+
+- The first MCP request can still be slow while the `uxc` daemon creates the stdio session and QMD warms model state.
+- Repeated calls through the same `uxc` daemon session can drop sharply in latency once the session is warm.
+- This skill is best for local knowledge bases, notes, and markdown corpora already indexed by QMD.
+- If you need the highest-quality but slowest retrieval path, you can still express it through `query` with richer `searches` arrays instead of shelling out to the standalone QMD CLI hybrid mode.
+
+## References
+
+- Invocation patterns:
+  - `references/usage-patterns.md`

--- a/skills/qmd-mcp-skill/agents/openai.yaml
+++ b/skills/qmd-mcp-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "QMD MCP"
+  short_description: "Query local QMD indexes via UXC MCP stdio"
+  default_prompt: "Use $qmd-mcp-skill to query a local QMD knowledge base through UXC MCP stdio with daemon-backed session reuse."

--- a/skills/qmd-mcp-skill/references/usage-patterns.md
+++ b/skills/qmd-mcp-skill/references/usage-patterns.md
@@ -1,0 +1,87 @@
+# QMD MCP Usage Patterns
+
+This skill defaults to fixed link command `qmd-mcp-cli`.
+
+Create it when missing:
+
+```bash
+command -v qmd-mcp-cli
+uxc link --daemon-idle-ttl 0 qmd-mcp-cli "qmd mcp"
+```
+
+If `qmd` depends on shell setup, wrap the command explicitly:
+
+```bash
+uxc link --daemon-idle-ttl 0 qmd-mcp-cli "/bin/bash -lc 'export NVM_DIR=$HOME/.nvm; . $NVM_DIR/nvm.sh; nvm use 23 >/dev/null; export CUDA_PATH=/usr/local/cuda-11.6; export CUDA_HOME=/usr/local/cuda-11.6; export CUDACXX=/usr/local/cuda-11.6/bin/nvcc; export LD_LIBRARY_PATH=/usr/local/cuda-11.6/lib64:${LD_LIBRARY_PATH:-}; export NODE_LLAMA_CPP_CMAKE_OPTION_CMAKE_CUDA_ARCHITECTURES=86; export NODE_LLAMA_CPP_GPU=cuda; qmd mcp'"
+```
+
+Inspect the linked tools first:
+
+```bash
+qmd-mcp-cli -h
+qmd-mcp-cli query -h
+qmd-mcp-cli get -h
+qmd-mcp-cli multi_get -h
+qmd-mcp-cli status -h
+```
+
+## Fast Interactive Search
+
+Prefer a typed `lex` query first:
+
+```bash
+qmd-mcp-cli query '{"searches":[{"type":"lex","query":"\"execution layer\" MCP CLI -migration"}],"collections":["workspace"],"limit":5,"intent":"Find the article about the missing execution surface for agents"}'
+```
+
+Add `vec` when the query is more semantic:
+
+```bash
+qmd-mcp-cli query '{"searches":[{"type":"lex","query":"\"Bitcoin L2\" DA rollup"},{"type":"vec","query":"How should Bitcoin layer 2 relate to DA and rollup architecture?"}],"collections":["workspace"],"limit":5,"intent":"Find articles discussing Bitcoin L2, DA, and rollup design"}'
+```
+
+Use `hyde` only when recall is still weak:
+
+```bash
+qmd-mcp-cli query '{"searches":[{"type":"lex","query":"\"connection pool\" timeout -redis"},{"type":"vec","query":"Why do database connections time out under load?"},{"type":"hyde","query":"Connection pool exhaustion occurs when all connections are busy and requests must wait. Under high concurrency, long-running queries can cause timeout cascades."}],"limit":5}'
+```
+
+## Retrieve Documents After Search
+
+Fetch one chosen document:
+
+```bash
+qmd-mcp-cli get file=workspace/public/how-to-define-bitcoin-l2/readme.md
+```
+
+Fetch multiple known candidates:
+
+```bash
+qmd-mcp-cli multi_get '{"pattern":"workspace/public/how-to-define-bitcoin-l2/readme.md,workspace/public/how-bitcoin-layer2-should-work/readme.md","maxBytes":32768}'
+```
+
+## Session Reuse Checks
+
+Check that `uxc` is reusing the stdio session:
+
+```bash
+uxc daemon status
+uxc daemon sessions
+```
+
+Recommended signs:
+
+- `mcp_stdio_sessions` is non-zero
+- `mcp_reuse_hits` increases after repeated calls
+- the `qmd-mcp-cli` session appears as `ready`
+
+## Fallback Equivalence
+
+- `qmd-mcp-cli <operation> ...` is equivalent to `uxc "qmd mcp" <operation> ...` when `qmd` already runs correctly in the current shell.
+- If shell initialization or GPU env exports are required, use the same wrapped shell command directly with `uxc "<wrapped-host>" ...` as fallback.
+
+## Limitations
+
+- The first daemon-backed call can still be slow because QMD may warm model state on first real request.
+- `lex` is usually the best default for low latency.
+- `vec` and especially `hyde` raise latency and should be added intentionally.
+- This skill assumes the QMD index already exists and is healthy; it does not replace `qmd update` or `qmd embed`.

--- a/skills/qmd-mcp-skill/scripts/validate.sh
+++ b/skills/qmd-mcp-skill/scripts/validate.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="${ROOT_DIR}/skills/qmd-mcp-skill"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
+
+fail() {
+  printf '[validate] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+need_cmd rg
+
+required_files=(
+  "${SKILL_FILE}"
+  "${OPENAI_FILE}"
+  "${SKILL_DIR}/references/usage-patterns.md"
+)
+
+for file in "${required_files[@]}"; do
+  if [[ ! -f "${file}" ]]; then
+    fail "missing required file: ${file}"
+  fi
+done
+
+if ! head -n 1 "${SKILL_FILE}" | rg -q '^---$'; then
+  fail "SKILL.md must include YAML frontmatter"
+fi
+
+if ! tail -n +2 "${SKILL_FILE}" | rg -q '^---$'; then
+  fail "SKILL.md must include YAML frontmatter"
+fi
+
+if ! rg -q '^name:\s*qmd-mcp-skill\s*$' "${SKILL_FILE}"; then
+  fail "SKILL.md frontmatter must define: name: qmd-mcp-skill"
+fi
+
+if ! rg -q '^description:\s*.+' "${SKILL_FILE}"; then
+  fail "SKILL.md frontmatter must define a description"
+fi
+
+if ! rg -q 'command -v qmd-mcp-cli' "${SKILL_FILE}"; then
+  fail "SKILL.md must include link command existence check"
+fi
+
+if ! rg -q 'uxc link --daemon-idle-ttl 0 qmd-mcp-cli "qmd mcp"' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must include the default daemon-backed link creation command"
+fi
+
+if ! rg -q 'qmd-mcp-cli -h' "${SKILL_FILE}"; then
+  fail "SKILL.md must use qmd-mcp-cli help-first discovery"
+fi
+
+if ! rg -q 'qmd-mcp-cli query -h' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must document query help inspection"
+fi
+
+if ! rg -q 'qmd-mcp-cli get -h' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must document get help inspection"
+fi
+
+if ! rg -q 'qmd-mcp-cli multi_get -h' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must document multi_get help inspection"
+fi
+
+if ! rg -q 'qmd-mcp-cli status -h' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must document status help inspection"
+fi
+
+if ! rg -q 'uxc daemon status' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must document daemon status checks"
+fi
+
+if ! rg -q 'uxc daemon sessions' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must document daemon session checks"
+fi
+
+if ! rg -q '"type":"lex"' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must include a lex query example"
+fi
+
+if ! rg -q '"type":"vec"' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must include a vec query example"
+fi
+
+if ! rg -q '"type":"hyde"' "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must include a hyde query example in usage patterns"
+fi
+
+if ! rg -q 'equivalent to `uxc "qmd mcp"' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must include fallback equivalence guidance"
+fi
+
+if rg -q -- 'qmd query ".*"|qmd search ".*"|qmd-mcp-cli (list|describe|call)\b|--input-json' "${SKILL_FILE}" "${SKILL_DIR}/references/usage-patterns.md"; then
+  fail "qmd skill must not rely on legacy list/describe/call or direct qmd query/search as the default workflow"
+fi
+
+if ! rg -q 'references/usage-patterns.md' "${SKILL_FILE}"; then
+  fail "SKILL.md must reference usage-patterns.md"
+fi
+
+if ! rg -q '^\s*display_name:\s*"QMD MCP"\s*$' "${OPENAI_FILE}"; then
+  fail "agents/openai.yaml must define interface.display_name"
+fi
+
+if ! rg -q '^\s*short_description:\s*".+"\s*$' "${OPENAI_FILE}"; then
+  fail "agents/openai.yaml must define interface.short_description"
+fi
+
+if ! rg -q '^\s*default_prompt:\s*".*\$qmd-mcp-skill.*"\s*$' "${OPENAI_FILE}"; then
+  fail 'agents/openai.yaml default_prompt must mention $qmd-mcp-skill'
+fi
+
+echo "skills/qmd-mcp-skill validation passed"


### PR DESCRIPTION
## What
Add a new `qmd-mcp-skill` that documents how to run a local QMD knowledge base through UXC over MCP stdio with daemon-backed session reuse.

## Why
QMD is useful for local knowledge-base retrieval, but the standalone CLI hybrid path is heavy and can pay repeated warmup cost. In testing, wrapping `qmd mcp` through `uxc` daemon-backed stdio produced a much better repeated-call path and gives a stable fixed command for agents.

Closes #N/A

## How
Document the recommended UXC-native setup instead of relying on `qmd query` shell calls.

## Changes
- [x] Add `skills/qmd-mcp-skill/` with `SKILL.md`, `agents/openai.yaml`, `references/usage-patterns.md`, and `scripts/validate.sh`
- [x] Document fixed link setup with `qmd-mcp-cli` and `--daemon-idle-ttl 0`
- [x] Document typed `query` / `get` / `multi_get` usage and daemon session checks
- [x] Update `skills/README.md` catalog entries
- [x] Add the new validator to `docs/operations/skills.md`

## Testing

### Unit Tests
- [x] New validator added for the new skill
- [ ] `cargo test` passes

### Manual Testing
- [x] Tested against real APIs / real MCP host
- [x] Tested repeated-call reuse behavior
- [ ] Tested error conditions

### Test Results
```bash
bash skills/qmd-mcp-skill/scripts/validate.sh
# skills/qmd-mcp-skill validation passed
```

Real validation on Ubuntu + RTX 3090:
- installed `uxc 0.12.6`
- linked `qmd-mcp-cli` to `qmd mcp` over stdio with `--daemon-idle-ttl 0`
- confirmed `uxc daemon` reused the MCP stdio session
- repeated `query` call latency dropped from about `7540 ms` to about `488 ms`

## Checklist
- [ ] Code formatted with `cargo fmt`
- [ ] No clippy warnings (`cargo clippy -- -D warnings`)
- [ ] All tests pass (`cargo test`)
- [x] Documentation updated
- [x] Commit messages follow convention
- [x] PR title follows convention

## Breaking Changes
None.

## Additional Notes
This skill intentionally recommends typed MCP `query` payloads over shelling out to the standalone QMD CLI hybrid mode. The goal is to keep the fast path inside UXC daemon session reuse rather than reproducing the heaviest CLI path by default.
