### PR TITLE
feat: add dynamic adapter discovery mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage/
 
 # Local agent settings
 .claude/settings.local.json
+.alma-snapshots

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3123,6 +3133,7 @@ dependencies = [
  "inventory",
  "json5",
  "jsonwebtoken",
+ "libloading",
  "mockito",
  "openapiv3",
  "p256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3111,6 +3120,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
+ "inventory",
  "json5",
  "jsonwebtoken",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tokio-stream = { version = "0.1", features = ["net"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 async-trait = "0.1"
 futures = "0.3"
+inventory = "0.3"
 
 # Web server for test servers
 axum = { version = "0.7", optional = true, features = ["ws"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ async-trait = "0.1"
 futures = "0.3"
 inventory = "0.3"
 
+# Dynamic plugin loading
+libloading = "0.8"
+
 # Web server for test servers
 axum = { version = "0.7", optional = true, features = ["ws"] }
 

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -5,6 +5,23 @@
 //! - Schema retrieval
 //! - Operation discovery
 //! - Execution
+//!
+//! ## Plugin System
+//!
+//! External adapters can be loaded at runtime from `~/.config/uxc/plugins/`.
+//! Plugins are cdylib crates that export a `uxc_plugin_register` function:
+//!
+//! ```ignore
+//! #[no_mangle]
+//! pub extern "C" fn uxc_plugin_register(registrar: &mut dyn PluginRegistrar) {
+//!     registrar.register_adapter(PluginAdapterEntry {
+//!         name: "feishu",
+//!         priority: 100,
+//!         can_handle: |url| url.starts_with("feishu://") || url.contains("feishu.cn"),
+//!         create: || Box::new(FeishuAdapter::new()),
+//!     });
+//! }
+//! ```
 
 pub mod graphql;
 pub mod grpc;
@@ -21,23 +38,11 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::time::Duration;
 
-/// Registration entry for dynamic adapter discovery.
+// ─── Compile-time registration (inventory) ───
+
+/// Registration entry for compile-time adapter discovery via `inventory::submit!`.
 ///
-/// Third-party crates can register adapters at compile time using `inventory::submit!`.
-/// Registered adapters are tried (sorted by descending priority) before built-in adapters
-/// during protocol detection.
-///
-/// # Example
-/// ```ignore
-/// inventory::submit! {
-///     AdapterRegistration {
-///         name: "my-protocol",
-///         priority: 100,
-///         can_handle: |url| Box::pin(async move { Ok(url.contains("my-proto://")) }),
-///         create: || Box::new(MyAdapter::new()),
-///     }
-/// }
-/// ```
+/// Kept for backward compatibility. New plugins should prefer the C ABI plugin system.
 pub struct AdapterRegistration {
     /// Human-readable name for this adapter.
     pub name: &'static str,
@@ -50,6 +55,40 @@ pub struct AdapterRegistration {
 }
 
 inventory::collect!(AdapterRegistration);
+
+// ─── Runtime plugin system (C ABI) ───
+
+/// Entry describing one adapter provided by a plugin.
+/// Uses simple `fn` pointers for C ABI safety — no generics, no async, no closures.
+pub struct PluginAdapterEntry {
+    /// Human-readable name for this adapter.
+    pub name: &'static str,
+    /// Priority (0-255). Higher values are tried first.
+    pub priority: u8,
+    /// Sync predicate: returns `true` if this adapter can handle the given URL.
+    pub can_handle: fn(&str) -> bool,
+    /// Factory that creates a new boxed adapter instance.
+    pub create: fn() -> Box<dyn Adapter>,
+}
+
+/// Trait implemented by uxc's plugin host. Plugins call methods on this to register adapters.
+#[allow(dead_code)] // Used by external plugins, not uxc itself
+pub trait PluginRegistrar {
+    fn register_adapter(&mut self, entry: PluginAdapterEntry);
+}
+
+/// Signature of the plugin entry point function.
+/// Plugins must export: `#[no_mangle] pub extern "C" fn uxc_plugin_register(registrar: &mut dyn PluginRegistrar)`
+#[allow(improper_ctypes_definitions)] // Rust-to-Rust ABI — trait object is safe in practice
+pub type PluginEntryFn = unsafe extern "C" fn(registrar: &mut dyn PluginRegistrar);
+
+/// Global plugin state: loaded libraries + registered adapter entries.
+struct PluginState {
+    _libs: Vec<libloading::Library>,
+    adapters: Vec<PluginAdapterEntry>,
+}
+
+static PLUGIN_STATE: std::sync::OnceLock<PluginState> = std::sync::OnceLock::new();
 
 /// Enum of all available adapters
 #[allow(non_camel_case_types)]
@@ -250,9 +289,103 @@ pub struct DetectionOptions {
     pub request_timeout: Option<Duration>,
 }
 
+/// Concrete registrar that collects adapter entries during plugin initialization.
+struct PluginRegistrarImpl {
+    adapters: Vec<PluginAdapterEntry>,
+}
+
+impl PluginRegistrar for PluginRegistrarImpl {
+    fn register_adapter(&mut self, entry: PluginAdapterEntry) {
+        tracing::debug!("Plugin registered adapter: {}", entry.name);
+        self.adapters.push(entry);
+    }
+}
+
 impl ProtocolDetector {
     pub fn new() -> Self {
+        PLUGIN_STATE.get_or_init(Self::load_plugins);
         Self
+    }
+
+    /// Load plugin shared libraries from ~/.config/uxc/plugins/
+    ///
+    /// For each library, looks up the `uxc_plugin_register` symbol and calls it
+    /// with a registrar so the plugin can register its adapters.
+    fn load_plugins() -> PluginState {
+        let mut libs = Vec::new();
+        let mut registrar = PluginRegistrarImpl {
+            adapters: Vec::new(),
+        };
+
+        let plugin_dir = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(|h| std::path::PathBuf::from(h).join(".config/uxc/plugins"))
+            .unwrap_or_default();
+
+        if !plugin_dir.exists() {
+            return PluginState {
+                _libs: libs,
+                adapters: registrar.adapters,
+            };
+        }
+
+        let entries = match std::fs::read_dir(&plugin_dir) {
+            Ok(entries) => entries,
+            Err(_) => {
+                return PluginState {
+                    _libs: libs,
+                    adapters: registrar.adapters,
+                }
+            }
+        };
+
+        let extension = std::env::consts::DLL_EXTENSION;
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some(extension) {
+                continue;
+            }
+
+            let lib = match unsafe { libloading::Library::new(&path) } {
+                Ok(lib) => lib,
+                Err(err) => {
+                    tracing::warn!("Failed to load plugin {}: {}", path.display(), err);
+                    continue;
+                }
+            };
+
+            // Look up the C ABI entry point
+            let register_fn: libloading::Symbol<PluginEntryFn> =
+                match unsafe { lib.get(b"uxc_plugin_register") } {
+                    Ok(f) => f,
+                    Err(err) => {
+                        tracing::warn!(
+                            "Plugin {} missing uxc_plugin_register symbol: {}",
+                            path.display(),
+                            err
+                        );
+                        continue;
+                    }
+                };
+
+            unsafe { register_fn(&mut registrar) };
+            tracing::debug!("Loaded plugin: {}", path.display());
+            libs.push(lib);
+        }
+
+        if !libs.is_empty() {
+            tracing::info!(
+                "Loaded {} plugin(s), {} adapter(s) registered",
+                libs.len(),
+                registrar.adapters.len()
+            );
+        }
+
+        PluginState {
+            _libs: libs,
+            adapters: registrar.adapters,
+        }
     }
 
     /// Get adapter for a URL (auto-detects protocol)
@@ -270,14 +403,28 @@ impl ProtocolDetector {
     ) -> Result<AdapterEnum> {
         let mut schema_probe_errors = Vec::new();
 
-        // Try dynamically registered adapters first (sorted by descending priority)
+        // 1. Try compile-time registered adapters (inventory)
         let mut registrations: Vec<&AdapterRegistration> =
             inventory::iter::<AdapterRegistration>.into_iter().collect();
         registrations.sort_by_key(|r| std::cmp::Reverse(r.priority));
 
         for reg in registrations {
             if (reg.can_handle)(url).await? {
+                tracing::debug!("Matched external adapter: {}", reg.name);
                 return Ok(AdapterEnum::External((reg.create)()));
+            }
+        }
+
+        // 2. Try runtime-loaded plugin adapters (C ABI)
+        if let Some(state) = PLUGIN_STATE.get() {
+            let mut plugins: Vec<&PluginAdapterEntry> = state.adapters.iter().collect();
+            plugins.sort_by_key(|e| std::cmp::Reverse(e.priority));
+
+            for entry in plugins {
+                if (entry.can_handle)(url) {
+                    tracing::debug!("Matched plugin adapter: {}", entry.name);
+                    return Ok(AdapterEnum::External((entry.create)()));
+                }
             }
         }
 

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -15,10 +15,41 @@ pub mod openapi;
 use crate::error::UxcError;
 use anyhow::Result;
 use async_trait::async_trait;
+use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::time::Duration;
+
+/// Registration entry for dynamic adapter discovery.
+///
+/// Third-party crates can register adapters at compile time using `inventory::submit!`.
+/// Registered adapters are tried (sorted by descending priority) before built-in adapters
+/// during protocol detection.
+///
+/// # Example
+/// ```ignore
+/// inventory::submit! {
+///     AdapterRegistration {
+///         name: "my-protocol",
+///         priority: 100,
+///         can_handle: |url| Box::pin(async move { Ok(url.contains("my-proto://")) }),
+///         create: || Box::new(MyAdapter::new()),
+///     }
+/// }
+/// ```
+pub struct AdapterRegistration {
+    /// Human-readable name for this adapter.
+    pub name: &'static str,
+    /// Priority (0-255). Higher values are tried first.
+    pub priority: u8,
+    /// Async predicate: returns `true` if this adapter can handle the given URL.
+    pub can_handle: fn(&str) -> BoxFuture<'static, Result<bool>>,
+    /// Factory that creates a new adapter instance.
+    pub create: fn() -> Box<dyn Adapter>,
+}
+
+inventory::collect!(AdapterRegistration);
 
 /// Enum of all available adapters
 #[allow(non_camel_case_types)]
@@ -28,6 +59,8 @@ pub enum AdapterEnum {
     JsonRpc(jsonrpc::JsonRpcAdapter),
     Mcp(mcp::McpAdapter),
     GraphQL(graphql::GraphQLAdapter),
+    /// Dynamically registered external adapter discovered via `inventory`.
+    External(Box<dyn Adapter>),
 }
 
 #[async_trait]
@@ -39,6 +72,7 @@ impl Adapter for AdapterEnum {
             AdapterEnum::JsonRpc(_) => ProtocolType::JsonRpc,
             AdapterEnum::Mcp(_) => ProtocolType::Mcp,
             AdapterEnum::GraphQL(_) => ProtocolType::GraphQL,
+            AdapterEnum::External(a) => a.protocol_type(),
         }
     }
 
@@ -49,6 +83,7 @@ impl Adapter for AdapterEnum {
             AdapterEnum::JsonRpc(a) => a.can_handle(url).await,
             AdapterEnum::Mcp(a) => a.can_handle(url).await,
             AdapterEnum::GraphQL(a) => a.can_handle(url).await,
+            AdapterEnum::External(a) => a.can_handle(url).await,
         }
     }
 
@@ -59,6 +94,7 @@ impl Adapter for AdapterEnum {
             AdapterEnum::JsonRpc(a) => a.fetch_schema(url).await,
             AdapterEnum::Mcp(a) => a.fetch_schema(url).await,
             AdapterEnum::GraphQL(a) => a.fetch_schema(url).await,
+            AdapterEnum::External(a) => a.fetch_schema(url).await,
         }
     }
 
@@ -69,6 +105,7 @@ impl Adapter for AdapterEnum {
             AdapterEnum::JsonRpc(a) => a.list_operations(url).await,
             AdapterEnum::Mcp(a) => a.list_operations(url).await,
             AdapterEnum::GraphQL(a) => a.list_operations(url).await,
+            AdapterEnum::External(a) => a.list_operations(url).await,
         }
     }
 
@@ -79,6 +116,7 @@ impl Adapter for AdapterEnum {
             AdapterEnum::JsonRpc(a) => a.describe_operation(url, operation).await,
             AdapterEnum::Mcp(a) => a.describe_operation(url, operation).await,
             AdapterEnum::GraphQL(a) => a.describe_operation(url, operation).await,
+            AdapterEnum::External(a) => a.describe_operation(url, operation).await,
         }
     }
 
@@ -94,6 +132,7 @@ impl Adapter for AdapterEnum {
             AdapterEnum::JsonRpc(a) => a.execute(url, operation, args).await,
             AdapterEnum::Mcp(a) => a.execute(url, operation, args).await,
             AdapterEnum::GraphQL(a) => a.execute(url, operation, args).await,
+            AdapterEnum::External(a) => a.execute(url, operation, args).await,
         }
     }
 }
