### PR TITLE
fix: keep daemon-exclusive stdio sessions off idle reap path

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -72,7 +72,8 @@ const STOP_POLL_INTERVAL_MS: u64 = 100;
 const START_LOCK_STALE_SECS: u64 = 30;
 const STDIO_INIT_LOCK_STALE_SECS: u64 = 30;
 const MCP_IDLE_TTL_SECS: u64 = 600;
-const MCP_CAN_REAP_PROBE_TIMEOUT_MS: u64 = 1_000;
+const MCP_CAN_REAP_PROBE_TIMEOUT_MS: u64 = 250;
+const MCP_IDLE_CLEANUP_INTERVAL_MS: u64 = 500;
 const MCP_CAN_REAP_RETRY_AFTER_SECS: u64 = 30;
 // Five seconds is long enough for cooperative stdio servers to notice stdin EOF
 // and release external resources, while still bounding daemon-side eviction stalls.
@@ -1319,6 +1320,14 @@ impl McpSessionManager {
             // Use try_lock to avoid blocking on sessions that may be held across .await in invoke_mcp.
             // If a session is busy, we'll check it again in the next cleanup cycle.
             if let Ok(mut guard) = session.try_lock() {
+                // Daemon-exclusive stdio sessions back long-lived local browser workers.
+                // Probing them with background MCP requests is intrusive because stdio MCP is
+                // single-lane: even a timed-out can_reap probe can still occupy the server and
+                // delay foreground requests that arrive moments later. Keep these sessions until
+                // the owner explicitly restarts/reaps them.
+                if !guard.daemon_exclusive.is_empty() {
+                    continue;
+                }
                 if guard.idle_ttl_secs == 0 {
                     continue;
                 }
@@ -1378,9 +1387,14 @@ impl McpSessionManager {
                             }
                         }
                         Err(err) => {
-                            guard.next_can_reap_probe_after = None;
+                            let method_not_found = can_reap_method_not_found(&err);
+                            guard.next_can_reap_probe_after = if method_not_found {
+                                None
+                            } else {
+                                Some(now + Duration::from_secs(MCP_CAN_REAP_RETRY_AFTER_SECS))
+                            };
                             guard.can_reap_contract = CanReapContractView {
-                                support: if can_reap_method_not_found(&err) {
+                                support: if method_not_found {
                                     CanReapContractSupport::Unsupported
                                 } else {
                                     CanReapContractSupport::Error
@@ -1390,9 +1404,18 @@ impl McpSessionManager {
                                 reason: None,
                                 retry_after_secs: None,
                                 state: None,
-                                last_error_summary: (!can_reap_method_not_found(&err))
+                                last_error_summary: (!method_not_found)
                                     .then(|| can_reap_error_summary(&err)),
                             };
+                            if !method_not_found {
+                                let contract = guard.can_reap_contract.clone();
+                                drop(guard);
+                                self.upsert_stdio_snapshot(key, |snapshot| {
+                                    snapshot.can_reap_contract = contract;
+                                })
+                                .await;
+                                continue;
+                            }
                         }
                     }
                     let contract = guard.can_reap_contract.clone();
@@ -3535,7 +3558,6 @@ impl DaemonRuntime {
     }
 
     async fn invoke_inner(&self, request: RuntimeInvokeRequest) -> Result<RuntimeInvokeResponse> {
-        self.mcp.cleanup_idle().await;
         {
             let mut st = self.state.lock().await;
             st.request_count = st.request_count.saturating_add(1);
@@ -6683,6 +6705,19 @@ pub async fn run_daemon_server() -> Result<()> {
         }
         if let Err(err) = resume_runtime.resume_managed_sources().await {
             tracing::warn!("Failed to resume managed sources: {}", err);
+        }
+    });
+    let cleanup_runtime = runtime.clone();
+    tokio::spawn(async move {
+        let mut interval =
+            tokio::time::interval(Duration::from_millis(MCP_IDLE_CLEANUP_INTERVAL_MS));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            if cleanup_runtime.should_stop().await {
+                break;
+            }
+            cleanup_runtime.mcp.cleanup_idle().await;
         }
     });
 

--- a/tests/daemon_reuse_test.rs
+++ b/tests/daemon_reuse_test.rs
@@ -419,6 +419,67 @@ fn can_reap_true_allows_idle_session_to_be_reaped_before_reuse() {
 
 #[test]
 #[serial]
+fn daemon_exclusive_stdio_sessions_skip_intrusive_idle_reap_probes() {
+    daemon_stop_best_effort();
+
+    let bin = test_server_binary("mcp-stdio");
+    let endpoint = format!("{} can_reap_timeout", bin.display());
+
+    let start = uxc_command()
+        .env("UXC_TEST_TIMEOUT_MS", "3000")
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("daemon start should run");
+    assert!(start.status.success());
+
+    let first = uxc_command()
+        .env("UXC_DAEMON_EXCLUSIVE", "~/.uxc/test-exclusive")
+        .arg("--daemon-idle-ttl")
+        .arg("1")
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"seed"}"#)
+        .output()
+        .expect("first call should run");
+    assert!(first.status.success());
+
+    std::thread::sleep(Duration::from_millis(1500));
+
+    let started = std::time::Instant::now();
+    let second = uxc_command()
+        .env("UXC_DAEMON_EXCLUSIVE", "~/.uxc/test-exclusive")
+        .arg("--daemon-idle-ttl")
+        .arg("1")
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"reuse"}"#)
+        .output()
+        .expect("second call should run");
+    let elapsed = started.elapsed();
+    assert!(
+        second.status.success(),
+        "second call should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+    assert!(
+        elapsed < Duration::from_millis(900),
+        "expected daemon-exclusive session reuse to avoid idle cleanup probe delay, took {:?}",
+        elapsed
+    );
+
+    let second_json: serde_json::Value =
+        serde_json::from_slice(&second.stdout).expect("second stdout should be valid JSON");
+    assert_eq!(second_json["meta"]["daemon_session_reused"], true);
+
+    daemon_stop_best_effort();
+}
+
+#[test]
+#[serial]
 fn daemon_sessions_reports_active_state_for_busy_stdio_session() {
     daemon_stop_best_effort();
 


### PR DESCRIPTION
What
- move stdio idle cleanup off the foreground invoke path into a background daemon task
- skip intrusive idle reap probes for daemon-exclusive stdio sessions
- shorten can_reap probe timeout and avoid synchronous kill on probe errors
- add a regression test covering daemon-exclusive stdio reuse with can_reap timeout

Why
- daemon-exclusive browser workers such as local-mcp are single-lane stdio MCP sessions
- background can_reap probes could occupy the child and stall foreground reused requests
- this showed up as x/weibo local-mcp sessions looking ready in daemon state but hanging on requests

How
- remove request-path cleanup_idle() from invoke_inner()
- run cleanup_idle() on a daemon background interval instead
- treat daemon-exclusive sessions as manual-reap for idle cleanup purposes
- keep probe failures advisory instead of immediately killing the child

Testing
- cargo check --bin uxc
- cargo build --bin uxc --bin uxc-test-mcp-stdio-server --features test-server
- cargo test --test daemon_reuse_test daemon_exclusive_stdio_sessions_skip_intrusive_idle_reap_probes -- --nocapture
- cargo test --test daemon_reuse_test can_reap_true_allows_idle_session_to_be_reaped_before_reuse -- --nocapture
- cargo test --test daemon_reuse_test daemon_sessions_expose_supported_can_reap_contract_when_idle_reap_is_deferred -- --nocapture

Fixes #368