### PR TITLE
fix: preserve stdio request cwd across daemon start

### DIFF
--- a/src/adapters/mcp/transport.rs
+++ b/src/adapters/mcp/transport.rs
@@ -39,6 +39,7 @@ pub trait StdioProcessExecutor: Send + Sync {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct StdioSpawnOptions {
     pub env_overrides: Vec<(String, String)>,
+    pub cwd: Option<PathBuf>,
 }
 
 /// Result of spawning a process
@@ -88,14 +89,25 @@ impl StdioProcessExecutor for DefaultStdioProcessExecutor {
                 .collect::<Vec<_>>();
             tracing::debug!("Injecting child env vars for MCP stdio: {:?}", env_names);
         }
+        if let Some(cwd) = options.cwd.as_ref() {
+            tracing::debug!(
+                "Using child working directory for MCP stdio: {}",
+                cwd.display()
+            );
+        }
 
         // Spawn the process
-        let mut child = Command::new(cmd)
+        let mut command = Command::new(cmd);
+        command
             .args(&full_args)
             .envs(options.env_overrides.iter().cloned())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::piped());
+        if let Some(cwd) = options.cwd.as_ref() {
+            command.current_dir(cwd);
+        }
+        let mut child = command
             .spawn()
             .context("Failed to spawn MCP server process")?;
 
@@ -1320,6 +1332,7 @@ mod tests {
         let mock = Arc::new(MockStdioExecutor::new());
         let options = StdioSpawnOptions {
             env_overrides: vec![("TOKEN".to_string(), "secret".to_string())],
+            cwd: None,
         };
         let _ = McpStdioTransport::connect_with_executor("test", &[], options, mock.clone()).await;
         let captured = mock.captured_env_overrides.lock().unwrap().clone();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -160,6 +160,8 @@ pub struct RuntimeInvokeOptions {
     pub daemon_idle_ttl: Option<u64>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub request_headers: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -4060,6 +4062,7 @@ impl DaemonRuntime {
                 &request.endpoint,
                 auth_profile.as_ref(),
                 &request.options.inject_env,
+                request.options.cwd.as_deref(),
             )?;
             self.mcp.get_stdio(&key).await.is_some()
         } else if adapters::mcp::McpAdapter::is_http_url(&request.endpoint) {
@@ -4113,8 +4116,12 @@ impl DaemonRuntime {
                         .unwrap_or_default()
                 }
             };
-            let key =
-                stdio_session_key(endpoint, auth_profile.as_ref(), &request.options.inject_env)?;
+            let key = stdio_session_key(
+                endpoint,
+                auth_profile.as_ref(),
+                &request.options.inject_env,
+                request.options.cwd.as_deref(),
+            )?;
             let (session, reused) = self
                 .mcp
                 .get_or_create_stdio(
@@ -6034,6 +6041,7 @@ async fn run_mcp_subscription_job(
         &request.endpoint,
         auth_profile.as_ref(),
         &request.options.inject_env,
+        request.options.cwd.as_deref(),
     )?;
     let (session, _) = runtime
         .mcp
@@ -7656,12 +7664,14 @@ fn stdio_session_key(
     endpoint: &str,
     profile: Option<&Profile>,
     inject_env: &[InjectEnvSpec],
+    cwd: Option<&str>,
 ) -> Result<String> {
     Ok(format!(
-        "stdio:{}:{}:{}",
+        "stdio:{}:{}:{}:{}",
         endpoint,
         auth_fingerprint(profile),
-        stdio_env_fingerprint(inject_env, profile)?
+        stdio_env_fingerprint(inject_env, profile)?,
+        cwd.unwrap_or("")
     ))
 }
 
@@ -7683,22 +7693,30 @@ fn build_stdio_spawn_options(
     options: &RuntimeInvokeOptions,
     profile: Option<&Profile>,
 ) -> Result<Option<adapters::mcp::StdioSpawnOptions>> {
-    if options.inject_env.is_empty() {
+    let cwd = options.cwd.as_deref().map(PathBuf::from);
+    if options.inject_env.is_empty() && cwd.is_none() {
         return Ok(None);
     }
     if !adapters::mcp::McpAdapter::is_stdio_command(endpoint) {
         return Err(UxcError::InvalidArguments(
-            "--inject-env is only supported for stdio endpoints".to_string(),
+            "--inject-env and request cwd are only supported for stdio endpoints".to_string(),
         )
         .into());
     }
-    let profile = profile.ok_or_else(|| {
-        UxcError::InvalidArguments(
-            "--inject-env requires a credential. Use --auth <credential_id> for direct stdio calls, or --credential <credential_id> when creating a link.".to_string(),
-        )
-    })?;
-    let env_overrides = render_injected_env(&options.inject_env, profile)?;
-    Ok(Some(adapters::mcp::StdioSpawnOptions { env_overrides }))
+    let env_overrides = if options.inject_env.is_empty() {
+        Vec::new()
+    } else {
+        let profile = profile.ok_or_else(|| {
+            UxcError::InvalidArguments(
+                "--inject-env requires a credential. Use --auth <credential_id> for direct stdio calls, or --credential <credential_id> when creating a link.".to_string(),
+            )
+        })?;
+        render_injected_env(&options.inject_env, profile)?
+    };
+    Ok(Some(adapters::mcp::StdioSpawnOptions {
+        env_overrides,
+        cwd,
+    }))
 }
 
 fn normalize_exclusive_keys(keys: &[String]) -> Vec<String> {
@@ -8259,8 +8277,12 @@ async fn invoke_live_stdio_mcp_help(
         return Ok(None);
     }
 
-    let session_key =
-        stdio_session_key(&request.endpoint, auth_profile, &request.options.inject_env)?;
+    let session_key = stdio_session_key(
+        &request.endpoint,
+        auth_profile,
+        &request.options.inject_env,
+        request.options.cwd.as_deref(),
+    )?;
     let Some(session) = runtime.mcp.get_stdio(&session_key).await else {
         return Ok(None);
     };
@@ -8691,6 +8713,7 @@ mod tests {
                 daemon_exclusive: Vec::new(),
                 daemon_idle_ttl: None,
                 request_headers: HashMap::new(),
+                cwd: None,
             },
         };
 
@@ -8790,6 +8813,7 @@ mod tests {
                 daemon_exclusive: Vec::new(),
                 daemon_idle_ttl: None,
                 request_headers: HashMap::new(),
+                cwd: None,
             },
         };
 
@@ -8866,6 +8890,7 @@ mod tests {
                 daemon_exclusive: Vec::new(),
                 daemon_idle_ttl: None,
                 request_headers: HashMap::new(),
+                cwd: None,
             },
         };
 
@@ -8899,6 +8924,7 @@ mod tests {
                 daemon_exclusive: Vec::new(),
                 daemon_idle_ttl: None,
                 request_headers: HashMap::new(),
+                cwd: None,
             },
         };
 