@@ -230,6 +269,17 @@ impl ProtocolDetector {
         options: &DetectionOptions,
     ) -> Result<AdapterEnum> {
         let mut schema_probe_errors = Vec::new();
+
+        // Try dynamically registered adapters first (sorted by descending priority)
+        let mut registrations: Vec<&AdapterRegistration> =
+            inventory::iter::<AdapterRegistration>.into_iter().collect();
+        registrations.sort_by_key(|r| std::cmp::Reverse(r.priority));
+
+        for reg in registrations {
+            if (reg.can_handle)(url).await? {
+                return Ok(AdapterEnum::External((reg.create)()));
+            }
+        }
 
         // Try MCP first (stdio commands are distinct)
         let mut mcp_adapter = mcp::McpAdapter::new();
@@ -637,5 +687,93 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(adapter, AdapterEnum::JsonRpc(_)));
+    }
+
+    /// A minimal adapter for testing dynamic registration.
+    struct DummyExternalAdapter;
+
+    #[async_trait]
+    impl Adapter for DummyExternalAdapter {
+        fn protocol_type(&self) -> ProtocolType {
+            ProtocolType::OpenAPI // reuse an existing variant for test
+        }
+        async fn can_handle(&self, _url: &str) -> Result<bool> {
+            Ok(true)
+        }
+        async fn fetch_schema(&self, _url: &str) -> Result<Value> {
+            Ok(serde_json::json!({"dummy": true}))
+        }
+        async fn list_operations(&self, _url: &str) -> Result<Vec<Operation>> {
+            Ok(vec![])
+        }
+        async fn describe_operation(
+            &self,
+            _url: &str,
+            _operation: &str,
+        ) -> Result<OperationDetail> {
+            Err(anyhow::anyhow!("not implemented"))
+        }
+        async fn execute(
+            &self,
+            _url: &str,
+            _operation: &str,
+            _args: HashMap<String, Value>,
+        ) -> Result<ExecutionResult> {
+            Err(anyhow::anyhow!("not implemented"))
+        }
+    }
+
+    inventory::submit! {
+        AdapterRegistration {
+            name: "dummy-test",
+            priority: 255,
+            can_handle: |url| {
+                let url = url.to_owned();
+                Box::pin(async move {
+                    Ok(url.contains("dummy-external-proto"))
+                })
+            },
+            create: || Box::new(DummyExternalAdapter),
+        }
+    }
+
+    #[tokio::test]
+    async fn detector_discovers_registered_external_adapter() {
+        let detector = ProtocolDetector::new();
+        let options = DetectionOptions::default();
+
+        let result = detector
+            .detect_adapter_with_options("http://dummy-external-proto.test/api", &options)
+            .await;
+        assert!(result.is_ok());
+        let adapter = result.unwrap();
+        assert!(matches!(adapter, AdapterEnum::External(_)));
+    }
+
+    #[tokio::test]
+    async fn external_adapter_delegates_to_trait() {
+        let detector = ProtocolDetector::new();
+        let options = DetectionOptions::default();
+
+        let adapter = detector
+            .detect_adapter_with_options("http://dummy-external-proto.test/api", &options)
+            .await
+            .unwrap();
+        let schema = adapter
+            .fetch_schema("http://dummy-external-proto.test/api")
+            .await
+            .unwrap();
+        assert_eq!(schema, serde_json::json!({"dummy": true}));
+    }
+
+    #[tokio::test]
+    async fn registered_adapters_sorted_by_priority() {
+        // Verify that inventory iteration produces at least our test registration
+        let registrations: Vec<&AdapterRegistration> =
+            inventory::iter::<AdapterRegistration>.into_iter().collect();
+        assert!(
+            registrations.iter().any(|r| r.name == "dummy-test"),
+            "Expected to find dummy-test registration"
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7935,6 +7935,7 @@ fn inject_cache_if_supported(
         adapters::AdapterEnum::GRpc(a) => adapters::AdapterEnum::GRpc(a.with_cache(cache)),
         adapters::AdapterEnum::JsonRpc(a) => adapters::AdapterEnum::JsonRpc(a.with_cache(cache)),
         adapters::AdapterEnum::Mcp(a) => adapters::AdapterEnum::Mcp(a.with_cache(cache)),
+        other @ adapters::AdapterEnum::External(_) => other,
     }
 }
 
@@ -7955,6 +7956,7 @@ fn inject_auth_if_supported(
                 adapters::AdapterEnum::JsonRpc(a.with_auth(profile))
             }
             adapters::AdapterEnum::Mcp(a) => adapters::AdapterEnum::Mcp(a.with_auth(profile)),
+            other @ adapters::AdapterEnum::External(_) => other,
         },
         None => adapter,
     }
