### PR TITLE
refactor: replace MCP can_reap with lifecycle notifications

### DIFF
--- a/docs/decisions/daemon-session-lifecycle.md
+++ b/docs/decisions/daemon-session-lifecycle.md
@@ -1,10 +1,10 @@
 # Daemon Session Lifecycle Contract
 
-This note records the lifecycle contract for issue #337.
+This note records the target daemon session lifecycle contract for issue `#337`.
 
 ## Summary
 
-UXC's daemon is the stable execution surface for long-lived runtimes, especially MCP stdio
+`uxc`'s daemon is the stable execution surface for long-lived runtimes, especially MCP stdio
 sessions. The lifecycle contract needs to explain:
 
 - what defines a reusable session
@@ -12,10 +12,12 @@ sessions. The lifecycle contract needs to explain:
 - what metadata may change across reuse
 - when a session is considered idle
 - when idle reap is allowed
+- what lifecycle state a child may report
 - what users and generated clients may observe from `uxc daemon sessions`
 
-This note defines a v1 contract for daemon-backed session lifecycle. It is primarily about MCP
-stdio sessions, because that is where reuse, exclusivity, and reaping semantics already exist.
+This note defines the target contract for daemon-backed session lifecycle. It is primarily about
+MCP stdio sessions, because that is where reuse, exclusivity, and idle-reap semantics already
+exist.
 
 ## Scope
 
@@ -26,6 +28,7 @@ This note covers:
 - daemon exclusivity
 - idle semantics
 - idle reap behavior
+- child-reported lifecycle state
 - observable daemon session state
 
 This note does not cover:
@@ -53,32 +56,27 @@ The current stdio session stores mutable runtime metadata such as:
 - `link_name`
 - `endpoint`
 - `daemon_exclusive`