@@ -9015,6 +9041,7 @@ mod tests {
                 daemon_exclusive: Vec::new(),
                 daemon_idle_ttl: None,
                 request_headers: HashMap::new(),
+                cwd: None,
             },
         }
     }
@@ -9047,6 +9074,7 @@ mod tests {
                 daemon_exclusive: Vec::new(),
                 daemon_idle_ttl: None,
                 request_headers: HashMap::new(),
+                cwd: None,
             },
         }
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1849,31 +1849,8 @@ impl McpSessionManager {
                     }
                     let key = conflicting.unwrap_or_else(|| "<unknown>".to_string());
 
-                    // session_key format: "stdio:{endpoint}:{auth_fingerprint}[:{env_fingerprint}]"
-                    // endpoint can contain ":", so parse from the last ":".
-                    // With env fingerprint, we need to handle: "stdio:endpoint:auth_fp:env_fp"
-                    // Without env fingerprint: "stdio:endpoint:auth_fp"
-                    // Split from the end twice to handle both cases.
-                    let (owner_endpoint, owner_auth_fp, owner_env_fp) = match owner_session_key
-                        .strip_prefix("stdio:")
-                    {
-                        Some(rest) => {
-                            // Try splitting twice for env fingerprint format
-                            if let Some((before_env, _env_fp)) = rest.rsplit_once(':') {
-                                if let Some((before_auth, auth_fp)) = before_env.rsplit_once(':') {
-                                    // Has both auth and env fingerprints
-                                    (Some(before_auth), Some(auth_fp), Some(_env_fp))
-                                } else {
-                                    // Only has auth fingerprint, env_fp was actually endpoint
-                                    (Some(before_env), Some(_env_fp), None)
-                                }
-                            } else {
-                                // No fingerprint at all
-                                (Some(rest), None, None)
-                            }
-                        }
-                        None => (None, None, None),
-                    };
+                    let (owner_endpoint, owner_auth_fp, owner_env_fp, _owner_cwd) =
+                        parse_stdio_session_key(&owner_session_key);
                     let owner_endpoint = owner_endpoint
                         .map(redact_endpoint)
                         .map(|s| redact_sensitive(&s));
@@ -7675,6 +7652,24 @@ fn stdio_session_key(
     ))
 }
 