@@ -7980,6 +7982,7 @@ fn inject_refresh_if_supported(
         adapters::AdapterEnum::Mcp(a) => {
             adapters::AdapterEnum::Mcp(a.with_refresh_schema(refresh_schema))
         }
+        other @ adapters::AdapterEnum::External(_) => other,
     }
 }
 
@@ -7999,6 +8002,7 @@ fn inject_timeout_if_supported(
             adapters::AdapterEnum::JsonRpc(a.with_timeout(timeout))
         }
         adapters::AdapterEnum::Mcp(a) => adapters::AdapterEnum::Mcp(a.with_timeout(timeout)),
+        other @ adapters::AdapterEnum::External(_) => other,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub mod subscription_websocket;
 #[cfg(feature = "test-server")]
 pub mod test_server;
 
-pub use adapters::{Adapter, ProtocolType};
+pub use adapters::{Adapter, PluginAdapterEntry, PluginRegistrar, ProtocolType};
 pub use cache::{create_cache, create_default_cache, Cache, CacheConfig, CacheResult};
 pub use error::{Result, UxcError};
 pub use output::OutputEnvelope;


### PR DESCRIPTION
## Summary

Implements #362 — Allow third-party adapters to register without modifying uxc core.

This PR adds a **complete runtime plugin system** for uxc:

1. **Compile-time registration** (commit 1): `inventory::submit!` for adapters linked at build time
2. **Runtime plugin loading** (commit 2): C ABI plugin system that loads `.dylib/.so/.dll` from `~/.config/uxc/plugins/` via `dlopen`

Plugins are built independently, installed by dropping a shared library into the plugins directory, and discovered automatically on startup — similar to Python's entry_points.

## Why C ABI instead of inventory for runtime plugins?

`inventory::submit!` only works within the same link unit. When a cdylib is loaded via `dlopen`, it carries its own isolated copy of the inventory registry. A C ABI entry point is the standard approach for Rust plugin systems — the host calls a known symbol, the plugin registers its adapters through a trait object.

## Design

```
~/.config/uxc/plugins/
  ├── libdatum_feishu.dylib     ← Feishu adapter
  └── libmy_custom.dylib        ← Your adapter

┌─────────────────────────────────────────────────┐
│  uxc process (CLI or daemon)                    │
│                                                 │
│  ProtocolDetector::new()                        │
│    │                                            │
│    ├─ OnceLock::get_or_init(load_plugins)       │
│    │    │                                       │
│    │    └─ scan ~/.config/uxc/plugins/          │
│    │         ├─ dlopen(libdatum_feishu.dylib)   │
│    │         │   └─ get("uxc_plugin_register")  │
│    │         │       └─ call → registrar        │
│    │         │           .register_adapter(     │
│    │         │             FeishuAdapter)        │
│    │         └─ dlopen(libmy_custom.dylib) ...  │
│    │                                            │
│    ├─ check inventory adapters (compile-time)   │
│    ├─ check plugin adapters (runtime) ←─────────│
│    └─ check built-in adapters (fallback)        │
│                                                 │
│  PLUGIN_STATE: OnceLock<PluginState>            │
│  (static — lives for entire process)            │
└─────────────────────────────────────────────────┘
```

