### PR TITLE
fix(auth): improve oauth required guidance

### DIFF
--- a/src/adapters/graphql.rs
+++ b/src/adapters/graphql.rs
@@ -119,12 +119,22 @@ impl GraphQLAdapter {
         req
     }
 
-    async fn refresh_effective_auth_profile(&self, force: bool) -> Result<Option<Profile>> {
+    async fn refresh_effective_auth_profile(
+        &self,
+        force: bool,
+        endpoint_hint: Option<&str>,
+    ) -> Result<Option<Profile>> {
         let _refresh_guard = self.oauth_refresh_lock.lock().await;
         let mut profile = self.effective_auth_profile().await;
         if let Some(active) = profile.as_mut() {
-            let refreshed =
-                auth::refresh_effective_auth_profile(active, &self.client, force, 60).await?;
+            let refreshed = auth::refresh_effective_auth_profile(
+                active,
+                &self.client,
+                force,
+                60,
+                endpoint_hint,
+            )
+            .await?;
             if refreshed {
                 crate::auth::persist_profile_if_named(active)?;
                 self.set_effective_auth_profile(active.clone()).await;
@@ -139,7 +149,9 @@ impl GraphQLAdapter {
         payload: &Value,
         timeout: Option<Duration>,
     ) -> Result<reqwest::Response> {
-        let mut profile = self.refresh_effective_auth_profile(false).await?;
+        let mut profile = self
+            .refresh_effective_auth_profile(false, Some(url))
+            .await?;
         let resolved = Self::resolve_auth_profile("POST", url, profile.as_ref())?;
 
         let mut req = self
@@ -155,7 +167,7 @@ impl GraphQLAdapter {
         if resp.status() == reqwest::StatusCode::UNAUTHORIZED
             && crate::auth::supports_refresh_retry(profile.as_ref())
         {
-            profile = self.refresh_effective_auth_profile(true).await?;
+            profile = self.refresh_effective_auth_profile(true, Some(url)).await?;
             let resolved = Self::resolve_auth_profile("POST", url, profile.as_ref())?;
 
             let mut retry_req = self

--- a/src/adapters/grpc.rs
+++ b/src/adapters/grpc.rs
@@ -210,13 +210,22 @@ impl GrpcAdapter {
         *self.runtime_auth_profile.lock().await = Some(profile);
     }
 
-    async fn refresh_effective_auth_profile(&self, force: bool) -> Result<Option<Profile>> {
+    async fn refresh_effective_auth_profile(
+        &self,
+        force: bool,
+        endpoint_hint: Option<&str>,
+    ) -> Result<Option<Profile>> {
         let _refresh_guard = self.oauth_refresh_lock.lock().await;
         let mut profile = self.effective_auth_profile().await;
         if let Some(active) = profile.as_mut() {
-            let refreshed =
-                auth::refresh_effective_auth_profile(active, &self.oauth_http_client, force, 60)
-                    .await?;
+            let refreshed = auth::refresh_effective_auth_profile(
+                active,
+                &self.oauth_http_client,
+                force,
+                60,
+                endpoint_hint,
+            )
+            .await?;
             if refreshed {
                 crate::auth::persist_profile_if_named(active)?;
                 self.set_effective_auth_profile(active.clone()).await;
@@ -941,7 +950,9 @@ impl GrpcAdapter {
         let attempts = Self::grpcurl_attempts(original_url, target);
         let mut last_error = String::new();
 
-        let profile = self.refresh_effective_auth_profile(false).await?;
+        let profile = self
+            .refresh_effective_auth_profile(false, Some(original_url))
+            .await?;
         let headers = if let Some(profile) = profile.as_ref() {
             profile.to_grpcurl_headers()?
         } else {

--- a/src/adapters/jsonrpc.rs
+++ b/src/adapters/jsonrpc.rs
@@ -126,12 +126,22 @@ impl JsonRpcAdapter {
         req
     }
 
-    async fn refresh_effective_auth_profile(&self, force: bool) -> Result<Option<Profile>> {
+    async fn refresh_effective_auth_profile(
+        &self,
+        force: bool,
+        endpoint_hint: Option<&str>,
+    ) -> Result<Option<Profile>> {
         let _refresh_guard = self.oauth_refresh_lock.lock().await;
         let mut profile = self.effective_auth_profile().await;
         if let Some(active) = profile.as_mut() {
-            let refreshed =
-                auth::refresh_effective_auth_profile(active, &self.client, force, 60).await?;
+            let refreshed = auth::refresh_effective_auth_profile(
+                active,
+                &self.client,
+                force,
+                60,
+                endpoint_hint,
+            )
+            .await?;
             if refreshed {
                 crate::auth::persist_profile_if_named(active)?;
                 self.set_effective_auth_profile(active.clone()).await;
@@ -140,17 +150,25 @@ impl JsonRpcAdapter {
         Ok(profile)
     }
 
-    async fn send_with_oauth_retry<F>(&self, build_request: F) -> Result<reqwest::Response>
+    async fn send_with_oauth_retry<F>(
+        &self,
+        endpoint_hint: &str,
+        build_request: F,
+    ) -> Result<reqwest::Response>
     where
         F: Fn(Option<&Profile>) -> Result<reqwest::RequestBuilder>,
     {
-        let mut profile = self.refresh_effective_auth_profile(false).await?;
+        let mut profile = self
+            .refresh_effective_auth_profile(false, Some(endpoint_hint))
+            .await?;
 
         let mut response = build_request(profile.as_ref())?.send().await?;
         if response.status() == reqwest::StatusCode::UNAUTHORIZED
             && crate::auth::supports_refresh_retry(profile.as_ref())
         {
-            profile = self.refresh_effective_auth_profile(true).await?;
+            profile = self
+                .refresh_effective_auth_profile(true, Some(endpoint_hint))
+                .await?;
             response = build_request(profile.as_ref())?.send().await?;
         }
 
@@ -232,7 +250,7 @@ impl JsonRpcAdapter {
         }
 
         let response = self
-            .send_with_oauth_retry(|profile| {
+            .send_with_oauth_retry(schema_url, |profile| {
                 let resolved = Self::resolve_auth_profile("GET", schema_url, profile)?;
                 let req = self
                     .client
@@ -577,7 +595,7 @@ impl JsonRpcAdapter {
         });
 
         let response = match self
-            .send_with_oauth_retry(|profile| {
+            .send_with_oauth_retry(url, |profile| {
                 let resolved = Self::resolve_auth_profile("POST", url, profile)?;
                 let req = self
                     .client
@@ -624,7 +642,7 @@ impl JsonRpcAdapter {
     ) -> Result<Option<ResolvedOpenRpc>> {
         for schema_url in candidates {
             let response = match self
-                .send_with_oauth_retry(|profile| {
+                .send_with_oauth_retry(&schema_url, |profile| {
                     let resolved = Self::resolve_auth_profile("GET", &schema_url, profile)?;
                     let req = self
                         .client
@@ -743,7 +761,7 @@ impl JsonRpcAdapter {
         }
 
         let response = self
-            .send_with_oauth_retry(|profile| {
+            .send_with_oauth_retry(rpc_url, |profile| {
                 let resolved = Self::resolve_auth_profile("POST", rpc_url, profile)?;
                 let req = self
                     .client

--- a/src/adapters/mcp/http_transport.rs
+++ b/src/adapters/mcp/http_transport.rs
@@ -322,8 +322,14 @@ impl McpHttpTransport {
     async fn maybe_refresh_auth_token(&self) -> Result<()> {
         let mut profile = self.auth_profile.lock().await.clone();
         if let Some(active) = profile.as_mut() {
-            let refreshed =
-                auth::refresh_effective_auth_profile(active, &self.client, false, 60).await?;
+            let refreshed = auth::refresh_effective_auth_profile(
+                active,
+                &self.client,
+                false,
+                60,
+                Some(&self.server_url),
+            )
+            .await?;
             if refreshed {
                 persist_profile_update(active).await?;
                 *self.auth_profile.lock().await = Some(active.clone());
@@ -338,7 +344,14 @@ impl McpHttpTransport {
         let mut profile = self.auth_profile.lock().await.clone().ok_or_else(|| {
             UxcError::OAuthRequired("No authentication profile available".to_string())
         })?;
-        auth::refresh_effective_auth_profile(&mut profile, &self.client, true, 60).await?;
+        auth::refresh_effective_auth_profile(
+            &mut profile,
+            &self.client,
+            true,
+            60,
+            Some(&self.server_url),
+        )
+        .await?;
         persist_profile_update(&profile).await?;
         *self.auth_profile.lock().await = Some(profile);
 
@@ -672,7 +685,8 @@ impl McpHttpTransport {
                     .expect("oauth probe path requires auth profile");
 
                 if let Err(err) =
-                    auth::refresh_effective_auth_profile(profile, &client, true, 60).await
+                    auth::refresh_effective_auth_profile(profile, &client, true, 60, Some(url))
+                        .await
                 {
                     return Ok(Self::probe_auth_failure_from_refresh_error(err));
                 }
@@ -736,7 +750,7 @@ impl McpHttpTransport {
                     .expect("oauth probe path requires auth profile");
 
                 if let Err(err) =
-                    auth::refresh_effective_auth_profile(profile, client, true, 60).await
+                    auth::refresh_effective_auth_profile(profile, client, true, 60, Some(url)).await
                 {
                     return Ok(Self::probe_auth_failure_from_refresh_error(err));
                 }
@@ -1475,8 +1489,14 @@ impl LegacySseTransport {
     async fn maybe_refresh_auth_token(&self) -> Result<()> {
         let mut profile = self.auth_profile.lock().await.clone();
         if let Some(active) = profile.as_mut() {
-            let refreshed =
-                auth::refresh_effective_auth_profile(active, &self.client, false, 60).await?;
+            let refreshed = auth::refresh_effective_auth_profile(
+                active,
+                &self.client,
+                false,
+                60,
+                Some(&self.connect_url),
+            )
+            .await?;
             if refreshed {
                 persist_profile_update(active).await?;
                 *self.auth_profile.lock().await = Some(active.clone());
@@ -1495,7 +1515,14 @@ impl LegacySseTransport {
         let mut profile = self.auth_profile.lock().await.clone().ok_or_else(|| {
             UxcError::OAuthRequired("No authentication profile available".to_string())
         })?;
-        auth::refresh_effective_auth_profile(&mut profile, &self.client, true, 60).await?;
+        auth::refresh_effective_auth_profile(
+            &mut profile,
+            &self.client,
+            true,
+            60,
+            Some(&self.connect_url),
+        )
+        .await?;
         persist_profile_update(&profile).await?;
         *self.auth_profile.lock().await = Some(profile);
         Ok(())

--- a/src/adapters/openapi.rs
+++ b/src/adapters/openapi.rs
@@ -164,12 +164,22 @@ impl OpenAPIAdapter {
         }
     }
 
-    async fn refresh_effective_auth_profile(&self, force: bool) -> Result<Option<Profile>> {
+    async fn refresh_effective_auth_profile(
+        &self,
+        force: bool,
+        endpoint_hint: Option<&str>,
+    ) -> Result<Option<Profile>> {
         let _refresh_guard = self.oauth_refresh_lock.lock().await;
         let mut profile = self.effective_auth_profile().await;
         if let Some(active) = profile.as_mut() {
-            let refreshed =
-                auth::refresh_effective_auth_profile(active, &self.client, force, 60).await?;
+            let refreshed = auth::refresh_effective_auth_profile(
+                active,
+                &self.client,
+                force,
+                60,
+                endpoint_hint,
+            )
+            .await?;
             if refreshed {
                 crate::auth::persist_profile_if_named(active)?;
                 self.set_effective_auth_profile(active.clone()).await;
@@ -178,17 +188,25 @@ impl OpenAPIAdapter {
         Ok(profile)
     }
 
-    async fn send_with_oauth_retry<F>(&self, build_request: F) -> Result<reqwest::Response>
+    async fn send_with_oauth_retry<F>(
+        &self,
+        endpoint_hint: &str,
+        build_request: F,
+    ) -> Result<reqwest::Response>
     where
         F: Fn(Option<&Profile>) -> Result<reqwest::RequestBuilder>,
     {
-        let mut profile = self.refresh_effective_auth_profile(false).await?;
+        let mut profile = self
+            .refresh_effective_auth_profile(false, Some(endpoint_hint))
+            .await?;
 
         let mut response = build_request(profile.as_ref())?.send().await?;
         if response.status() == reqwest::StatusCode::UNAUTHORIZED
             && crate::auth::supports_refresh_retry(profile.as_ref())
         {
-            profile = self.refresh_effective_auth_profile(true).await?;
+            profile = self
+                .refresh_effective_auth_profile(true, Some(endpoint_hint))
+                .await?;
             response = build_request(profile.as_ref())?.send().await?;
         }
 
@@ -272,7 +290,7 @@ impl OpenAPIAdapter {
         }
 
         let response = self
-            .send_with_oauth_retry(|profile| {
+            .send_with_oauth_retry(schema_url, |profile| {
                 let resolved = self.resolve_schema_auth_profile("GET", schema_url, profile)?;
                 let req = self
                     .client
@@ -405,7 +423,7 @@ impl OpenAPIAdapter {
 
         for full_url in Self::schema_candidates(&normalized) {
             let resp = match self
-                .send_with_oauth_retry(|profile| {
+                .send_with_oauth_retry(&full_url, |profile| {
                     let resolved = self.resolve_schema_auth_profile("GET", &full_url, profile)?;
                     let req = self
                         .client
@@ -1939,7 +1957,7 @@ impl Adapter for OpenAPIAdapter {
         let should_apply_auth = !matches!(auth_requirement, OperationAuthRequirement::Public);
 
         let resp = self
-            .send_with_oauth_retry(|profile| {
+            .send_with_oauth_retry(&prepared_url, |profile| {
                 let full_url = {
                     let mut parsed = url::Url::parse(&prepared_url).with_context(|| {
                         format!("Invalid prepared OpenAPI request URL '{}'", prepared_url)

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1513,13 +1513,20 @@ pub async fn refresh_effective_auth_profile(
     client: &reqwest::Client,
     force: bool,
     oauth_skew_seconds: i64,
+    endpoint_hint: Option<&str>,
 ) -> Result<bool> {
     if profile.auth_type == AuthType::OAuth {
         if force {
-            oauth::refresh_oauth_profile(profile, client).await?;
+            oauth::refresh_oauth_profile(profile, client, endpoint_hint).await?;
             return Ok(true);
         }
-        return oauth::maybe_refresh_oauth_profile(profile, client, oauth_skew_seconds).await;
+        return oauth::maybe_refresh_oauth_profile(
+            profile,
+            client,
+            oauth_skew_seconds,
+            endpoint_hint,
+        )
+        .await;
     }
 
     if profile.auth_type == AuthType::Bearer && profile.has_bootstrap_config() {

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -239,6 +239,7 @@ pub async fn maybe_refresh_oauth_profile(
     profile: &mut Profile,
     client: &Client,
     skew_seconds: i64,
+    endpoint_hint: Option<&str>,
 ) -> Result<bool> {
     if profile.auth_type != crate::auth::AuthType::OAuth {
         return Ok(false);
@@ -252,8 +253,55 @@ pub async fn maybe_refresh_oauth_profile(
         return Ok(false);
     }
 
-    refresh_oauth_profile(profile, client).await?;
+    refresh_oauth_profile(profile, client, endpoint_hint).await?;
     Ok(true)
+}
+
+fn oauth_login_endpoint_hint(profile: &Profile, endpoint_hint: Option<&str>) -> String {
+    endpoint_hint
+        .map(str::to_string)
+        .or_else(|| {
+            profile
+                .oauth
+                .as_ref()
+                .and_then(|oauth| oauth.resource_metadata_url.clone())
+        })
+        .or_else(|| {
+            profile
+                .oauth
+                .as_ref()
+                .and_then(|oauth| oauth.authorization_server.clone())
+        })
+        .or_else(|| {
+            profile
+                .oauth
+                .as_ref()
+                .and_then(|oauth| oauth.provider_issuer.clone())
+        })
+        .unwrap_or_else(|| "<url>".to_string())
+}
+
+fn oauth_login_credential_hint(profile: &Profile) -> String {
+    profile
+        .name
+        .clone()
+        .unwrap_or_else(|| "<credential_id>".to_string())
+}
+
+fn oauth_login_required_message(profile: &Profile, endpoint_hint: Option<&str>) -> String {
+    let credential_id = oauth_login_credential_hint(profile);
+    let endpoint = oauth_login_endpoint_hint(profile, endpoint_hint);
+    format!(
+        "No refresh token available for credential '{}' at '{}'.\n\
+         \n\
+         For agents:\n\
+           1. uxc auth oauth start {} --endpoint {} --redirect-uri <callback_uri>\n\
+           2. uxc auth oauth complete {} --session-id <session_id> --authorization-response '<callback_url_or_code>'\n\
+         \n\
+         Interactive fallback:\n\
+           uxc auth oauth login {} --endpoint {}",
+        credential_id, endpoint, credential_id, endpoint, credential_id, credential_id, endpoint
+    )
 }
 
 pub fn apply_token_to_profile(
@@ -931,7 +979,11 @@ pub async fn login_with_device_code(
     }
 }
 
-pub async fn refresh_oauth_profile(profile: &mut Profile, client: &Client) -> Result<()> {
+pub async fn refresh_oauth_profile(
+    profile: &mut Profile,
+    client: &Client,
+    endpoint_hint: Option<&str>,
+) -> Result<()> {
     let oauth = profile
         .oauth
         .as_mut()
@@ -986,11 +1038,7 @@ pub async fn refresh_oauth_profile(profile: &mut Profile, client: &Client) -> Re
         return Ok(());
     }
 
-    Err(UxcError::OAuthRequired(
-        "No refresh token available. Run 'uxc auth oauth login <credential_id> --endpoint <mcp_url>'"
-            .to_string(),
-    )
-    .into())
+    Err(UxcError::OAuthRequired(oauth_login_required_message(profile, endpoint_hint)).into())
 }
 
 pub fn parse_scopes(scopes: &[String]) -> Vec<String> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7419,13 +7419,31 @@ async fn client_call(method: &str, params: Option<Value>) -> Result<Value> {
             return Err(UxcError::OperationNotFound(err.message).into());
         }
         if err.code == ERR_OAUTH_REQUIRED {
-            return Err(UxcError::OAuthRequired(err.message).into());
+            return Err(structured_error_from_jsonrpc_error(
+                i64::from(err.code),
+                &err.message,
+                None,
+                "OAUTH_REQUIRED",
+            )
+            .into());
         }
         if err.code == ERR_OAUTH_REFRESH_FAILED {
-            return Err(UxcError::OAuthRefreshFailed(err.message).into());
+            return Err(structured_error_from_jsonrpc_error(
+                i64::from(err.code),
+                &err.message,
+                None,
+                "OAUTH_REFRESH_FAILED",
+            )
+            .into());
         }
         if err.code == ERR_OAUTH_SCOPE_INSUFFICIENT {
-            return Err(UxcError::OAuthScopeInsufficient(err.message).into());
+            return Err(structured_error_from_jsonrpc_error(
+                i64::from(err.code),
+                &err.message,
+                None,
+                "OAUTH_SCOPE_INSUFFICIENT",
+            )
+            .into());
         }
         bail!("{}", err.message);
     }
@@ -9088,6 +9106,28 @@ mod tests {
         let raw = std::fs::read_to_string(&store_path).unwrap();
         let store: PersistedSubscriptionStore = serde_json::from_str(&raw).unwrap();
         assert!(store.jobs.is_empty());
+    }
+
+    #[test]
+    fn client_call_error_path_does_not_double_prefix_oauth_messages() {
+        let err = structured_error_from_jsonrpc_error(
+            i64::from(ERR_OAUTH_REQUIRED),
+            "OAuth required: No refresh token available for credential 'x-api-user' at 'https://api.x.com'.\n\nFor agents:\n  1. uxc auth oauth start x-api-user --endpoint https://api.x.com --redirect-uri <callback_uri>\n  2. uxc auth oauth complete x-api-user --session-id <session_id> --authorization-response '<callback_url_or_code>'\n\nInteractive fallback:\n  uxc auth oauth login x-api-user --endpoint https://api.x.com",
+            None,
+            "OAUTH_REQUIRED",
+        );
+        assert_eq!(err.code, "OAUTH_REQUIRED");
+        assert_eq!(
+            err.message,
+            "OAuth required: No refresh token available for credential 'x-api-user' at 'https://api.x.com'.\n\nFor agents:\n  1. uxc auth oauth start x-api-user --endpoint https://api.x.com --redirect-uri <callback_uri>\n  2. uxc auth oauth complete x-api-user --session-id <session_id> --authorization-response '<callback_url_or_code>'\n\nInteractive fallback:\n  uxc auth oauth login x-api-user --endpoint https://api.x.com"
+        );
+        assert!(
+            !err.message.contains("OAuth required: OAuth required:"),
+            "oauth-required message should not duplicate display prefixes"
+        );
+        assert!(err.message.contains("For agents:"));
+        assert!(err.message.contains("uxc auth oauth start x-api-user"));
+        assert!(err.message.contains("Interactive fallback:"));
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7448,7 +7448,7 @@ async fn handle_auth_oauth_command(command: &AuthOauthCommands) -> Result<Output
                 .into());
             }
 
-            auth::oauth::refresh_oauth_profile(&mut profile_data, &client).await?;
+            auth::oauth::refresh_oauth_profile(&mut profile_data, &client, None).await?;
             profiles.set_profile(credential_id.clone(), profile_data.clone())?;
             profiles.save_profiles()?;
 


### PR DESCRIPTION
What
- improve OAuth-required errors to prefer agent-friendly start/complete guidance
- include concrete credential and endpoint hints when available
- avoid double-prefixing OAuth error messages returned through the daemon

Why
- current errors point agents at `oauth login` and repeat the OAuth prefix in daemon flows
- callers usually know enough context to render actionable commands

How
- thread endpoint hints through auth refresh callers
- build OAuth-required messages from credential/profile context
- preserve daemon JSON-RPC errors as structured errors instead of re-wrapping them

Testing
- cargo fmt --all
- CARGO_TARGET_DIR=/tmp/uxc-target-oauth-msg cargo test client_call_error_path_does_not_double_prefix_oauth_messages --lib -- --nocapture