+fn parse_stdio_session_key(
+    session_key: &str,
+) -> (Option<&str>, Option<&str>, Option<&str>, Option<&str>) {
+    let Some(rest) = session_key.strip_prefix("stdio:") else {
+        return (None, None, None, None);
+    };
+    let Some((before_cwd, cwd)) = rest.rsplit_once(':') else {
+        return (Some(rest), None, None, None);
+    };
+    let Some((before_env, env_fp)) = before_cwd.rsplit_once(':') else {
+        return (Some(before_cwd), Some(cwd), None, None);
+    };
+    let Some((endpoint, auth_fp)) = before_env.rsplit_once(':') else {
+        return (Some(before_env), Some(env_fp), Some(cwd), None);
+    };
+    (Some(endpoint), Some(auth_fp), Some(env_fp), Some(cwd))
+}
+
 fn http_session_lookup_key(endpoint: &str, profile: Option<&Profile>) -> String {
     format!("http_lookup:{}:{}", endpoint, auth_fingerprint(profile))
 }
@@ -7693,15 +7688,18 @@ fn build_stdio_spawn_options(
     options: &RuntimeInvokeOptions,
     profile: Option<&Profile>,
 ) -> Result<Option<adapters::mcp::StdioSpawnOptions>> {
+    if !adapters::mcp::McpAdapter::is_stdio_command(endpoint) {
+        if options.inject_env.is_empty() {
+            return Ok(None);
+        }
+        return Err(UxcError::InvalidArguments(
+            "--inject-env is only supported for stdio endpoints".to_string(),
+        )
+        .into());
+    }
     let cwd = options.cwd.as_deref().map(PathBuf::from);
     if options.inject_env.is_empty() && cwd.is_none() {
         return Ok(None);
-    }
-    if !adapters::mcp::McpAdapter::is_stdio_command(endpoint) {
-        return Err(UxcError::InvalidArguments(
-            "--inject-env and request cwd are only supported for stdio endpoints".to_string(),
-        )
-        .into());
     }
     let env_overrides = if options.inject_env.is_empty() {
         Vec::new()
@@ -8730,6 +8728,70 @@ mod tests {
         assert!(display.starts_with("stdio:"));
         assert!(!display.contains("example.com"));
         assert!(!display.contains("secret"));
+    }
+
+    #[test]
+    fn parse_stdio_session_key_supports_cwd_segment() {
+        let (endpoint, auth_fp, env_fp, cwd) =
+            parse_stdio_session_key("stdio:./mcp-stdio-rel ok:auth123:env456:/tmp/workdir");
+        assert_eq!(endpoint, Some("./mcp-stdio-rel ok"));
+        assert_eq!(auth_fp, Some("auth123"));
+        assert_eq!(env_fp, Some("env456"));
+        assert_eq!(cwd, Some("/tmp/workdir"));
+    }
+
+    #[test]
+    fn build_stdio_spawn_options_ignores_cwd_for_non_stdio_endpoints() {
+        let options = RuntimeInvokeOptions {
+            auth: None,
+            inject_env: Vec::new(),
+            no_cache: false,
+            cache_ttl: None,
+            timeout_ms: None,
+            refresh_schema: false,
+            schema_url: None,
+            link_name: None,
+            link_skill: None,
+            link_skill_doc: None,
+            link_skill_path: None,
+            schema_mapping_file: None,
+            daemon_exclusive: Vec::new(),
+            daemon_idle_ttl: None,
+            request_headers: HashMap::new(),
+            cwd: Some("/tmp/workdir".to_string()),
+        };
+
+        let options = build_stdio_spawn_options("https://api.example.com", &options, None)
+            .expect("non-stdio requests should ignore cwd");
+        assert!(options.is_none());
+    }
+
+    #[test]
+    fn build_stdio_spawn_options_still_rejects_inject_env_for_non_stdio_endpoints() {
+        let options = RuntimeInvokeOptions {
+            auth: None,
+            inject_env: vec![InjectEnvSpec::parse("TOKEN={{secret}}").expect("valid inject env")],
+            no_cache: false,
+            cache_ttl: None,
+            timeout_ms: None,
+            refresh_schema: false,
+            schema_url: None,
+            link_name: None,
+            link_skill: None,
+            link_skill_doc: None,
+            link_skill_path: None,
+            schema_mapping_file: None,
+            daemon_exclusive: Vec::new(),
+            daemon_idle_ttl: None,
+            request_headers: HashMap::new(),
+            cwd: Some("/tmp/workdir".to_string()),
+        };
+
+        let err = build_stdio_spawn_options("https://api.example.com", &options, None)
+            .expect_err("inject-env should still be rejected for non-stdio endpoints");
+        assert!(err
+            .to_string()
+            .contains("--inject-env is only supported for stdio endpoints"));
     }
 
     #[test]

--- a/src/daemon_client.rs
+++ b/src/daemon_client.rs
@@ -29,6 +29,7 @@ pub struct DaemonClientOptions {
     pub daemon_exclusive: Vec<String>,
     pub daemon_idle_ttl: Option<u64>,
     pub request_headers: HashMap<String, String>,
+    pub cwd: Option<String>,
 }
 
 impl From<DaemonClientOptions> for RuntimeInvokeOptions {
@@ -49,6 +50,7 @@ impl From<DaemonClientOptions> for RuntimeInvokeOptions {
             daemon_exclusive: value.daemon_exclusive,
             daemon_idle_ttl: value.daemon_idle_ttl,
             request_headers: value.request_headers,
+            cwd: value.cwd,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1979,6 +1979,9 @@ async fn execute_endpoint_via_daemon(
             daemon_exclusive: collect_daemon_exclusive_keys(cli)?,
             daemon_idle_ttl: collect_daemon_idle_ttl(cli)?,
             request_headers: HashMap::new(),
+            cwd: std::env::current_dir()
+                .ok()
+                .map(|path| path.to_string_lossy().into_owned()),
         },
     };
 
@@ -5799,6 +5802,9 @@ async fn handle_subscribe_command(
                     daemon_exclusive: collect_daemon_exclusive_keys(cli)?,
                     daemon_idle_ttl: collect_daemon_idle_ttl(cli)?,
                     request_headers: HashMap::new(),
+                    cwd: std::env::current_dir()
+                        .ok()
+                        .map(|path| path.to_string_lossy().into_owned()),
                 },
             };
             let data = serde_json::to_value(daemon::subscribe_start_client(&request).await?)?;
@@ -6114,6 +6120,9 @@ fn build_managed_source_spec(
             daemon_exclusive: collect_daemon_exclusive_keys(cli)?,
             daemon_idle_ttl: collect_daemon_idle_ttl(cli)?,
             request_headers: HashMap::new(),
+            cwd: std::env::current_dir()
+                .ok()
+                .map(|path| path.to_string_lossy().into_owned()),
         },
     })
 }