## Changes

### Commit 1: Compile-time adapter registration
- Add `inventory` crate for distributed plugin registration
- Introduce `AdapterRegistration` struct with priority-based ordering
- Add `AdapterEnum::External` variant for registered adapters
- Update `ProtocolDetector` to check registered adapters before built-ins

### Commit 2: Runtime plugin system (C ABI)
- Add `PluginAdapterEntry`, `PluginRegistrar` trait, `PluginEntryFn` type
- Add `load_plugins()`: scans plugin dir, calls `uxc_plugin_register` symbol
- Use `OnceLock<PluginState>` for process-lifetime storage (load once, never unload)
- `detect_adapter_with_options()` checks: inventory → plugins → built-ins
- Export `PluginAdapterEntry` and `PluginRegistrar` from `lib.rs`
- Cross-platform: `std::env::consts::DLL_EXTENSION` for dylib/so/dll

## Plugin API

```rust
// my_adapter/Cargo.toml
[lib]
crate-type = ["cdylib"]

[dependencies]
uxc = "0.13"
```

```rust
// my_adapter/src/lib.rs
use uxc::{Adapter, PluginAdapterEntry, PluginRegistrar};

pub struct FeishuAdapter { /* ... */ }
impl Adapter for FeishuAdapter { /* ... */ }

#[no_mangle]
#[allow(improper_ctypes_definitions)]
pub extern "C" fn uxc_plugin_register(registrar: &mut dyn PluginRegistrar) {
    registrar.register_adapter(PluginAdapterEntry {
        name: "feishu",
        priority: 100,
        can_handle: |url| url.starts_with("feishu://"),
        create: || Box::new(FeishuAdapter::new()),
    });
}
```

