### PR TITLE
feat(source): add managed source overview surfaces

### DIFF
--- a/packages/uxc-daemon-client/src/index.ts
+++ b/packages/uxc-daemon-client/src/index.ts
@@ -163,6 +163,16 @@ export interface ManagedSourceView {
   last_error?: string | null;
 }
 
+export interface ManagedSourceListEntry {
+  namespace: string;
+  source_key: string;
+  status: string;
+  run_id: string;
+  stream_id: string;
+  updated_at_unix: number;
+  last_error?: string | null;
+}
+
 export interface ManagedSourceStopResponse {
   namespace: string;
   source_key: string;
@@ -239,6 +249,9 @@ export interface DaemonStatus {
   mcp_stdio_sessions: number;
   mcp_http_sessions: number;
   mcp_reuse_hits: number;
+  managed_sources: number;
+  managed_sources_running: number;
+  managed_streams: number;
   log_file?: string | null;
 }
 
@@ -476,6 +489,10 @@ export class UxcDaemonClient {
       namespace,
       source_key: sourceKey,
     });
+  }
+
+  async sourceList(): Promise<ManagedSourceListEntry[]> {
+    return this.request("source.list");
   }
 
   async sourceStop(namespace: string, sourceKey: string): Promise<ManagedSourceStopResponse> {

--- a/packages/uxc-daemon-client/test/client.test.ts
+++ b/packages/uxc-daemon-client/test/client.test.ts
@@ -303,6 +303,16 @@ describe("UxcDaemonClient", () => {
       expect(status.source_key).toBe(sourceKey);
       expect(status.stream_id).toBe(ensured.stream_id);
 
+      const listed = await client.sourceList();
+      expect(
+        listed.some(
+          (entry) =>
+            entry.namespace === namespace &&
+            entry.source_key === sourceKey &&
+            entry.stream_id === ensured.stream_id,
+        ),
+      ).toBe(true);
+
       const initialRead = await waitForManagedStreamEvent(client, ensured.stream_id);
       expect(initialRead.events[0]?.raw_payload).toEqual({ value: 42 });
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -804,6 +804,7 @@ struct SubscriptionManager {
     terminal_jobs: Arc<Mutex<HashMap<String, TerminalSubscriptionEntry>>>,
     next_id: Arc<Mutex<u64>>,
     store_path: PathBuf,
+    memory_sink_dir: PathBuf,
 }
 
 #[derive(Clone)]
@@ -2133,14 +2134,24 @@ fn resolve_stream_subscription_protocol(request: &SubscribeStartRequest) -> Resu
 
 impl SubscriptionManager {
     fn new(store_path: PathBuf) -> Result<Self> {
+        let memory_sink_dir = store_path
+            .parent()
+            .map(PathBuf::from)
+            .unwrap_or_else(daemon_dir)
+            .join("subscription-events");
         let manager = Self {
             jobs: Arc::new(Mutex::new(HashMap::new())),
             terminal_jobs: Arc::new(Mutex::new(HashMap::new())),
             next_id: Arc::new(Mutex::new(0)),
             store_path,
+            memory_sink_dir,
         };
         manager.load_persisted_records()?;
         Ok(manager)
+    }
+
+    fn internal_memory_sink_path(&self, job_id: &str) -> PathBuf {
+        self.memory_sink_dir.join(format!("{}.ndjson", job_id))
     }
 
     fn load_persisted_records(&self) -> Result<()> {
@@ -2570,8 +2581,22 @@ impl SubscriptionManager {
         };
         let sink_path = match prepared.sink {
             PreparedSubscriptionSink::File(path) => path,
-            PreparedSubscriptionSink::Memory => internal_memory_sink_path(&job_id),
+            PreparedSubscriptionSink::Memory => self.internal_memory_sink_path(&job_id),
         };
+        if sink_is_memory(&request.sink) {
+            match fs::remove_file(&sink_path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == ErrorKind::NotFound => {}
+                Err(err) => {
+                    return Err(err).with_context(|| {
+                        format!(
+                            "Failed to reset in-memory subscription sink {}",
+                            sink_path.display()
+                        )
+                    });
+                }
+            }
+        }
         let now = now_unix_secs();
         let view = Arc::new(Mutex::new(SubscriptionJobView {
             job_id: job_id.clone(),
@@ -4268,12 +4293,6 @@ fn parse_file_sink(spec: &str) -> Result<PathBuf> {
     let path = PathBuf::from(path);
     validate_subscription_sink_path(&path)?;
     Ok(path)
-}
-
-fn internal_memory_sink_path(job_id: &str) -> PathBuf {
-    daemon_dir()
-        .join("subscription-events")
-        .join(format!("{}.ndjson", job_id))
 }
 
 fn sink_is_memory(spec: &str) -> bool {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -384,6 +384,17 @@ pub struct ManagedSourceView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedSourceListEntry {
+    pub namespace: String,
+    pub source_key: String,
+    pub status: String,
+    pub run_id: String,
+    pub stream_id: String,
+    pub updated_at_unix: u64,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManagedSourceStopResponse {
     pub namespace: String,
     pub source_key: String,
@@ -518,6 +529,9 @@ pub struct DaemonStatus {
     pub mcp_stdio_sessions: usize,
     pub mcp_http_sessions: usize,
     pub mcp_reuse_hits: u64,
+    pub managed_sources: usize,
+    pub managed_sources_running: usize,
+    pub managed_streams: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_file: Option<String>,
 }
@@ -2897,6 +2911,20 @@ impl ManagedSourceManager {
         Ok(view_from_record(&record))
     }
 
+    async fn list(&self) -> Result<Vec<ManagedSourceListEntry>> {
+        let records = self.store.load_sources().await?;
+        Ok(records.iter().map(list_entry_from_record).collect())
+    }
+
+    async fn summary(&self) -> Result<(usize, usize, usize)> {
+        let summary = self.store.summary().await?;
+        Ok((
+            summary.source_count,
+            summary.running_source_count,
+            summary.stream_count,
+        ))
+    }
+
     async fn stop(
         &self,
         runtime: &DaemonRuntime,
@@ -3382,6 +3410,18 @@ fn view_from_record(record: &ManagedSourceRecord) -> ManagedSourceView {
     }
 }
 
+fn list_entry_from_record(record: &ManagedSourceRecord) -> ManagedSourceListEntry {
+    ManagedSourceListEntry {
+        namespace: record.namespace.clone(),
+        source_key: record.source_key.clone(),
+        status: record.status.clone(),
+        run_id: record.run_id.clone(),
+        stream_id: record.stream_id.clone(),
+        updated_at_unix: record.updated_at_unix,
+        last_error: record.last_error.clone(),
+    }
+}
+
 fn stream_event_view(record: StreamEventRecord) -> ManagedStreamEvent {
     ManagedStreamEvent {
         stream_id: record.stream_id,
@@ -3839,6 +3879,8 @@ impl DaemonRuntime {
     pub async fn status(&self) -> DaemonStatus {
         let state = self.state.lock().await;
         let (stdio_sessions, http_sessions, reuse_hits) = self.mcp.status_counts().await;
+        let (managed_sources, managed_sources_running, managed_streams) =
+            self.managed_sources.summary().await.unwrap_or((0, 0, 0));
         let log_file: Option<String> = self
             .logger
             .as_ref()
@@ -3853,12 +3895,19 @@ impl DaemonRuntime {
             mcp_stdio_sessions: stdio_sessions,
             mcp_http_sessions: http_sessions,
             mcp_reuse_hits: reuse_hits,
+            managed_sources,
+            managed_sources_running,
+            managed_streams,
             log_file,
         }
     }
 
     pub async fn session_views(&self) -> Vec<DaemonSessionView> {
         self.mcp.session_views().await
+    }
+
+    pub async fn source_list(&self) -> Result<Vec<ManagedSourceListEntry>> {
+        self.managed_sources.list().await
     }
 
     pub async fn subscribe_start(
@@ -6453,6 +6502,17 @@ pub async fn source_status_client(
 }
 
 #[cfg(unix)]
+pub async fn source_list_client() -> Result<Vec<ManagedSourceListEntry>> {
+    let value = client_call("source.list", None).await?;
+    Ok(serde_json::from_value(value)?)
+}
+
+#[cfg(not(unix))]
+pub async fn source_list_client() -> Result<Vec<ManagedSourceListEntry>> {
+    bail!("uxcd daemon is not supported on this platform; run uxc inside WSL")
+}
+
+#[cfg(unix)]
 pub async fn source_stop_client(
     request: &ManagedSourceStatusRequest,
 ) -> Result<ManagedSourceStopResponse> {
@@ -7090,6 +7150,20 @@ async fn handle_connection(mut stream: UnixStream, runtime: Arc<DaemonRuntime>) 
                 },
             }
         }
+        "source.list" => match runtime.source_list().await {
+            Ok(result) => JsonRpcResponse {
+                jsonrpc: JSONRPC_VERSION.to_string(),
+                id: req.id,
+                result: Some(serde_json::to_value(result)?),
+                error: None,
+            },
+            Err(err) => JsonRpcResponse {
+                jsonrpc: JSONRPC_VERSION.to_string(),
+                id: req.id,
+                result: None,
+                error: Some(jsonrpc_error_from_anyhow(&err)),
+            },
+        },
         "source.stop" => {
             let Some(params) = req.params else {
                 let resp = JsonRpcResponse {
@@ -9655,6 +9729,68 @@ mod tests {
             .any(|event| event.raw_payload == json!({"value":"persisted"})));
 
         server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn managed_source_list_and_daemon_status_expose_overview_counts() {
+        let temp = tempdir().unwrap();
+        let (endpoint_one, _connects_one, server_task_one) =
+            start_test_websocket_server(vec![TestWsConnectionPlan {
+                frames: vec![TestWsFrame::Text(r#"{"value":"one"}"#)],
+                hold_open_after_send: true,
+            }])
+            .await;
+        let (endpoint_two, _connects_two, server_task_two) =
+            start_test_websocket_server(vec![TestWsConnectionPlan {
+                frames: vec![TestWsFrame::Text(r#"{"value":"two"}"#)],
+                hold_open_after_send: true,
+            }])
+            .await;
+
+        let runtime = test_runtime_with_store(&temp);
+        runtime
+            .source_ensure(ManagedSourceEnsureRequest {
+                namespace: "team".to_string(),
+                source_key: "alpha".to_string(),
+                spec: managed_source_spec(&endpoint_one),
+            })
+            .await
+            .unwrap();
+        runtime
+            .source_ensure(ManagedSourceEnsureRequest {
+                namespace: "team".to_string(),
+                source_key: "beta".to_string(),
+                spec: managed_source_spec(&endpoint_two),
+            })
+            .await
+            .unwrap();
+
+        let sources = runtime.source_list().await.unwrap();
+        assert_eq!(sources.len(), 2);
+        assert_eq!(sources[0].namespace, "team");
+        assert_eq!(sources[0].source_key, "alpha");
+        assert_eq!(sources[1].source_key, "beta");
+
+        let status = runtime.status().await;
+        assert_eq!(status.managed_sources, 2);
+        assert_eq!(status.managed_sources_running, 2);
+        assert_eq!(status.managed_streams, 2);
+
+        runtime
+            .source_stop(&ManagedSourceStatusRequest {
+                namespace: "team".to_string(),
+                source_key: "beta".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let status_after_stop = runtime.status().await;
+        assert_eq!(status_after_stop.managed_sources, 2);
+        assert_eq!(status_after_stop.managed_sources_running, 1);
+        assert_eq!(status_after_stop.managed_streams, 2);
+
+        server_task_one.abort();
+        server_task_two.abort();
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,8 +14,8 @@ use crate::error::{
     StructuredErrorPayload, UxcError,
 };
 use crate::managed_source_streams::{
-    ManagedSourceRecord, ManagedSourceStore, SourceRuntimeUpdate, StreamEventRecord,
-    StreamInfoRecord,
+    ManagedSourceListRecord, ManagedSourceRecord, ManagedSourceStore, SourceRuntimeUpdate,
+    StreamEventRecord, StreamInfoRecord,
 };
 use crate::subscription_discord::{
     derive_gateway_bot_endpoint, parse_gateway_bot_response, prepare_gateway_websocket_url,
@@ -2912,8 +2912,8 @@ impl ManagedSourceManager {
     }
 
     async fn list(&self) -> Result<Vec<ManagedSourceListEntry>> {
-        let records = self.store.load_sources().await?;
-        Ok(records.iter().map(list_entry_from_record).collect())
+        let records = self.store.load_source_list_records().await?;
+        Ok(records.iter().map(list_entry_from_list_record).collect())
     }
 
     async fn summary(&self) -> Result<(usize, usize, usize)> {
@@ -3410,7 +3410,7 @@ fn view_from_record(record: &ManagedSourceRecord) -> ManagedSourceView {
     }
 }
 
-fn list_entry_from_record(record: &ManagedSourceRecord) -> ManagedSourceListEntry {
+fn list_entry_from_list_record(record: &ManagedSourceListRecord) -> ManagedSourceListEntry {
     ManagedSourceListEntry {
         namespace: record.namespace.clone(),
         source_key: record.source_key.clone(),
@@ -3880,7 +3880,16 @@ impl DaemonRuntime {
         let state = self.state.lock().await;
         let (stdio_sessions, http_sessions, reuse_hits) = self.mcp.status_counts().await;
         let (managed_sources, managed_sources_running, managed_streams) =
-            self.managed_sources.summary().await.unwrap_or((0, 0, 0));
+            match self.managed_sources.summary().await {
+                Ok(summary) => summary,
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        "Failed to summarize managed sources for daemon status"
+                    );
+                    (0, 0, 0)
+                }
+            };
         let log_file: Option<String> = self
             .logger
             .as_ref()

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -529,8 +529,11 @@ pub struct DaemonStatus {
     pub mcp_stdio_sessions: usize,
     pub mcp_http_sessions: usize,
     pub mcp_reuse_hits: u64,
+    #[serde(default)]
     pub managed_sources: usize,
+    #[serde(default)]
     pub managed_sources_running: usize,
+    #[serde(default)]
     pub managed_streams: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_file: Option<String>,

--- a/src/daemon_client.rs
+++ b/src/daemon_client.rs
@@ -1,12 +1,12 @@
 use crate::auth::injected_env::InjectEnvSpec;
 use crate::daemon::{
     self, DaemonSessionView, DaemonStatus, ManagedSourceEnsureRequest, ManagedSourceEnsureResponse,
-    ManagedSourceSpec, ManagedSourceStatusRequest, ManagedSourceStopResponse, ManagedSourceView,
-    ManagedStreamInfo, ManagedStreamReadRequest, ManagedStreamReadResponse,
-    ManagedStreamTrimRequest, ManagedStreamTrimResponse, RuntimeAction, RuntimeInvokeOptions,
-    RuntimeInvokeRequest, RuntimeInvokeResponse, SubscribeStartRequest, SubscribeStartResponse,
-    SubscribeStopResponse, SubscriptionEventsRequest, SubscriptionEventsResponse,
-    SubscriptionJobView, SubscriptionMode, SubscriptionTransportHint,
+    ManagedSourceListEntry, ManagedSourceSpec, ManagedSourceStatusRequest,
+    ManagedSourceStopResponse, ManagedSourceView, ManagedStreamInfo, ManagedStreamReadRequest,
+    ManagedStreamReadResponse, ManagedStreamTrimRequest, ManagedStreamTrimResponse, RuntimeAction,
+    RuntimeInvokeOptions, RuntimeInvokeRequest, RuntimeInvokeResponse, SubscribeStartRequest,
+    SubscribeStartResponse, SubscribeStopResponse, SubscriptionEventsRequest,
+    SubscriptionEventsResponse, SubscriptionJobView, SubscriptionMode, SubscriptionTransportHint,
 };
 use anyhow::Result;
 use serde_json::Value;
@@ -183,6 +183,10 @@ impl DaemonClient {
             source_key: source_key.into(),
         })
         .await
+    }
+
+    pub async fn source_list(&self) -> Result<Vec<ManagedSourceListEntry>> {
+        daemon::source_list_client().await
     }
 
     pub async fn source_stop(

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,6 +367,8 @@ enum SubscribeCommands {
 
 #[derive(Subcommand)]
 enum SourceCommands {
+    /// List managed sources
+    List,
     /// Ensure a managed source exists and is running
     Ensure {
         #[arg(value_name = "NAMESPACE")]
@@ -1115,6 +1117,11 @@ struct SubscribeListData {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+struct SourceListData {
+    sources: Vec<daemon::ManagedSourceListEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 struct LinkCreateData {
     name: String,
     host: String,
@@ -1669,6 +1676,7 @@ fn static_help_path_from_cli(cli: &Cli) -> Option<Vec<&'static str>> {
             SubscribeCommands::Stop { .. } => Some(vec!["subscribe", "stop"]),
         },
         Some(Commands::Source { source_command }) => match source_command {
+            SourceCommands::List => Some(vec!["source", "list"]),
             SourceCommands::Ensure { .. } => Some(vec!["source", "ensure"]),
             SourceCommands::Status { .. } => Some(vec!["source", "status"]),
             SourceCommands::Stop { .. } => Some(vec!["source", "stop"]),
@@ -2332,8 +2340,9 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
         ["source"] => HelpData {
             path: "uxc source".to_string(),
             about: "Manage daemon-backed source streams".to_string(),
-            usage: "uxc source <ensure|status|stop|delete> ...".to_string(),
+            usage: "uxc source <list|ensure|status|stop|delete> ...".to_string(),
             commands: commands(&[
+                ("list", "List managed sources"),
                 ("ensure", "Ensure a managed source exists and is running"),
                 ("status", "Show a managed source"),
                 ("stop", "Stop a managed source"),
@@ -2345,11 +2354,23 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
                 "Managed source streams are raw-oriented in v1: stream records persist only payload rows, not lifecycle envelopes.".to_string(),
             ],
             examples: vec![
+                "uxc source list".to_string(),
                 "uxc source ensure agentinbox github_repo:holon-run/uxc https://api.github.com get:/repos/{owner}/{repo}/events owner=holon-run repo=uxc --mode poll --poll-config '{\"interval_secs\":30,\"extract_items_pointer\":\"\",\"checkpoint_strategy\":{\"type\":\"item_key\",\"item_key_pointer\":\"/id\"}}'".to_string(),
                 "uxc source status agentinbox github_repo:holon-run/uxc".to_string(),
                 "uxc source stop agentinbox github_repo:holon-run/uxc".to_string(),
                 "uxc source delete agentinbox github_repo:holon-run/uxc".to_string(),
             ],
+        },
+        ["source", "list"] => HelpData {
+            path: "uxc source list".to_string(),
+            about: "List managed sources".to_string(),
+            usage: "uxc source list".to_string(),
+            commands: vec![],
+            notes: vec![
+                "Shows the current managed source bindings so callers can discover namespace/source_key identities before inspecting a single source.".to_string(),
+                "Use `uxc source status <namespace> <source_key>` for detailed single-source state, and `uxc daemon status` for aggregate daemon-wide counts.".to_string(),
+            ],
+            examples: vec!["uxc source list".to_string()],
         },
         ["source", "ensure"] => HelpData {
             path: "uxc source ensure".to_string(),
@@ -5392,6 +5413,9 @@ async fn handle_daemon_command(command: &DaemonCommands) -> Result<OutputEnvelop
                     "socket": daemon::socket_path().display().to_string(),
                     "client_version": env!("CARGO_PKG_VERSION"),
                     "version_mismatch": false,
+                    "managed_sources": 0,
+                    "managed_sources_running": 0,
+                    "managed_streams": 0,
                     "error": {
                         "code": "DAEMON_UNREACHABLE",
                         "message": err.to_string()
@@ -6140,6 +6164,12 @@ async fn handle_source_command(command: &SourceCommands, cli: &Cli) -> Result<Ou
     let daemon_restarted_for_version_mismatch = Some(daemon_ensure.restarted_for_version_mismatch);
 
     let envelope = match command {
+        SourceCommands::List => {
+            let data = serde_json::to_value(SourceListData {
+                sources: daemon::source_list_client().await?,
+            })?;
+            OutputEnvelope::success("source_list", "cli", "uxc", None, data, None)
+        }
         SourceCommands::Ensure {
             namespace,
             source_key,

--- a/src/managed_source_streams.rs
+++ b/src/managed_source_streams.rs
@@ -73,6 +73,17 @@ pub struct ManagedSourceStoreSummary {
 }
 
 #[derive(Debug, Clone)]
+pub struct ManagedSourceListRecord {
+    pub namespace: String,
+    pub source_key: String,
+    pub status: String,
+    pub run_id: String,
+    pub stream_id: String,
+    pub updated_at_unix: u64,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct SourceRuntimeUpdate {
     pub status: String,
     pub updated_at_unix: u64,
@@ -188,6 +199,42 @@ impl ManagedSourceStore {
                 out.push(row?);
             }
             Ok(out)
+        })
+        .await?
+    }
+
+    pub async fn load_source_list_records(&self) -> Result<Vec<ManagedSourceListRecord>> {
+        let _guard = self.gate.lock().await;
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = Connection::open(&path)?;
+            let mut stmt = conn.prepare(
+                r#"
+                select
+                    namespace,
+                    source_key,
+                    status,
+                    run_id,
+                    stream_id,
+                    updated_at_unix,
+                    last_error
+                from managed_sources
+                order by updated_at_unix desc, namespace asc, source_key asc
+                "#,
+            )?;
+            let rows = stmt.query_map([], |row| {
+                Ok(ManagedSourceListRecord {
+                    namespace: row.get(0)?,
+                    source_key: row.get(1)?,
+                    status: row.get(2)?,
+                    run_id: row.get(3)?,
+                    stream_id: row.get(4)?,
+                    updated_at_unix: row.get(5)?,
+                    last_error: row.get(6)?,
+                })
+            })?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(Into::into)
         })
         .await?
     }

--- a/src/managed_source_streams.rs
+++ b/src/managed_source_streams.rs
@@ -66,6 +66,13 @@ pub struct StreamInfoRecord {
 }
 
 #[derive(Debug, Clone)]
+pub struct ManagedSourceStoreSummary {
+    pub source_count: usize,
+    pub running_source_count: usize,
+    pub stream_count: usize,
+}
+
+#[derive(Debug, Clone)]
 pub struct SourceRuntimeUpdate {
     pub status: String,
     pub updated_at_unix: u64,
@@ -181,6 +188,29 @@ impl ManagedSourceStore {
                 out.push(row?);
             }
             Ok(out)
+        })
+        .await?
+    }
+
+    pub async fn summary(&self) -> Result<ManagedSourceStoreSummary> {
+        let _guard = self.gate.lock().await;
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = Connection::open(&path)?;
+            let source_count: usize =
+                conn.query_row("select count(*) from managed_sources", [], |row| row.get(0))?;
+            let running_source_count: usize = conn.query_row(
+                "select count(*) from managed_sources where status = 'running'",
+                [],
+                |row| row.get(0),
+            )?;
+            let stream_count: usize =
+                conn.query_row("select count(*) from event_streams", [], |row| row.get(0))?;
+            Ok(ManagedSourceStoreSummary {
+                source_count,
+                running_source_count,
+                stream_count,
+            })
         })
         .await?
     }

--- a/tests/cli_help_regression_test.rs
+++ b/tests/cli_help_regression_test.rs
@@ -838,7 +838,25 @@ fn source_help_flag_outputs_subcommand_help_json() {
     assert!(json["data"]["usage"]
         .as_str()
         .unwrap_or_default()
-        .contains("uxc source <ensure|status|stop|delete>"));
+        .contains("uxc source <list|ensure|status|stop|delete>"));
+}
+
+#[test]
+#[serial]
+fn source_list_help_flag_outputs_subcommand_help_json() {
+    let output = uxc_command()
+        .arg("source")
+        .arg("list")
+        .arg("--help")
+        .output()
+        .expect("failed to run uxc source list --help");
+    assert!(output.status.success(), "command should succeed");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["kind"], "subcommand_help");
+    assert_eq!(json["data"]["path"], "uxc source list");
+    assert_eq!(json["data"]["usage"], "uxc source list");
 }
 
 #[test]

--- a/tests/daemon_cli_test.rs
+++ b/tests/daemon_cli_test.rs
@@ -35,6 +35,9 @@ fn daemon_start_status_stop_lifecycle() {
     assert_eq!(json["data"]["version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["data"]["client_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["data"]["version_mismatch"], false);
+    assert!(json["data"]["managed_sources"].is_number());
+    assert!(json["data"]["managed_sources_running"].is_number());
+    assert!(json["data"]["managed_streams"].is_number());
 
     let stop = uxc_command()
         .arg("daemon")
@@ -54,6 +57,9 @@ fn daemon_start_status_stop_lifecycle() {
         serde_json::from_slice(&status_after_stop.stdout).expect("valid json");
     assert_eq!(json_after_stop["ok"], true);
     assert_eq!(json_after_stop["data"]["running"], false);
+    assert_eq!(json_after_stop["data"]["managed_sources"], 0);
+    assert_eq!(json_after_stop["data"]["managed_sources_running"], 0);
+    assert_eq!(json_after_stop["data"]["managed_streams"], 0);
     assert!(json_after_stop["data"]["error"]["message"]
         .as_str()
         .is_some_and(|v| !v.is_empty()));


### PR DESCRIPTION
## What
Add managed source overview surfaces to the daemon and client APIs.

## Why
Managed sources already have per-source detail via `uxc source status`, but there is no good top-level way to discover them or see whether the daemon is managing any at all.

Closes #372

## How
Added aggregate managed-source counts to `uxc daemon status`, introduced a new `source.list` daemon RPC plus `uxc source list`, and exposed the new data through both the Rust and TypeScript daemon clients.

## Changes
- [x] Add managed source summary fields to `uxc daemon status`
- [x] Add `source.list` RPC and `uxc source list`
- [x] Expose source list and new daemon status fields in Rust/TS daemon clients
- [x] Add CLI, daemon, and TS client test coverage

## Testing

### Unit Tests
- [x] New tests added where needed
- [ ] Full `cargo test` suite run

### Manual Testing
- [ ] Tested against real APIs
- [x] Tested edge cases relevant to daemon status fallback and source discovery
- [ ] Tested error conditions beyond automated coverage

### Test Results
```bash
cargo check -q
cargo test --test daemon_cli_test daemon_start_status_stop_lifecycle -- --test-threads=1
cargo test managed_source_list_and_daemon_status_expose_overview_counts --lib -- --test-threads=1
cargo test --test cli_help_regression_test -- --test-threads=1
npm test --workspace @holon-run/uxc-daemon-client -- client.test.ts
```

## Checklist

- [x] Code formatted with `cargo fmt`
- [ ] No clippy warnings (`cargo clippy -- -D warnings`)
- [ ] All tests pass (`cargo test`)
- [x] Documentation updated via CLI/help surfaces
- [x] Commit messages follow convention
- [x] PR title follows convention

## Breaking Changes
None.

## Additional Notes
`daemon status` keeps managed-source data at the aggregate level, while `source list` is the new overview surface and `source status` remains the per-source detail surface.