--- a/tests/daemon_reuse_test.rs
+++ b/tests/daemon_reuse_test.rs
@@ -259,6 +259,65 @@ fn daemon_sessions_surface_link_source_metadata() {
     daemon_stop_best_effort();
 }
 
+#[cfg(unix)]
+#[test]
+#[serial]
+fn daemon_start_preserves_request_cwd_for_relative_stdio_endpoint_commands() {
+    let home = common::fresh_test_home_dir();
+    daemon_stop_best_effort_with_home(&home);
+
+    let workdir = tempfile::tempdir().expect("tempdir should be created");
+    let server = test_server_binary("mcp-stdio");
+    let relative_server = workdir.path().join("mcp-stdio-rel");
+    std::os::unix::fs::symlink(&server, &relative_server).expect("symlink should be created");
+    let endpoint = "./mcp-stdio-rel ok";
+
+    let start = uxc_command_with_home(&home)
+        .current_dir(workdir.path())
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("daemon start should run");
+    assert!(start.status.success());
+
+    let cold = uxc_command_with_home(&home)
+        .current_dir(workdir.path())
+        .arg(endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"first"}"#)
+        .output()
+        .expect("cold call should run");
+    assert!(
+        cold.status.success(),
+        "cold call should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&cold.stdout),
+        String::from_utf8_lossy(&cold.stderr)
+    );
+
+    let warm = uxc_command_with_home(&home)
+        .current_dir(workdir.path())
+        .arg(endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"second"}"#)
+        .output()
+        .expect("warm call should run");
+    assert!(
+        warm.status.success(),
+        "warm call should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&warm.stdout),
+        String::from_utf8_lossy(&warm.stderr)
+    );
+
+    let warm_json: serde_json::Value =
+        serde_json::from_slice(&warm.stdout).expect("warm stdout should be valid JSON");
+    assert_eq!(warm_json["ok"], true);
+    assert_eq!(warm_json["meta"]["daemon_session_reused"], true);
+
+    daemon_stop_best_effort_with_home(&home);
+}
+
 #[test]
 #[serial]
 fn daemon_sessions_expose_stateful_lifecycle_contract_when_idle_reap_is_deferred() {


### PR DESCRIPTION
## Summary
- preserve the caller working directory when daemon-backed stdio endpoints spawn child processes
- include request cwd in stdio session identity so daemon reuse stays scoped to the directory-sensitive endpoint invocation
- add a regression test for `daemon start` + relative stdio commands

## Root cause
`uxc daemon start` launches `_serve` from `~/.uxc/daemon`, while a foreground `uxc daemon _serve` inherits the caller cwd. For stdio endpoints that depend on relative paths inside the command line, the daemon-backed child was being spawned from the daemon directory instead of the original request directory. That produced inconsistent behavior between foreground and background daemon modes and could surface as reused sessions that only worked when the daemon was started manually.

## Validation
- `cargo fmt --all`
- `cargo check --bin uxc`
- `cargo test --test daemon_reuse_test daemon_start_preserves_request_cwd_for_relative_stdio_endpoint_commands -- --nocapture`

Refs #368