```bash
# Build & install
cargo build --release
mkdir -p ~/.config/uxc/plugins
cp target/release/libmy_adapter.dylib ~/.config/uxc/plugins/

# Use — zero config needed
$ uxc feishu://api
# → lists operations: send_message, create_doc

$ uxc feishu://api send_message receive_id=ou_xxx msg_type=text content='{"text":"hello"}'
# → executes the operation
```

## Verified End-to-End

Tested with [datum-api-hub](https://github.com/Meta42/datum-api-hub) (Feishu adapter):

```
$ make install
Installed libdatum_feishu.dylib -> ~/.config/uxc/plugins/

$ uxc feishu://api
{
  "ok": true,
  "protocol": "openapi",
  "endpoint": "feishu://api",
  "operations": [
    { "operation_id": "send_message", "display_name": "发送消息" },
    { "operation_id": "create_doc", "display_name": "创建文档" }
  ],
  "daemon_used": true
}
```

Works in both direct mode and daemon mode.

## Implementation Notes

- Plugin `Library` handles held in `static OnceLock` — no dangling pointers
- Graceful degradation: missing plugin dir → no-op, bad plugin → warn and skip
- `PluginAdapterEntry.can_handle` is sync `fn(&str) -> bool` (not async) for C ABI safety
- `improper_ctypes_definitions` suppressed — Rust-to-Rust ABI, trait objects work in practice
- `libloading` is widely used (wasmtime, wgpu, etc.)

---

Closes #362

cc @nicolo-ribaudo — This enables third-party adapter development with true runtime discovery. Happy to adjust based on feedback!