-- `can_reap_contract`
+- lifecycle declaration
+- latest lifecycle snapshot
 
 Implementation reference:
 
 - [src/daemon.rs](/Users/jolestar/opensource/src/github.com/holon-run/uxc/src/daemon.rs#L498)
 - [src/daemon.rs](/Users/jolestar/opensource/src/github.com/holon-run/uxc/src/daemon.rs#L627)
 
-The current cleanup path already treats stdio sessions differently from HTTP sessions and probes
-`can_reap` before removing an idle stdio session.
+The current cleanup path has already moved off the foreground request path and currently skips
+intrusive background probes for `daemon_exclusive` stdio sessions.
 
 Implementation reference:
 
-- [src/daemon.rs](/Users/jolestar/opensource/src/github.com/holon-run/uxc/src/daemon.rs#L1077)
+- [src/daemon.rs](/Users/jolestar/opensource/src/github.com/holon-run/uxc/src/daemon.rs#L1312)
 
-MCP stdio subscriptions already reuse stdio sessions through the same `get_or_create_stdio(...)`
-path, but the current lifecycle model does not define a separate attachment contract. Session
-retention is still expressed through daemon-known busy/subscription state plus runtime-reported
-`can_reap`.
-
-Implementation reference:
-
-- [src/daemon.rs](/Users/jolestar/opensource/src/github.com/holon-run/uxc/src/daemon.rs#L4983)
+The current implementation is being refactored away from live runtime probes and toward static
+lifecycle declaration plus pushed lifecycle snapshots.
 
 ## Model
 
-The lifecycle model is split into three layers.
+The lifecycle model is split into four layers.
 
 ### 1. Session Identity
 
@@ -86,20 +84,19 @@ Session identity answers:
 
 - does this request refer to the same runtime session?
 
-For stdio, v1 identity is:
+For stdio, identity is:
 
 - endpoint
 - auth fingerprint
 - injected env fingerprint
 - transport/runtime family
 
-For current implementation, this is equivalent to the current stdio session key contract.
-
 Identity does not include:
 
 - `link_name`
 - `daemon_idle_ttl`
 - `daemon_exclusive`
+- lifecycle contract fields
 
 Those fields affect how a session is presented, owned, or cleaned up, but they do not define which
 underlying runtime process is being reused.
@@ -120,18 +117,32 @@ For v1, ownership policy includes:
 
 `daemon_exclusive` is an ownership boundary, not part of identity.
 
-### 3. Presentation and Cleanup Hints
+### 3. Lifecycle Contract
 
-Presentation and cleanup hints answer:
+Lifecycle contract answers:
+
+- how should the daemon decide whether automatic idle reap is allowed for this child kind?
+- what dynamic state may the child report without exposing child-specific internals?
+
+The contract is split into:
+
+- a static lifecycle declaration, fetched once at startup
+- a dynamic lifecycle snapshot, pushed from the child to the daemon as notifications
+
+The daemon should not rely on live request-time lifecycle probes as the primary cleanup decision
+mechanism for stdio sessions.
+
+### 4. Presentation Hints
+
+Presentation hints answer:
 
 - how should this session be shown to users?
-- how should this session be cleaned up when it becomes idle?
 
 For v1, these include:
 
 - `link_name`
-- `idle_ttl_secs`
-- future source metadata such as skill/docs origin
+- source link metadata such as skill/docs origin
+- endpoint presentation metadata
 
 These hints may change when a request reuses a matching session.
 
@@ -201,6 +212,59 @@ This aligns with current behavior:
 - idle owners may be replaced
 - busy owners may not be evicted
 
+Lifecycle policy does not override ownership policy. A child may be stateful for idle cleanup while
+still participating in explicit ownership hand-off rules.
+
+## Static Lifecycle Declaration
+
+Each stdio child may declare a static lifecycle contract once at startup.
+
+The static declaration should contain a small, generic cleanup policy surface:
+
+- `reap_policy: "safe_idle_reap" | "stateful"`
+
+The daemon should use `reap_policy` as the authoritative cleanup-class input.
+
+### Reap Policies
+
+`safe_idle_reap`
+
+- generic disposable stdio helper
+- daemon-local idle signals are sufficient for automatic reap
+
+`stateful`
+
+- automatic reap depends on child-reported lifecycle state
+- the daemon must not infer child state from provider-specific internals
+- the daemon must not send live background request probes just to discover current cleanup state
+
+If no static lifecycle declaration is present, the daemon may continue using current generic stdio
+behavior as a compatibility fallback until migration is complete.
+
+## Dynamic Lifecycle Snapshot
+
+For `stateful` workers, the child should push lifecycle state changes to the daemon as
+notifications.
+
+The daemon should cache only a compressed, generic lifecycle snapshot. It should not need to
+understand child-specific state machines such as browser presentation mode, bootstrap mode, or
+auth internals.
+
+Suggested fields are:
+
+- `auto_reap_allowed: boolean`
+- `retention_reason: "interactive" | "waiting_for_human" | "external_resource" | "active_runtime" | null`
+- `retry_after_secs: number | null`
+- `updated_at_unix: number`
+
+The child should send:
+
+- an initial snapshot once the session is initialized
+- an updated snapshot whenever the effective auto-reap decision changes
+
+For `stateful` workers, the dynamic lifecycle snapshot is the primary runtime-side input for
+automatic reap decisions.
+
 ## Idle Semantics
 
 `idle_ttl_secs` is a session-level cleanup policy.
@@ -226,19 +290,32 @@ Idle reap is allowed only when all of the following are true:
 2. the session is not currently busy from the daemon's point of view
 3. `idle_ttl_secs != 0`
 4. idle time exceeds the configured cutoff
-5. `can_reap` allows removal, or the runtime does not support `can_reap` and the daemon falls back
-   to current best-effort cleanup rules
+5. the lifecycle policy allows removal
 
-For MCP stdio sessions, `can_reap` is the runtime-side guard after daemon-side idleness. It is not
-the primary definition of idleness.
+Lifecycle policy is evaluated as follows:
 
-### Deferred Reap
+- `safe_idle_reap`
+  - daemon-local idle signals are sufficient
+- `stateful`
+  - the daemon must consult the latest cached lifecycle snapshot
+  - automatic reap is allowed only when `auto_reap_allowed == true`
+  - if no lifecycle snapshot is available, the daemon should keep the session rather than guess
 
-When `can_reap` says the session should be kept alive:
+The daemon must not perform synchronous request-path probing to decide whether an idle stdio session
+may be reaped.
 
-- the daemon must not remove the session
-- the daemon should record the observed `can_reap_contract`
-- the daemon may retry after the indicated delay or a default retry interval
+## Child Exit And Terminal State
+
+If the underlying runtime has become permanently unusable, the child should not remain indefinitely
+alive in a misleading "ready" state.
+
+For `stateful` workers, the child should:
+
+- proactively update lifecycle state when retention conditions change
+- proactively exit when the owner session is terminally gone and the process can no longer provide
+  meaningful service
+
+The daemon should still treat child process exit as the final authoritative terminal signal.
 
 ## Subscriptions
 
@@ -269,7 +346,9 @@ V1 observable guarantees should include:
 - `daemon_exclusive`
 - `in_flight_requests`
 - `reuse_eligible`
-- `can_reap_contract`
+- `lifecycle_contract`
+- `last_lifecycle_update_at_unix`
+- `last_lifecycle_snapshot`
 
 Future lifecycle work may add more explicit retention-oriented fields, for example:
 
@@ -294,18 +373,29 @@ That avoids unnecessary breakage for:
 - current daemon-exclusive workflows
 - current `daemon sessions` tooling
 
-The main change is not the identity key itself. The main change is making ownership and idle/reap
-semantics explicit instead of leaving them implicit in implementation details.
+The main lifecycle change is:
+
+- move from live probe-driven runtime cleanup hints
+- to static lifecycle declaration plus pushed lifecycle state plus local daemon state
+
+This note supersedes the older assumption that live runtime probes should be the default
+runtime-side guard for stdio idle cleanup.
 
 ## Follow-Up Work
 
-The follow-up issues under #337 remain useful as implementation slices:
+The follow-up issues under `#337` remain useful as implementation slices:
 
 - `#340`: session identity and reuse rules
 - `#341`: ownership / idle-reap semantics
 - `#342`: observable daemon session state contract
 
-## Open Questions
+Additional lifecycle follow-up from the browser-worker path:
 
-- Should `daemon_exclusive` conflicts surface richer observable state in `daemon sessions`?
-- Should subscription-held state be exposed directly, or summarized into a pinned-state view?
+- `#368`: stateful stdio worker cleanup contract
+
+## V1 Follow-Through Decisions
+
+- `daemon_exclusive` remains an ownership rule, not a lifecycle policy.
+- `stateful` workers must proactively report lifecycle changes; the daemon should not poll them on
+  the request path.
+- `uxc` should rely on lifecycle declaration plus pushed snapshots, not live runtime probes.

--- a/docs/decisions/daemon-session-lifecycle.md
+++ b/docs/decisions/daemon-session-lifecycle.md
@@ -48,7 +48,7 @@ The current stdio session key is based on:
 
 Implementation reference:
 
-- [src/daemon.rs](/Users/jolestar/opensource/src/github.com/holon-run/uxc/src/daemon.rs#L6183)
+- [src/daemon.rs](../../src/daemon.rs)
 
 The current stdio session stores mutable runtime metadata such as:
 
@@ -61,15 +61,14 @@ The current stdio session stores mutable runtime metadata such as:
 
 Implementation reference:
 
-- [src/daemon.rs](/Users/jolestar/opensource/src/github.com/holon-run/uxc/src/daemon.rs#L498)
-- [src/daemon.rs](/Users/jolestar/opensource/src/github.com/holon-run/uxc/src/daemon.rs#L627)
+- [src/daemon.rs](../../src/daemon.rs)
 
 The current cleanup path has already moved off the foreground request path and currently skips
 intrusive background probes for `daemon_exclusive` stdio sessions.
 
 Implementation reference:
 
-- [src/daemon.rs](/Users/jolestar/opensource/src/github.com/holon-run/uxc/src/daemon.rs#L1312)
+- [src/daemon.rs](../../src/daemon.rs)
 
 The current implementation is being refactored away from live runtime probes and toward static
 lifecycle declaration plus pushed lifecycle snapshots.
@@ -238,8 +237,11 @@ The daemon should use `reap_policy` as the authoritative cleanup-class input.
 - the daemon must not infer child state from provider-specific internals
 - the daemon must not send live background request probes just to discover current cleanup state
 
-If no static lifecycle declaration is present, the daemon may continue using current generic stdio
-behavior as a compatibility fallback until migration is complete.
+If the child explicitly does not support static lifecycle declaration, the daemon may continue
+using current generic stdio behavior as a compatibility fallback until migration is complete.
+
+If lifecycle declaration fetch fails for another reason, the daemon should keep the session rather
+than guess that `safe_idle_reap` applies.
 
 ## Dynamic Lifecycle Snapshot
 

--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -11,25 +11,16 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct CanReapState {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub interactive: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub owns_external_resource: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub waiting_for_human: Option<bool>,
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleReapPolicy {
+    SafeIdleReap,
+    Stateful,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CanReapProbeResult {
-    pub can_reap: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub retry_after_secs: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<CanReapState>,
+pub struct LifecycleContract {
+    pub reap_policy: LifecycleReapPolicy,
 }
 
 /// MCP stdio client
@@ -182,24 +173,15 @@ impl McpStdioClient {
         self.transport.drain_notifications().await
     }
 
-    pub async fn probe_can_reap(
-        &mut self,
-        idle_for_secs: u64,
-        idle_ttl_secs: u64,
-        timeout: Duration,
-    ) -> Result<CanReapProbeResult> {
-        let params = json!({
-            "idle_for_secs": idle_for_secs,
-            "idle_ttl_secs": idle_ttl_secs,
-        });
+    pub async fn lifecycle_contract(&mut self, timeout: Duration) -> Result<LifecycleContract> {
         let result = self
             .transport
-            .send_request_with_timeout("uxc/can_reap", Some(params), timeout)
+            .send_request_with_timeout("uxc/lifecycle_contract", Some(json!({})), timeout)
             .await
-            .context("Failed to probe uxc/can_reap")?;
-        let probe: CanReapProbeResult =
-            serde_json::from_value(result).context("Failed to parse can_reap probe result")?;
-        Ok(probe)
+            .context("Failed to fetch uxc/lifecycle_contract")?;
+        let contract: LifecycleContract =
+            serde_json::from_value(result).context("Failed to parse lifecycle contract result")?;
+        Ok(contract)
     }
 
     /// List available tools
@@ -749,12 +731,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn probe_can_reap_parses_successful_response() {
+    async fn lifecycle_contract_parses_successful_response() {
         let script = r#"
             read line
             echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"test","version":"1.0"}}}'
             read line
-            echo '{"jsonrpc":"2.0","id":2,"result":{"can_reap":false,"reason":"interactive_session","retry_after_secs":30,"state":{"interactive":true,"owns_external_resource":true}}}'
+            echo '{"jsonrpc":"2.0","id":2,"result":{"reap_policy":"stateful"}}'
         "#;
 
         let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
@@ -762,24 +744,14 @@ mod tests {
             .unwrap();
 
         let result = client
-            .probe_can_reap(123, 600, Duration::from_millis(50))
+            .lifecycle_contract(Duration::from_millis(50))
             .await
             .unwrap();
-        assert!(!result.can_reap);
-        assert_eq!(result.reason.as_deref(), Some("interactive_session"));
-        assert_eq!(result.retry_after_secs, Some(30));
-        assert_eq!(
-            result.state,
-            Some(CanReapState {
-                interactive: Some(true),
-                owns_external_resource: Some(true),
-                waiting_for_human: None,
-            })
-        );
+        assert_eq!(result.reap_policy, LifecycleReapPolicy::Stateful);
     }
 
     #[tokio::test]
-    async fn probe_can_reap_surfaces_method_not_found_code() {
+    async fn lifecycle_contract_surfaces_method_not_found_code() {
         let script = r#"
             read line
             echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"test","version":"1.0"}}}'
@@ -792,7 +764,7 @@ mod tests {
             .unwrap();
 
         let err = client
-            .probe_can_reap(123, 600, Duration::from_millis(50))
+            .lifecycle_contract(Duration::from_millis(50))
             .await
             .unwrap_err();
         let structured = structured_error_from_anyhow(&err).expect("structured error");

--- a/src/adapters/mcp/mod.rs
+++ b/src/adapters/mcp/mod.rs
@@ -12,7 +12,7 @@ use crate::auth::Profile;
 use crate::error::UxcError;
 use anyhow::{bail, Result};
 use async_trait::async_trait;
-pub use client::{CanReapState, McpStdioClient};
+pub use client::{LifecycleReapPolicy, McpStdioClient};
 pub use http_transport::{McpHttpTransport, McpRemoteTransport, ResolvedMcpHttpTransport};
 use serde_json::Value;
 use std::collections::HashMap;

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -259,8 +259,17 @@ fn lifecycle_contract() -> Value {
             "not_busy",
             "idle_ttl_non_zero",
             "idle_exceeded",
-            "can_reap_or_best_effort_cleanup"
+            "lifecycle_policy_allows_reap"
         ],
+        "mcp_stdio_lifecycle": {
+            "declaration_method": "uxc/lifecycle_contract",
+            "state_change_notification": "notifications/uxc.lifecycle_changed",
+            "reap_policies": [
+                "safe_idle_reap",
+                "stateful"
+            ],
+            "stateful_requires_cached_snapshot": true
+        },
         "observable_session_fields": [
             "endpoint",
             "protocol",
@@ -270,7 +279,9 @@ fn lifecycle_contract() -> Value {
             "daemon_exclusive",
             "in_flight_requests",
             "reuse_eligible",
-            "can_reap_contract"
+            "lifecycle_contract",
+            "last_lifecycle_update_at_unix",
+            "last_lifecycle_snapshot"
         ]
     })
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -72,9 +72,7 @@ const STOP_POLL_INTERVAL_MS: u64 = 100;
 const START_LOCK_STALE_SECS: u64 = 30;
 const STDIO_INIT_LOCK_STALE_SECS: u64 = 30;
 const MCP_IDLE_TTL_SECS: u64 = 600;
-const MCP_CAN_REAP_PROBE_TIMEOUT_MS: u64 = 250;
 const MCP_IDLE_CLEANUP_INTERVAL_MS: u64 = 500;
-const MCP_CAN_REAP_RETRY_AFTER_SECS: u64 = 30;
 // Five seconds is long enough for cooperative stdio servers to notice stdin EOF
 // and release external resources, while still bounding daemon-side eviction stalls.
 const MCP_STDIO_EXIT_TIMEOUT_SECS: u64 = 5;
@@ -562,38 +560,31 @@ pub struct DaemonSessionView {
     /// Number of daemon-tracked in-flight requests currently using this session.
     pub in_flight_requests: u64,
     pub reuse_eligible: bool,
-    pub can_reap_contract: CanReapContractView,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle_contract: Option<LifecycleContractView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_lifecycle_update_at_unix: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_lifecycle_snapshot: Option<LifecycleSnapshotView>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error_summary: Option<String>,
     #[serde(default)]
     pub recent_stderr: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum CanReapContractSupport {
-    #[default]
-    Unknown,
-    Supported,
-    Unsupported,
-    Error,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LifecycleContractView {
+    pub reap_policy: adapters::mcp::LifecycleReapPolicy,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CanReapContractView {
-    pub support: CanReapContractSupport,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LifecycleSnapshotView {
+    pub auto_reap_allowed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub checked_at_unix: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub can_reap: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
+    pub retention_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_after_secs: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<adapters::mcp::CanReapState>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_error_summary: Option<String>,
+    pub updated_at_unix: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -682,8 +673,9 @@ struct McpStdioSession {
     link_skill_path: Option<String>,
     endpoint: String,
     daemon_exclusive: Vec<String>,
-    can_reap_contract: CanReapContractView,
-    next_can_reap_probe_after: Option<Instant>,
+    lifecycle_contract: Option<LifecycleContractView>,
+    last_lifecycle_update_at_unix: Option<u64>,
+    last_lifecycle_snapshot: Option<LifecycleSnapshotView>,
 }
 
 #[derive(Debug, Clone)]
@@ -701,7 +693,9 @@ struct McpStdioSessionSnapshot {
     daemon_exclusive: Vec<String>,
     in_flight_requests: u64,
     reuse_eligible: bool,
-    can_reap_contract: CanReapContractView,
+    lifecycle_contract: Option<LifecycleContractView>,
+    last_lifecycle_update_at_unix: Option<u64>,
+    last_lifecycle_snapshot: Option<LifecycleSnapshotView>,
     last_error_summary: Option<String>,
     recent_stderr: Vec<String>,
 }
@@ -845,6 +839,18 @@ fn persisted_record_sink_path(record: &PersistedSubscriptionRecord) -> Result<Pa
 }
 
 impl McpStdioSession {
+    fn apply_lifecycle_notification(&mut self, notification: &JsonRpcNotification) -> Result<bool> {
+        if notification.method != "notifications/uxc.lifecycle_changed" {
+            return Ok(false);
+        }
+        let params = notification.params.clone().unwrap_or_else(|| json!({}));
+        let snapshot: LifecycleSnapshotView =
+            serde_json::from_value(params).context("Failed to parse lifecycle snapshot")?;
+        self.last_lifecycle_update_at_unix = Some(snapshot.updated_at_unix);
+        self.last_lifecycle_snapshot = Some(snapshot);
+        Ok(true)
+    }
+
     fn apply_request_metadata(&mut self, metadata: &StdioSessionRequestMetadata<'_>) {
         let resolved = resolve_stdio_request_metadata(metadata, &self.daemon_exclusive);
         self.idle_ttl_secs = resolved.idle_ttl_secs;
@@ -887,16 +893,25 @@ impl McpStdioSession {
         endpoint: &str,
         cache: Option<&Arc<dyn Cache>>,
     ) -> Vec<JsonRpcNotification> {
-        for notification in &notifications {
+        let mut public_notifications = Vec::new();
+        for notification in notifications {
+            if let Err(err) = self.apply_lifecycle_notification(&notification) {
+                tracing::warn!(endpoint = %endpoint, error = %err, "Failed to apply MCP lifecycle notification");
+                continue;
+            }
+            if notification.method == "notifications/uxc.lifecycle_changed" {
+                continue;
+            }
             if notification.method == "notifications/tools/list_changed" {
                 self.tools_dirty = true;
                 if let Some(cache) = cache {
                     let _ = cache.invalidate(endpoint);
                 }
             }
+            public_notifications.push(notification);
         }
-        self.notifications.extend(notifications.clone());
-        notifications
+        self.notifications.extend(public_notifications.clone());
+        public_notifications
     }
 
     async fn sync_notifications(
@@ -1121,7 +1136,9 @@ impl McpStdioSessionSnapshot {
             },
             in_flight_requests: self.in_flight_requests,
             reuse_eligible: self.reuse_eligible,
-            can_reap_contract: self.can_reap_contract.clone(),
+            lifecycle_contract: self.lifecycle_contract.clone(),
+            last_lifecycle_update_at_unix: self.last_lifecycle_update_at_unix,
+            last_lifecycle_snapshot: self.last_lifecycle_snapshot.clone(),
             last_error_summary: self.last_error_summary.clone(),
             recent_stderr: self.recent_stderr.clone(),
         }
@@ -1170,17 +1187,6 @@ fn redact_recent_stderr(lines: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-fn can_reap_error_summary(err: &anyhow::Error) -> String {
-    truncate_for_session_summary(&redact_sensitive(&err.to_string()))
-}
-
-fn can_reap_method_not_found(err: &anyhow::Error) -> bool {
-    structured_error_from_anyhow(err)
-        .and_then(|payload| payload.details)
-        .and_then(|details| details.get("jsonrpc_code").and_then(Value::as_i64))
-        == Some(-32601)
-}
-
 impl McpSessionManager {
     fn new(logger: Option<DaemonLogger>) -> Self {
         Self {
@@ -1221,6 +1227,9 @@ impl McpSessionManager {
             "idle_for_secs": now_unix_secs().saturating_sub(snapshot.last_used_at_unix),
             "in_flight_requests": snapshot.in_flight_requests,
             "reuse_eligible": snapshot.reuse_eligible,
+            "lifecycle_contract": snapshot.lifecycle_contract.clone(),
+            "last_lifecycle_update_at_unix": snapshot.last_lifecycle_update_at_unix,
+            "last_lifecycle_snapshot": snapshot.last_lifecycle_snapshot.clone(),
             "recent_stderr": snapshot.recent_stderr.clone(),
         });
         if let Some(reason) = reason {
@@ -1232,47 +1241,6 @@ impl McpSessionManager {
             .with_meta(meta);
         if let Some(error) = error {
             entry = entry.with_error(error.to_string());
-        }
-        let _ = logger.log(&entry).await;
-    }
-
-    async fn log_stdio_reap_deferred(
-        &self,
-        session_key: &str,
-        snapshot: &McpStdioSessionSnapshot,
-        contract: &CanReapContractView,
-    ) {
-        let Some(logger) = self.logger.as_ref() else {
-            return;
-        };
-        let mut meta = json!({
-            "session_key": display_session_key(session_key),
-            "link_name": snapshot.link_name.clone(),
-            "link_skill": snapshot.link_skill.clone(),
-            "link_skill_doc": snapshot.link_skill_doc.clone(),
-            "link_skill_path": snapshot.link_skill_path.clone(),
-            "command_summary": snapshot.command_summary.clone(),
-            "daemon_exclusive": snapshot.daemon_exclusive.clone(),
-            "child_pid": snapshot.child_pid,
-            "idle_ttl_secs": snapshot.idle_ttl_secs,
-            "idle_for_secs": now_unix_secs().saturating_sub(snapshot.last_used_at_unix),
-            "in_flight_requests": snapshot.in_flight_requests,
-            "reason": contract.reason.clone(),
-            "retry_after_secs": contract.retry_after_secs,
-            "state": contract.state.clone(),
-        });
-        if let Some(can_reap) = contract.can_reap {
-            meta["can_reap"] = json!(can_reap);
-        }
-        if let Some(checked_at_unix) = contract.checked_at_unix {
-            meta["checked_at_unix"] = json!(checked_at_unix);
-        }
-        let mut entry = DaemonLogEntry::new(DaemonEventType::DaemonSessionReapDeferred)
-            .with_endpoint(snapshot.endpoint.clone())
-            .with_protocol("mcp_stdio".to_string())
-            .with_meta(meta);
-        if let Some(error) = &contract.last_error_summary {
-            entry = entry.with_error(error.clone());
         }
         let _ = logger.log(&entry).await;
     }
@@ -1320,105 +1288,29 @@ impl McpSessionManager {
             // Use try_lock to avoid blocking on sessions that may be held across .await in invoke_mcp.
             // If a session is busy, we'll check it again in the next cleanup cycle.
             if let Ok(mut guard) = session.try_lock() {
-                // Daemon-exclusive stdio sessions back long-lived local browser workers.
-                // Probing them with background MCP requests is intrusive because stdio MCP is
-                // single-lane: even a timed-out can_reap probe can still occupy the server and
-                // delay foreground requests that arrive moments later. Keep these sessions until
-                // the owner explicitly restarts/reaps them.
-                if !guard.daemon_exclusive.is_empty() {
-                    continue;
-                }
+                let endpoint = guard.endpoint.clone();
+                let _ = guard.sync_notifications(&endpoint, None).await;
                 if guard.idle_ttl_secs == 0 {
                     continue;
                 }
                 let now = Instant::now();
                 let cutoff = now - Duration::from_secs(guard.idle_ttl_secs);
                 if guard.last_used < cutoff {
-                    if guard
-                        .next_can_reap_probe_after
-                        .is_some_and(|next_probe_after| next_probe_after > now)
+                    let lifecycle_allows_reap = match guard
+                        .lifecycle_contract
+                        .as_ref()
+                        .map(|contract| contract.reap_policy)
+                        .unwrap_or(adapters::mcp::LifecycleReapPolicy::SafeIdleReap)
                     {
+                        adapters::mcp::LifecycleReapPolicy::SafeIdleReap => true,
+                        adapters::mcp::LifecycleReapPolicy::Stateful => guard
+                            .last_lifecycle_snapshot
+                            .as_ref()
+                            .is_some_and(|snapshot| snapshot.auto_reap_allowed),
+                    };
+                    if !lifecycle_allows_reap {
                         continue;
                     }
-                    let checked_at_unix = now_unix_secs();
-                    let idle_for_secs = checked_at_unix.saturating_sub(guard.last_used_at_unix);
-                    let idle_ttl_secs = guard.idle_ttl_secs;
-                    match guard
-                        .client
-                        .probe_can_reap(
-                            idle_for_secs,
-                            idle_ttl_secs,
-                            Duration::from_millis(MCP_CAN_REAP_PROBE_TIMEOUT_MS),
-                        )
-                        .await
-                    {
-                        Ok(result) => {
-                            guard.can_reap_contract = CanReapContractView {
-                                support: CanReapContractSupport::Supported,
-                                checked_at_unix: Some(checked_at_unix),
-                                can_reap: Some(result.can_reap),
-                                reason: result.reason.clone(),
-                                retry_after_secs: result.retry_after_secs,
-                                state: result.state.clone(),
-                                last_error_summary: None,
-                            };
-                            if result.can_reap {
-                                guard.next_can_reap_probe_after = None;
-                            } else {
-                                let retry_after_secs = result
-                                    .retry_after_secs
-                                    .unwrap_or(MCP_CAN_REAP_RETRY_AFTER_SECS);
-                                guard.next_can_reap_probe_after =
-                                    Some(now + Duration::from_secs(retry_after_secs));
-                                let contract = guard.can_reap_contract.clone();
-                                drop(guard);
-                                self.upsert_stdio_snapshot(key, |snapshot| {
-                                    snapshot.can_reap_contract = contract.clone();
-                                })
-                                .await;
-                                if let Some(snapshot) = {
-                                    let snapshots = self.stdio_snapshots.lock().await;
-                                    snapshots.get(key).cloned()
-                                } {
-                                    self.log_stdio_reap_deferred(key, &snapshot, &contract)
-                                        .await;
-                                }
-                                continue;
-                            }
-                        }
-                        Err(err) => {
-                            let method_not_found = can_reap_method_not_found(&err);
-                            guard.next_can_reap_probe_after = if method_not_found {
-                                None
-                            } else {
-                                Some(now + Duration::from_secs(MCP_CAN_REAP_RETRY_AFTER_SECS))
-                            };
-                            guard.can_reap_contract = CanReapContractView {
-                                support: if method_not_found {
-                                    CanReapContractSupport::Unsupported
-                                } else {
-                                    CanReapContractSupport::Error
-                                },
-                                checked_at_unix: Some(checked_at_unix),
-                                can_reap: None,
-                                reason: None,
-                                retry_after_secs: None,
-                                state: None,
-                                last_error_summary: (!method_not_found)
-                                    .then(|| can_reap_error_summary(&err)),
-                            };
-                            if !method_not_found {
-                                let contract = guard.can_reap_contract.clone();
-                                drop(guard);
-                                self.upsert_stdio_snapshot(key, |snapshot| {
-                                    snapshot.can_reap_contract = contract;
-                                })
-                                .await;
-                                continue;
-                            }
-                        }
-                    }
-                    let contract = guard.can_reap_contract.clone();
                     // Idle cleanup is best-effort: even if shutdown waiting fails, we still drop
                     // the cached session so cleanup can make forward progress on the next cycle.
                     if let Err(err) = guard
@@ -1433,10 +1325,6 @@ impl McpSessionManager {
                         );
                     }
                     drop(guard);
-                    self.upsert_stdio_snapshot(key, |snapshot| {
-                        snapshot.can_reap_contract = contract;
-                    })
-                    .await;
                     stdio_remove.push(key.clone());
                 }
             }
@@ -1573,7 +1461,7 @@ impl McpSessionManager {
             }
         }
 
-        let client = adapters::mcp::McpStdioClient::connect_with_options_and_timeout(
+        let mut client = adapters::mcp::McpStdioClient::connect_with_options_and_timeout(
             command,
             args,
             spawn_options.clone(),
@@ -1582,6 +1470,20 @@ impl McpSessionManager {
             ),
         )
         .await?;
+        let lifecycle_contract = match client
+            .lifecycle_contract(request_timeout.unwrap_or_else(
+                adapters::mcp::transport::McpStdioTransport::default_request_timeout,
+            ))
+            .await
+        {
+            Ok(contract) => Some(LifecycleContractView {
+                reap_policy: contract.reap_policy,
+            }),
+            Err(err) => {
+                tracing::debug!(session_key = %session_key, error = %err, "MCP stdio child did not declare lifecycle contract");
+                None
+            }
+        };
         let created_at_unix = now_unix_secs();
         let command_summary = command_summary_from_endpoint(metadata.endpoint);
         let child_pid = client.child_id();
@@ -1601,8 +1503,9 @@ impl McpSessionManager {
             link_skill_path: metadata.link_skill_path.map(str::to_string),
             endpoint: metadata.endpoint.to_string(),
             daemon_exclusive: exclusive_keys.clone(),
-            can_reap_contract: CanReapContractView::default(),
-            next_can_reap_probe_after: None,
+            lifecycle_contract: lifecycle_contract.clone(),
+            last_lifecycle_update_at_unix: None,
+            last_lifecycle_snapshot: None,
         }));
 
         {
@@ -1625,7 +1528,9 @@ impl McpSessionManager {
                 daemon_exclusive: exclusive_keys.clone(),
                 in_flight_requests: 0,
                 reuse_eligible: true,
-                can_reap_contract: CanReapContractView::default(),
+                lifecycle_contract,
+                last_lifecycle_update_at_unix: None,
+                last_lifecycle_snapshot: None,
                 last_error_summary: None,
                 recent_stderr: Vec::new(),
             },
@@ -1701,7 +1606,9 @@ impl McpSessionManager {
         let idle_ttl_secs = guard.idle_ttl_secs;
         let last_used_at_unix = guard.last_used_at_unix;
         let daemon_exclusive = guard.daemon_exclusive.clone();
-        let can_reap_contract = guard.can_reap_contract.clone();
+        let lifecycle_contract = guard.lifecycle_contract.clone();
+        let last_lifecycle_update_at_unix = guard.last_lifecycle_update_at_unix;
+        let last_lifecycle_snapshot = guard.last_lifecycle_snapshot.clone();
         drop(guard);
         self.upsert_stdio_snapshot(session_key, |snapshot| {
             snapshot.endpoint = endpoint;
@@ -1713,7 +1620,9 @@ impl McpSessionManager {
             snapshot.idle_ttl_secs = idle_ttl_secs;
             snapshot.last_used_at_unix = last_used_at_unix;
             snapshot.daemon_exclusive = daemon_exclusive;
-            snapshot.can_reap_contract = can_reap_contract;
+            snapshot.lifecycle_contract = lifecycle_contract;
+            snapshot.last_lifecycle_update_at_unix = last_lifecycle_update_at_unix;
+            snapshot.last_lifecycle_snapshot = last_lifecycle_snapshot;
             snapshot.recent_stderr = recent_stderr;
         })
         .await;
@@ -2066,6 +1975,8 @@ impl McpSessionManager {
         };
         for (session_key, session) in &stdio_entries {
             if let Ok(mut guard) = session.try_lock() {
+                let endpoint = guard.endpoint.clone();
+                let _ = guard.sync_notifications(&endpoint, None).await;
                 let recent_stderr = redact_recent_stderr(guard.client.recent_stderr_lines(5).await);
                 let child_exited = guard.client.child_has_exited().unwrap_or(false);
                 self.upsert_stdio_snapshot(session_key, |snapshot| {
@@ -2078,7 +1989,9 @@ impl McpSessionManager {
                     snapshot.last_used_at_unix = guard.last_used_at_unix;
                     snapshot.idle_ttl_secs = guard.idle_ttl_secs;
                     snapshot.daemon_exclusive = guard.daemon_exclusive.clone();
-                    snapshot.can_reap_contract = guard.can_reap_contract.clone();
+                    snapshot.lifecycle_contract = guard.lifecycle_contract.clone();
+                    snapshot.last_lifecycle_update_at_unix = guard.last_lifecycle_update_at_unix;
+                    snapshot.last_lifecycle_snapshot = guard.last_lifecycle_snapshot.clone();
                     snapshot.recent_stderr = recent_stderr;
                     if child_exited {
                         snapshot.reuse_eligible = false;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -587,6 +587,24 @@ pub struct LifecycleSnapshotView {
     pub updated_at_unix: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LifecycleContractFetchState {
+    Unsupported,
+    Available,
+    Unknown,
+}
+
+fn lifecycle_contract_fetch_state(err: &anyhow::Error) -> LifecycleContractFetchState {
+    let jsonrpc_code = structured_error_from_anyhow(err)
+        .and_then(|payload| payload.details)
+        .and_then(|details| details.get("jsonrpc_code").and_then(Value::as_i64));
+    if jsonrpc_code == Some(-32601) {
+        LifecycleContractFetchState::Unsupported
+    } else {
+        LifecycleContractFetchState::Unknown
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct JsonRpcRequest {
     jsonrpc: String,
@@ -674,6 +692,7 @@ struct McpStdioSession {
     endpoint: String,
     daemon_exclusive: Vec<String>,
     lifecycle_contract: Option<LifecycleContractView>,
+    lifecycle_contract_fetch_state: LifecycleContractFetchState,
     last_lifecycle_update_at_unix: Option<u64>,
     last_lifecycle_snapshot: Option<LifecycleSnapshotView>,
 }
@@ -694,6 +713,7 @@ struct McpStdioSessionSnapshot {
     in_flight_requests: u64,
     reuse_eligible: bool,
     lifecycle_contract: Option<LifecycleContractView>,
+    lifecycle_contract_fetch_state: LifecycleContractFetchState,
     last_lifecycle_update_at_unix: Option<u64>,
     last_lifecycle_snapshot: Option<LifecycleSnapshotView>,
     last_error_summary: Option<String>,
@@ -1296,17 +1316,25 @@ impl McpSessionManager {
                 let now = Instant::now();
                 let cutoff = now - Duration::from_secs(guard.idle_ttl_secs);
                 if guard.last_used < cutoff {
-                    let lifecycle_allows_reap = match guard
-                        .lifecycle_contract
-                        .as_ref()
-                        .map(|contract| contract.reap_policy)
-                        .unwrap_or(adapters::mcp::LifecycleReapPolicy::SafeIdleReap)
-                    {
-                        adapters::mcp::LifecycleReapPolicy::SafeIdleReap => true,
-                        adapters::mcp::LifecycleReapPolicy::Stateful => guard
+                    let lifecycle_allows_reap = match (
+                        guard.lifecycle_contract_fetch_state,
+                        guard
+                            .lifecycle_contract
+                            .as_ref()
+                            .map(|contract| contract.reap_policy),
+                    ) {
+                        (_, Some(adapters::mcp::LifecycleReapPolicy::SafeIdleReap)) => true,
+                        (LifecycleContractFetchState::Unsupported, None) => true,
+                        (
+                            LifecycleContractFetchState::Unsupported
+                            | LifecycleContractFetchState::Available,
+                            Some(adapters::mcp::LifecycleReapPolicy::Stateful),
+                        ) => guard
                             .last_lifecycle_snapshot
                             .as_ref()
                             .is_some_and(|snapshot| snapshot.auto_reap_allowed),
+                        (LifecycleContractFetchState::Unknown, _) => false,
+                        (LifecycleContractFetchState::Available, None) => false,
                     };
                     if !lifecycle_allows_reap {
                         continue;
@@ -1470,18 +1498,38 @@ impl McpSessionManager {
             ),
         )
         .await?;
-        let lifecycle_contract = match client
+        let (lifecycle_contract, lifecycle_contract_fetch_state) = match client
             .lifecycle_contract(request_timeout.unwrap_or_else(
                 adapters::mcp::transport::McpStdioTransport::default_request_timeout,
             ))
             .await
         {
-            Ok(contract) => Some(LifecycleContractView {
-                reap_policy: contract.reap_policy,
-            }),
+            Ok(contract) => (
+                Some(LifecycleContractView {
+                    reap_policy: contract.reap_policy,
+                }),
+                LifecycleContractFetchState::Available,
+            ),
             Err(err) => {
-                tracing::debug!(session_key = %session_key, error = %err, "MCP stdio child did not declare lifecycle contract");
-                None
+                let fetch_state = lifecycle_contract_fetch_state(&err);
+                match fetch_state {
+                    LifecycleContractFetchState::Unsupported => {
+                        tracing::debug!(
+                            session_key = %session_key,
+                            error = %err,
+                            "MCP stdio child does not declare lifecycle contract"
+                        );
+                    }
+                    LifecycleContractFetchState::Unknown => {
+                        tracing::warn!(
+                            session_key = %session_key,
+                            error = %err,
+                            "Failed to fetch MCP stdio lifecycle contract; automatic idle reap will stay disabled"
+                        );
+                    }
+                    LifecycleContractFetchState::Available => {}
+                }
+                (None, fetch_state)
             }
         };
         let created_at_unix = now_unix_secs();
@@ -1504,6 +1552,7 @@ impl McpSessionManager {
             endpoint: metadata.endpoint.to_string(),
             daemon_exclusive: exclusive_keys.clone(),
             lifecycle_contract: lifecycle_contract.clone(),
+            lifecycle_contract_fetch_state,
             last_lifecycle_update_at_unix: None,
             last_lifecycle_snapshot: None,
         }));
@@ -1529,6 +1578,7 @@ impl McpSessionManager {
                 in_flight_requests: 0,
                 reuse_eligible: true,
                 lifecycle_contract,
+                lifecycle_contract_fetch_state,
                 last_lifecycle_update_at_unix: None,
                 last_lifecycle_snapshot: None,
                 last_error_summary: None,
@@ -1607,6 +1657,7 @@ impl McpSessionManager {
         let last_used_at_unix = guard.last_used_at_unix;
         let daemon_exclusive = guard.daemon_exclusive.clone();
         let lifecycle_contract = guard.lifecycle_contract.clone();
+        let lifecycle_contract_fetch_state = guard.lifecycle_contract_fetch_state;
         let last_lifecycle_update_at_unix = guard.last_lifecycle_update_at_unix;
         let last_lifecycle_snapshot = guard.last_lifecycle_snapshot.clone();
         drop(guard);
@@ -1621,6 +1672,7 @@ impl McpSessionManager {
             snapshot.last_used_at_unix = last_used_at_unix;
             snapshot.daemon_exclusive = daemon_exclusive;
             snapshot.lifecycle_contract = lifecycle_contract;
+            snapshot.lifecycle_contract_fetch_state = lifecycle_contract_fetch_state;
             snapshot.last_lifecycle_update_at_unix = last_lifecycle_update_at_unix;
             snapshot.last_lifecycle_snapshot = last_lifecycle_snapshot;
             snapshot.recent_stderr = recent_stderr;
@@ -1990,6 +2042,7 @@ impl McpSessionManager {
                     snapshot.idle_ttl_secs = guard.idle_ttl_secs;
                     snapshot.daemon_exclusive = guard.daemon_exclusive.clone();
                     snapshot.lifecycle_contract = guard.lifecycle_contract.clone();
+                    snapshot.lifecycle_contract_fetch_state = guard.lifecycle_contract_fetch_state;
                     snapshot.last_lifecycle_update_at_unix = guard.last_lifecycle_update_at_unix;
                     snapshot.last_lifecycle_snapshot = guard.last_lifecycle_snapshot.clone();
                     snapshot.recent_stderr = recent_stderr;

--- a/src/daemon_log.rs
+++ b/src/daemon_log.rs
@@ -49,7 +49,6 @@ pub enum DaemonEventType {
     DaemonSessionCreated,
     DaemonSessionReused,
     DaemonSessionUnhealthy,
-    DaemonSessionReapDeferred,
     DaemonSessionRemoved,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2214,7 +2214,7 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
             usage: "uxc daemon sessions".to_string(),
             commands: vec![],
             notes: vec![
-                "Shows live stdio daemon session metadata including command summary, reuse eligibility, recent stderr, per-session idle TTL where 0 disables idle reaping, and the latest uxc/can_reap contract state."
+                "Shows live stdio daemon session metadata including command summary, reuse eligibility, recent stderr, per-session idle TTL where 0 disables idle reaping, and the latest lifecycle contract and snapshot state."
                     .to_string(),
             ],
             examples: vec!["uxc daemon sessions".to_string()],

--- a/src/test_server/common.rs
+++ b/src/test_server/common.rs
@@ -35,12 +35,12 @@ pub enum Scenario {
     SuiPubSub,
     /// Resource state is scoped to a single MCP session/instance
     SessionScopedResource,
-    /// uxc/can_reap returns can_reap=false with structured state
-    CanReapKeepAlive,
-    /// uxc/can_reap returns can_reap=true
-    CanReapAllowReap,
-    /// uxc/can_reap times out
-    CanReapTimeout,
+    /// uxc/lifecycle_contract returns stateful and sends auto_reap_allowed=false
+    LifecycleStatefulHold,
+    /// uxc/lifecycle_contract returns stateful and sends auto_reap_allowed=true
+    LifecycleStatefulAllow,
+    /// uxc/lifecycle_contract returns stateful and sends no lifecycle snapshot
+    LifecycleStatefulNoSnapshot,
 }
 
 impl Scenario {
@@ -62,11 +62,11 @@ impl Scenario {
             "empty_object_required" => Ok(Self::EmptyObjectRequired),
             "sui_pubsub" => Ok(Self::SuiPubSub),
             "session_scoped_resource" => Ok(Self::SessionScopedResource),
-            "can_reap_keep_alive" => Ok(Self::CanReapKeepAlive),
-            "can_reap_allow_reap" => Ok(Self::CanReapAllowReap),
-            "can_reap_timeout" => Ok(Self::CanReapTimeout),
+            "lifecycle_stateful_hold" => Ok(Self::LifecycleStatefulHold),
+            "lifecycle_stateful_allow" => Ok(Self::LifecycleStatefulAllow),
+            "lifecycle_stateful_no_snapshot" => Ok(Self::LifecycleStatefulNoSnapshot),
             _ => anyhow::bail!(
-                "Unknown scenario: {}. Use: ok, auth_required, malformed, timeout, legacy, tool_call_timeout, tools_list_fail_after_first, structured_content, tool_structured_error, resource_read_fail_once, dynamic_toolset, empty_object_required, sui_pubsub, session_scoped_resource, can_reap_keep_alive, can_reap_allow_reap, can_reap_timeout",
+                "Unknown scenario: {}. Use: ok, auth_required, malformed, timeout, legacy, tool_call_timeout, tools_list_fail_after_first, structured_content, tool_structured_error, resource_read_fail_once, dynamic_toolset, empty_object_required, sui_pubsub, session_scoped_resource, lifecycle_stateful_hold, lifecycle_stateful_allow, lifecycle_stateful_no_snapshot",
                 s
             ),
         }

--- a/src/test_server/graphql.rs
+++ b/src/test_server/graphql.rs
@@ -338,9 +338,9 @@ async fn execute_query(
         | Scenario::ResourceReadFailOnce
         | Scenario::SessionScopedResource
         | Scenario::DynamicToolset
-        | Scenario::CanReapKeepAlive
-        | Scenario::CanReapAllowReap
-        | Scenario::CanReapTimeout => {
+        | Scenario::LifecycleStatefulHold
+        | Scenario::LifecycleStatefulAllow
+        | Scenario::LifecycleStatefulNoSnapshot => {
             // Introspection query
             if query.contains("__schema") || query.contains("__type(") {
                 return Ok(GraphQLResponse {

--- a/src/test_server/grpc.rs
+++ b/src/test_server/grpc.rs
@@ -35,9 +35,9 @@ impl addsvc::add_server::Add for AddService {
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
             | Scenario::DynamicToolset
-            | Scenario::CanReapKeepAlive
-            | Scenario::CanReapAllowReap
-            | Scenario::CanReapTimeout => {
+            | Scenario::LifecycleStatefulHold
+            | Scenario::LifecycleStatefulAllow
+            | Scenario::LifecycleStatefulNoSnapshot => {
                 let req = request.into_inner();
                 Ok(Response::new(addsvc::SumReply { v: req.a + req.b }))
             }

--- a/src/test_server/jsonrpc.rs
+++ b/src/test_server/jsonrpc.rs
@@ -60,9 +60,9 @@ fn pubsub_profile(scenario: Scenario) -> Option<JsonRpcPubSubProfile> {
     match scenario {
         Scenario::Ok
         | Scenario::Legacy
-        | Scenario::CanReapKeepAlive
-        | Scenario::CanReapAllowReap
-        | Scenario::CanReapTimeout => Some(JsonRpcPubSubProfile::DerivedUnsubscribe),
+        | Scenario::LifecycleStatefulHold
+        | Scenario::LifecycleStatefulAllow
+        | Scenario::LifecycleStatefulNoSnapshot => Some(JsonRpcPubSubProfile::DerivedUnsubscribe),
         Scenario::SuiPubSub => Some(JsonRpcPubSubProfile::CloseOnly),
         _ => None,
     }
@@ -329,9 +329,9 @@ async fn execute_method(
         | Scenario::ResourceReadFailOnce
         | Scenario::SessionScopedResource
         | Scenario::DynamicToolset
-        | Scenario::CanReapKeepAlive
-        | Scenario::CanReapAllowReap
-        | Scenario::CanReapTimeout => {
+        | Scenario::LifecycleStatefulHold
+        | Scenario::LifecycleStatefulAllow
+        | Scenario::LifecycleStatefulNoSnapshot => {
             let result = match method {
                 "rpc.discover" => schema_value(state.scenario),
                 "health" => json!({"status": "ok"}),

--- a/src/test_server/mcp_stdio.rs
+++ b/src/test_server/mcp_stdio.rs
@@ -39,6 +39,40 @@ pub fn run(scenario: Scenario) -> Result<()> {
 
         if req.get("id").is_none() {
             // Notification
+            if method == "notifications/initialized" {
+                match scenario {
+                    Scenario::LifecycleStatefulHold => {
+                        respond(
+                            &mut out,
+                            json!({
+                                "jsonrpc": "2.0",
+                                "method": "notifications/uxc.lifecycle_changed",
+                                "params": {
+                                    "auto_reap_allowed": false,
+                                    "retention_reason": "interactive",
+                                    "retry_after_secs": 30,
+                                    "updated_at_unix": 1_700_000_001u64
+                                }
+                            }),
+                        )?;
+                    }
+                    Scenario::LifecycleStatefulAllow => {
+                        respond(
+                            &mut out,
+                            json!({
+                                "jsonrpc": "2.0",
+                                "method": "notifications/uxc.lifecycle_changed",
+                                "params": {
+                                    "auto_reap_allowed": true,
+                                    "updated_at_unix": 1_700_000_002u64
+                                }
+                            }),
+                        )?;
+                    }
+                    Scenario::LifecycleStatefulNoSnapshot => {}
+                    _ => {}
+                }
+            }
             continue;
         }
 
@@ -94,39 +128,20 @@ pub fn run(scenario: Scenario) -> Result<()> {
                     }),
                 )?;
             }
-            "uxc/can_reap" => {
-                if matches!(scenario, Scenario::CanReapTimeout) {
-                    std::thread::sleep(super::common::timeout_duration());
-                }
-                if matches!(scenario, Scenario::CanReapKeepAlive) {
+            "uxc/lifecycle_contract" => {
+                if matches!(
+                    scenario,
+                    Scenario::LifecycleStatefulHold
+                        | Scenario::LifecycleStatefulAllow
+                        | Scenario::LifecycleStatefulNoSnapshot
+                ) {
                     respond(
                         &mut out,
                         json!({
                             "jsonrpc": "2.0",
                             "id": id,
                             "result": {
-                                "can_reap": false,
-                                "reason": "interactive_session",
-                                "retry_after_secs": 30,
-                                "state": {
-                                    "interactive": true,
-                                    "owns_external_resource": true,
-                                    "waiting_for_human": false
-                                }
-                            }
-                        }),
-                    )?;
-                    continue;
-                }
-                if matches!(scenario, Scenario::CanReapAllowReap) {
-                    respond(
-                        &mut out,
-                        json!({
-                            "jsonrpc": "2.0",
-                            "id": id,
-                            "result": {
-                                "can_reap": true,
-                                "reason": "idle_session"
+                                "reap_policy": "stateful"
                             }
                         }),
                     )?;

--- a/src/test_server/openapi.rs
+++ b/src/test_server/openapi.rs
@@ -308,9 +308,11 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
             | Scenario::DynamicToolset
-            | Scenario::CanReapKeepAlive
-            | Scenario::CanReapAllowReap
-            | Scenario::CanReapTimeout => Ok(Json(json!({"status": "ok"})).into_response()),
+            | Scenario::LifecycleStatefulHold
+            | Scenario::LifecycleStatefulAllow
+            | Scenario::LifecycleStatefulNoSnapshot => {
+                Ok(Json(json!({"status": "ok"})).into_response())
+            }
             Scenario::AuthRequired => Err(StatusCode::UNAUTHORIZED),
             Scenario::Malformed => {
                 // Return invalid JSON
@@ -340,9 +342,9 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
             | Scenario::DynamicToolset
-            | Scenario::CanReapKeepAlive
-            | Scenario::CanReapAllowReap
-            | Scenario::CanReapTimeout => {
+            | Scenario::LifecycleStatefulHold
+            | Scenario::LifecycleStatefulAllow
+            | Scenario::LifecycleStatefulNoSnapshot => {
                 let users = vec![
                     json!({"id": 1, "name": "Alice", "email": "alice@example.com"}),
                     json!({"id": 2, "name": "Bob", "email": "bob@example.com"}),
@@ -378,9 +380,9 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
             | Scenario::DynamicToolset
-            | Scenario::CanReapKeepAlive
-            | Scenario::CanReapAllowReap
-            | Scenario::CanReapTimeout => {
+            | Scenario::LifecycleStatefulHold
+            | Scenario::LifecycleStatefulAllow
+            | Scenario::LifecycleStatefulNoSnapshot => {
                 let name = payload
                     .get("name")
                     .and_then(|v| v.as_str())
@@ -424,9 +426,9 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
             | Scenario::DynamicToolset
-            | Scenario::CanReapKeepAlive
-            | Scenario::CanReapAllowReap
-            | Scenario::CanReapTimeout => {
+            | Scenario::LifecycleStatefulHold
+            | Scenario::LifecycleStatefulAllow
+            | Scenario::LifecycleStatefulNoSnapshot => {
                 if id == 1 {
                     Ok(
                         Json(json!({"id": 1, "name": "Alice", "email": "alice@example.com"}))
@@ -466,9 +468,9 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
             | Scenario::DynamicToolset
-            | Scenario::CanReapKeepAlive
-            | Scenario::CanReapAllowReap
-            | Scenario::CanReapTimeout => {
+            | Scenario::LifecycleStatefulHold
+            | Scenario::LifecycleStatefulAllow
+            | Scenario::LifecycleStatefulNoSnapshot => {
                 let body = Body::from_stream(stream::iter(vec![
                     Ok::<Bytes, std::convert::Infallible>(Bytes::from_static(
                         br#"{"type":"tick","value":1}
@@ -518,9 +520,9 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
             | Scenario::DynamicToolset
-            | Scenario::CanReapKeepAlive
-            | Scenario::CanReapAllowReap
-            | Scenario::CanReapTimeout => {
+            | Scenario::LifecycleStatefulHold
+            | Scenario::LifecycleStatefulAllow
+            | Scenario::LifecycleStatefulNoSnapshot => {
                 let response = match query.cursor.as_deref() {
                     None => json!({
                         "items": [
@@ -570,9 +572,9 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
             | Scenario::DynamicToolset
-            | Scenario::CanReapKeepAlive
-            | Scenario::CanReapAllowReap
-            | Scenario::CanReapTimeout => {
+            | Scenario::LifecycleStatefulHold
+            | Scenario::LifecycleStatefulAllow
+            | Scenario::LifecycleStatefulNoSnapshot => {
                 let response = match query.offset {
                     None | Some(0) => json!({
                         "ok": true,
@@ -629,9 +631,9 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
             | Scenario::DynamicToolset
-            | Scenario::CanReapKeepAlive
-            | Scenario::CanReapAllowReap
-            | Scenario::CanReapTimeout => {
+            | Scenario::LifecycleStatefulHold
+            | Scenario::LifecycleStatefulAllow
+            | Scenario::LifecycleStatefulNoSnapshot => {
                 let since = query.since.unwrap_or(0);
                 let response = if since >= 3 {
                     json!([])
@@ -672,9 +674,9 @@ fn create_router(state: ServerState) -> Router {
             | Scenario::ResourceReadFailOnce
             | Scenario::SessionScopedResource
             | Scenario::DynamicToolset
-            | Scenario::CanReapKeepAlive
-            | Scenario::CanReapAllowReap
-            | Scenario::CanReapTimeout => {
+            | Scenario::LifecycleStatefulHold
+            | Scenario::LifecycleStatefulAllow
+            | Scenario::LifecycleStatefulNoSnapshot => {
                 let inbound_etag = headers
                     .get("if-none-match")
                     .and_then(|value| value.to_str().ok());

--- a/tests/codegen_schema_cli_test.rs
+++ b/tests/codegen_schema_cli_test.rs
@@ -60,6 +60,10 @@ fn endpoint_codegen_schema_exports_runtime_contract_boundaries() {
         true
     );
     assert_eq!(
+        json["data"]["runtime"]["lifecycle_contract"]["mcp_stdio_lifecycle"]["declaration_method"],
+        "uxc/lifecycle_contract"
+    );
+    assert_eq!(
         json["data"]["runtime"]["artifact_contract"]["compaction_model"]["meta_fields"][4],
         "artifact_ref"
     );

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,7 @@
 //! Common utilities for local E2E tests
 
 use anyhow::Result;
+use assert_cmd::Command as AssertCommand;
 use std::fs;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -46,6 +47,21 @@ pub fn uxc_binary() -> PathBuf {
         assert!(status.success(), "Failed to build uxc binary");
         debug_bin
     }
+}
+
+#[allow(deprecated)]
+pub fn uxc_command() -> AssertCommand {
+    AssertCommand::cargo_bin("uxc").expect("uxc binary should build")
+}
+
+pub fn uxc_command_with_home(home: &std::path::Path) -> AssertCommand {
+    let runtime_dir = home.join("runtime");
+    fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let mut cmd = uxc_command();
+    cmd.env("HOME", home);
+    cmd.env("USERPROFILE", home);
+    cmd.env("XDG_RUNTIME_DIR", &runtime_dir);
+    cmd
 }
 
 /// Path to test server binaries

--- a/tests/daemon_logging_test.rs
+++ b/tests/daemon_logging_test.rs
@@ -6,6 +6,18 @@ mod common;
 
 use common::test_server_binary;
 use serial_test::serial;
+use std::fs;
+use std::path::Path;
+
+fn uxc_command_with_home(home: &Path) -> assert_cmd::Command {
+    let runtime_dir = home.join("runtime");
+    fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
+    let mut cmd = uxc_command();
+    cmd.env("HOME", home);
+    cmd.env("USERPROFILE", home);
+    cmd.env("XDG_RUNTIME_DIR", &runtime_dir);
+    cmd
+}
 
 #[test]
 #[serial]
@@ -232,28 +244,25 @@ fn daemon_log_contains_stdio_session_lifecycle_events() {
 
 #[test]
 #[serial]
-fn daemon_log_contains_reap_deferred_event_when_can_reap_is_false() {
-    use std::fs;
+fn daemon_log_contains_lifecycle_snapshot_metadata_for_stateful_stdio_sessions() {
     use std::path::PathBuf;
     use std::thread;
     use std::time::Duration;
 
-    let _ = uxc_command().arg("daemon").arg("stop").output();
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    let _ = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("stop")
+        .output();
 
-    let log_dir = if let Some(dir) = std::env::var_os("XDG_RUNTIME_DIR") {
-        PathBuf::from(dir).join("uxc")
-    } else if let Some(home) = std::env::var_os("HOME") {
-        PathBuf::from(home).join(".uxc").join("daemon")
-    } else {
-        return;
-    };
+    let log_dir = PathBuf::from(temp_home.path()).join("runtime").join("uxc");
 
     let log_file = log_dir.join("daemon.log");
     if log_file.exists() {
         let _ = fs::remove_file(&log_file);
     }
 
-    let start = uxc_command()
+    let start = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("start")
         .output()
@@ -261,8 +270,8 @@ fn daemon_log_contains_reap_deferred_event_when_can_reap_is_false() {
     assert!(start.status.success());
 
     let bin = test_server_binary("mcp-stdio");
-    let endpoint = format!("{} can_reap_keep_alive", bin.display());
-    let first = uxc_command()
+    let endpoint = format!("{} lifecycle_stateful_hold", bin.display());
+    let first = uxc_command_with_home(temp_home.path())
         .arg("--daemon-idle-ttl")
         .arg("1")
         .arg(&endpoint)
@@ -275,7 +284,7 @@ fn daemon_log_contains_reap_deferred_event_when_can_reap_is_false() {
 
     thread::sleep(Duration::from_millis(1500));
 
-    let second = uxc_command()
+    let second = uxc_command_with_home(temp_home.path())
         .arg(&endpoint)
         .arg("echo")
         .arg("--input-json")
@@ -288,15 +297,18 @@ fn daemon_log_contains_reap_deferred_event_when_can_reap_is_false() {
 
     let content = fs::read_to_string(&log_file).expect("should be able to read daemon log");
     assert!(
-        content.contains("daemon_session_reap_deferred"),
-        "log should contain daemon_session_reap_deferred event"
+        content.contains("\"lifecycle_contract\":{\"reap_policy\":\"stateful\"}"),
+        "log should include the stateful lifecycle contract"
     );
     assert!(
-        content.contains("interactive_session"),
-        "log should include the can_reap defer reason"
+        content.contains("\"retention_reason\":\"interactive\""),
+        "log should include the latest lifecycle retention reason"
     );
 
-    let _ = uxc_command().arg("daemon").arg("stop").output();
+    let _ = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("stop")
+        .output();
     let _ = fs::remove_file(&log_file);
 }
 

--- a/tests/daemon_logging_test.rs
+++ b/tests/daemon_logging_test.rs
@@ -4,20 +4,9 @@
 
 mod common;
 
-use common::test_server_binary;
+use common::{test_server_binary, uxc_command, uxc_command_with_home};
 use serial_test::serial;
 use std::fs;
-use std::path::Path;
-
-fn uxc_command_with_home(home: &Path) -> assert_cmd::Command {
-    let runtime_dir = home.join("runtime");
-    fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
-    let mut cmd = uxc_command();
-    cmd.env("HOME", home);
-    cmd.env("USERPROFILE", home);
-    cmd.env("XDG_RUNTIME_DIR", &runtime_dir);
-    cmd
-}
 
 #[test]
 #[serial]
@@ -296,13 +285,17 @@ fn daemon_log_contains_lifecycle_snapshot_metadata_for_stateful_stdio_sessions()
     thread::sleep(Duration::from_millis(200));
 
     let content = fs::read_to_string(&log_file).expect("should be able to read daemon log");
+    let entries = content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("valid log json"))
+        .collect::<Vec<_>>();
     assert!(
-        content.contains("\"lifecycle_contract\":{\"reap_policy\":\"stateful\"}"),
-        "log should include the stateful lifecycle contract"
-    );
-    assert!(
-        content.contains("\"retention_reason\":\"interactive\""),
-        "log should include the latest lifecycle retention reason"
+        entries.iter().any(|entry| {
+            entry["meta"]["lifecycle_contract"]["reap_policy"] == "stateful"
+                && entry["meta"]["last_lifecycle_snapshot"]["retention_reason"] == "interactive"
+        }),
+        "log should include lifecycle metadata for a stateful interactive session"
     );
 
     let _ = uxc_command_with_home(temp_home.path())
@@ -310,9 +303,4 @@ fn daemon_log_contains_lifecycle_snapshot_metadata_for_stateful_stdio_sessions()
         .arg("stop")
         .output();
     let _ = fs::remove_file(&log_file);
-}
-
-#[allow(deprecated)]
-fn uxc_command() -> assert_cmd::Command {
-    assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()
 }

--- a/tests/daemon_reuse_test.rs
+++ b/tests/daemon_reuse_test.rs
@@ -1,7 +1,6 @@
 mod common;
 
-use assert_cmd::Command;
-use common::test_server_binary;
+use common::{test_server_binary, uxc_command, uxc_command_with_home};
 use serial_test::serial;
 use std::fs;
 #[cfg(unix)]
@@ -10,23 +9,8 @@ use std::path::Path;
 use std::sync::{Arc, Barrier};
 use std::time::Duration;
 
-#[allow(deprecated)]
-fn uxc_command() -> Command {
-    Command::cargo_bin("uxc").expect("uxc binary should build")
-}
-
 fn daemon_stop_best_effort() {
     let _ = uxc_command().arg("daemon").arg("stop").output();
-}
-
-fn uxc_command_with_home(home: &Path) -> Command {
-    let runtime_dir = home.join("runtime");
-    fs::create_dir_all(&runtime_dir).expect("runtime dir should be created");
-    let mut cmd = uxc_command();
-    cmd.env("HOME", home);
-    cmd.env("USERPROFILE", home);
-    cmd.env("XDG_RUNTIME_DIR", &runtime_dir);
-    cmd
 }
 
 fn daemon_stop_best_effort_with_home(home: &Path) {

--- a/tests/daemon_reuse_test.rs
+++ b/tests/daemon_reuse_test.rs
@@ -277,20 +277,21 @@ fn daemon_sessions_surface_link_source_metadata() {
 
 #[test]
 #[serial]
-fn daemon_sessions_expose_supported_can_reap_contract_when_idle_reap_is_deferred() {
-    daemon_stop_best_effort();
+fn daemon_sessions_expose_stateful_lifecycle_contract_when_idle_reap_is_deferred() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
 
     let bin = test_server_binary("mcp-stdio");
-    let endpoint = format!("{} can_reap_keep_alive", bin.display());
+    let endpoint = format!("{} lifecycle_stateful_hold", bin.display());
 
-    let start = uxc_command()
+    let start = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("start")
         .output()
         .expect("daemon start should run");
     assert!(start.status.success());
 
-    let first = uxc_command()
+    let first = uxc_command_with_home(temp_home.path())
         .arg("--daemon-idle-ttl")
         .arg("1")
         .arg(&endpoint)
@@ -303,7 +304,7 @@ fn daemon_sessions_expose_supported_can_reap_contract_when_idle_reap_is_deferred
 
     std::thread::sleep(Duration::from_millis(1500));
 
-    let second = uxc_command()
+    let second = uxc_command_with_home(temp_home.path())
         .arg(&endpoint)
         .arg("echo")
         .arg("--input-json")
@@ -316,7 +317,7 @@ fn daemon_sessions_expose_supported_can_reap_contract_when_idle_reap_is_deferred
         serde_json::from_slice(&second.stdout).expect("second stdout should be valid JSON");
     assert_eq!(second_json["meta"]["daemon_session_reused"], true);
 
-    let sessions = uxc_command()
+    let sessions = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("sessions")
         .output()
@@ -329,34 +330,41 @@ fn daemon_sessions_expose_supported_can_reap_contract_when_idle_reap_is_deferred
         .as_array()
         .expect("session list should be an array");
     assert_eq!(sessions.len(), 1, "expected one stdio session");
-    let contract = &sessions[0]["can_reap_contract"];
-    assert_eq!(contract["support"], "supported");
-    assert_eq!(contract["can_reap"], false);
-    assert_eq!(contract["reason"], "interactive_session");
-    assert_eq!(contract["retry_after_secs"], 30);
-    assert_eq!(contract["state"]["interactive"], true);
-    assert_eq!(contract["state"]["owns_external_resource"], true);
-    assert_eq!(contract["state"]["waiting_for_human"], false);
+    assert_eq!(sessions[0]["lifecycle_contract"]["reap_policy"], "stateful");
+    assert_eq!(
+        sessions[0]["last_lifecycle_snapshot"]["auto_reap_allowed"],
+        false
+    );
+    assert_eq!(
+        sessions[0]["last_lifecycle_snapshot"]["retention_reason"],
+        "interactive"
+    );
+    assert_eq!(
+        sessions[0]["last_lifecycle_snapshot"]["retry_after_secs"],
+        30
+    );
+    assert_eq!(sessions[0]["last_lifecycle_update_at_unix"], 1700000001u64);
 
-    daemon_stop_best_effort();
+    daemon_stop_best_effort_with_home(temp_home.path());
 }
 
 #[test]
 #[serial]
-fn can_reap_true_allows_idle_session_to_be_reaped_before_reuse() {
-    daemon_stop_best_effort();
+fn stateful_session_with_auto_reap_allowed_is_reaped_before_reuse() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
 
     let bin = test_server_binary("mcp-stdio");
-    let endpoint = format!("{} can_reap_allow_reap", bin.display());
+    let endpoint = format!("{} lifecycle_stateful_allow", bin.display());
 
-    let start = uxc_command()
+    let start = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("start")
         .output()
         .expect("daemon start should run");
     assert!(start.status.success());
 
-    let first = uxc_command()
+    let first = uxc_command_with_home(temp_home.path())
         .arg("--daemon-idle-ttl")
         .arg("1")
         .arg(&endpoint)
@@ -367,7 +375,7 @@ fn can_reap_true_allows_idle_session_to_be_reaped_before_reuse() {
         .expect("first call should run");
     assert!(first.status.success());
 
-    let first_sessions = uxc_command()
+    let first_sessions = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("sessions")
         .output()
@@ -381,7 +389,7 @@ fn can_reap_true_allows_idle_session_to_be_reaped_before_reuse() {
 
     std::thread::sleep(Duration::from_millis(1500));
 
-    let second = uxc_command()
+    let second = uxc_command_with_home(temp_home.path())
         .arg(&endpoint)
         .arg("echo")
         .arg("--input-json")
@@ -394,10 +402,10 @@ fn can_reap_true_allows_idle_session_to_be_reaped_before_reuse() {
         serde_json::from_slice(&second.stdout).expect("second stdout should be valid JSON");
     assert!(
         second_json["meta"]["daemon_session_reused"] != true,
-        "expected second call to use a fresh session after can_reap=true"
+        "expected second call to use a fresh session after auto_reap_allowed=true"
     );
 
-    let second_sessions = uxc_command()
+    let second_sessions = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("sessions")
         .output()
@@ -410,31 +418,30 @@ fn can_reap_true_allows_idle_session_to_be_reaped_before_reuse() {
         .expect("child pid should be present");
     assert_ne!(first_pid, second_pid, "expected a new MCP child process");
     assert_eq!(
-        second_sessions_json["data"][0]["can_reap_contract"]["support"],
-        "unknown"
+        second_sessions_json["data"][0]["lifecycle_contract"]["reap_policy"],
+        "stateful"
     );
 
-    daemon_stop_best_effort();
+    daemon_stop_best_effort_with_home(temp_home.path());
 }
 
 #[test]
 #[serial]
-fn daemon_exclusive_stdio_sessions_skip_intrusive_idle_reap_probes() {
-    daemon_stop_best_effort();
+fn stateful_session_without_snapshot_is_kept_for_reuse() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
 
     let bin = test_server_binary("mcp-stdio");
-    let endpoint = format!("{} can_reap_timeout", bin.display());
+    let endpoint = format!("{} lifecycle_stateful_no_snapshot", bin.display());
 
-    let start = uxc_command()
-        .env("UXC_TEST_TIMEOUT_MS", "3000")
+    let start = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("start")
         .output()
         .expect("daemon start should run");
     assert!(start.status.success());
 
-    let first = uxc_command()
-        .env("UXC_DAEMON_EXCLUSIVE", "~/.uxc/test-exclusive")
+    let first = uxc_command_with_home(temp_home.path())
         .arg("--daemon-idle-ttl")
         .arg("1")
         .arg(&endpoint)
@@ -447,35 +454,34 @@ fn daemon_exclusive_stdio_sessions_skip_intrusive_idle_reap_probes() {
 
     std::thread::sleep(Duration::from_millis(1500));
 
-    let started = std::time::Instant::now();
-    let second = uxc_command()
-        .env("UXC_DAEMON_EXCLUSIVE", "~/.uxc/test-exclusive")
-        .arg("--daemon-idle-ttl")
-        .arg("1")
+    let second = uxc_command_with_home(temp_home.path())
         .arg(&endpoint)
         .arg("echo")
         .arg("--input-json")
         .arg(r#"{"message":"reuse"}"#)
         .output()
         .expect("second call should run");
-    let elapsed = started.elapsed();
-    assert!(
-        second.status.success(),
-        "second call should succeed\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&second.stdout),
-        String::from_utf8_lossy(&second.stderr)
-    );
-    assert!(
-        elapsed < Duration::from_millis(900),
-        "expected daemon-exclusive session reuse to avoid idle cleanup probe delay, took {:?}",
-        elapsed
-    );
+    assert!(second.status.success());
 
     let second_json: serde_json::Value =
         serde_json::from_slice(&second.stdout).expect("second stdout should be valid JSON");
     assert_eq!(second_json["meta"]["daemon_session_reused"], true);
 
-    daemon_stop_best_effort();
+    let sessions = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("sessions")
+        .output()
+        .expect("daemon sessions should run");
+    assert!(sessions.status.success());
+    let sessions_json: serde_json::Value =
+        serde_json::from_slice(&sessions.stdout).expect("valid daemon sessions json");
+    assert_eq!(
+        sessions_json["data"][0]["lifecycle_contract"]["reap_policy"],
+        "stateful"
+    );
+    assert!(sessions_json["data"][0]["last_lifecycle_snapshot"].is_null());
+
+    daemon_stop_best_effort_with_home(temp_home.path());
 }
 
 #[test]
@@ -669,11 +675,11 @@ fn daemon_status_not_blocked_by_stuck_mcp_invoke() {
     assert_eq!(json["kind"], "daemon_status");
     assert_eq!(json["data"]["running"], true);
 
-    let first_output = first.join().expect("first timeout thread panicked");
+    let _first_output = first.join().expect("first timeout thread panicked");
     // The timeout calls are expected to succeed (they timeout after 4s)
     // We don't assert on status.success() because the test is about
     // daemon status being responsive, not about the timeout calls themselves
-    let second_output = second.join().expect("second timeout thread panicked");
+    let _second_output = second.join().expect("second timeout thread panicked");
 
     daemon_stop_best_effort();
 }


### PR DESCRIPTION
## What
- replace live `uxc/can_reap` probing with one-time `uxc/lifecycle_contract` declaration and pushed `notifications/uxc.lifecycle_changed` snapshots
- update daemon cleanup, session views, runtime schema, docs, and MCP stdio test servers around the new contract
- remove `can_reap` plumbing and add stateful lifecycle coverage in daemon reuse/logging tests

## Why
- live MCP probe requests do not work reliably for single-lane stdio workers like `local-mcp`
- daemon cleanup should use cached lifecycle state instead of competing with foreground requests

## How
- add lifecycle declaration/snapshot types in the MCP stdio client and daemon session state
- consume lifecycle notifications internally and drive idle cleanup from cached state
- default undeclared workers to `safe_idle_reap`, and require explicit `auto_reap_allowed=true` for `stateful` workers

## Testing
- `cargo check -q`
- `cargo fmt --all`
- `cargo test daemon_sessions_expose_stateful_lifecycle_contract_when_idle_reap_is_deferred --test daemon_reuse_test -- --test-threads=1`
- `cargo test stateful_session_with_auto_reap_allowed_is_reaped_before_reuse --test daemon_reuse_test -- --test-threads=1`
- `cargo test stateful_session_without_snapshot_is_kept_for_reuse --test daemon_reuse_test -- --test-threads=1`
- `cargo test --test daemon_reuse_test -- --test-threads=1`
- `cargo test daemon_log_contains_lifecycle_snapshot_metadata_for_stateful_stdio_sessions --test daemon_logging_test -- --nocapture --test-threads=1`
- `cargo test --test daemon_logging_test -- --test-threads=1`
- `cargo test --test codegen_schema_cli_test -- --test-threads=1`