### PR TITLE
fix(daemon): avoid schema fetch for empty MCP args

### DIFF
--- a/src/arg_coercion.rs
+++ b/src/arg_coercion.rs
@@ -17,6 +17,19 @@ pub async fn prepare_execute_args(
     operation_id: &str,
     raw_args: HashMap<String, Value>,
 ) -> Result<HashMap<String, Value>> {
+    prepare_execute_args_with_adapter(adapter, endpoint, operation_id, raw_args).await
+}
+
+async fn prepare_execute_args_with_adapter<A: Adapter + Sync>(
+    adapter: &A,
+    endpoint: &str,
+    operation_id: &str,
+    raw_args: HashMap<String, Value>,
+) -> Result<HashMap<String, Value>> {
+    if raw_args.is_empty() {
+        return Ok(raw_args);
+    }
+
     let detail = match adapter.describe_operation(endpoint, operation_id).await {
         Ok(detail) => detail,
         Err(_) => return Ok(raw_args),
@@ -598,6 +611,12 @@ fn render_value(value: &Value) -> String {
 mod tests {
     use super::*;
     use crate::adapters::Parameter;
+    use crate::adapters::{Adapter, ExecutionResult};
+    use async_trait::async_trait;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     fn graphql_detail() -> OperationDetail {
         OperationDetail {
@@ -717,5 +736,76 @@ mod tests {
 
         let schema = normalize_openapi_schema(&detail).unwrap();
         assert_eq!(schema.root["properties"]["limit"]["type"], "integer");
+    }
+
+    struct StubAdapter {
+        describe_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Adapter for StubAdapter {
+        fn protocol_type(&self) -> ProtocolType {
+            ProtocolType::Mcp
+        }
+
+        async fn can_handle(&self, _url: &str) -> Result<bool> {
+            Ok(true)
+        }
+
+        async fn fetch_schema(&self, _url: &str) -> Result<Value> {
+            Ok(serde_json::json!({}))
+        }
+
+        async fn list_operations(&self, _url: &str) -> Result<Vec<crate::adapters::Operation>> {
+            Ok(Vec::new())
+        }
+
+        async fn describe_operation(
+            &self,
+            _url: &str,
+            _operation: &str,
+        ) -> Result<OperationDetail> {
+            self.describe_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(OperationDetail {
+                operation_id: "noop".to_string(),
+                display_name: "noop".to_string(),
+                description: None,
+                parameters: Vec::new(),
+                return_type: None,
+                input_schema: None,
+            })
+        }
+
+        async fn execute(
+            &self,
+            _url: &str,
+            _operation: &str,
+            _args: HashMap<String, Value>,
+        ) -> Result<ExecutionResult> {
+            Ok(ExecutionResult {
+                data: Value::Null,
+                metadata: crate::adapters::ExecutionMetadata {
+                    duration_ms: 0,
+                    operation: "noop".to_string(),
+                    response_status_code: None,
+                    response_headers: HashMap::new(),
+                },
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_args_skip_describe_operation() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let stub = StubAdapter {
+            describe_calls: calls.clone(),
+        };
+
+        let result = prepare_execute_args_with_adapter(&stub, "ignored", "noop", HashMap::new())
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 }


### PR DESCRIPTION
Refs #368

## Summary
- skip `describe_operation()` / schema fetch when an execute call has no input args
- keep MCP arg coercion for non-empty payloads
- add a unit test proving the empty-args path does not call `describe_operation`

## Root cause
`uxc` was always running `prepare_execute_args()` before MCP execution. For no-arg tools like `bridge.session.status` and `bridge.open`, that triggered `describe_operation()`, which in turn spawned a temporary stdio MCP client and fetched `tools/list` before the real call. In the `local-mcp` + X bootstrap path this extra schema fetch could stall before the daemon ever created or reused the real stdio session, so the CLI appeared to hang after `runtime_invoke_start`.

## Validation
- `cargo check --bin uxc`
- `cargo test empty_args_skip_describe_operation --lib -- --nocapture`
- isolated real repro with patched binary and `HOME=/tmp/uxc-x-bridge-open-test`
  - cold `bridge.session.status`: success in ~26.5s
  - cold `bridge.open`: success in ~25.6s
  - warm `bridge.session.status`: success in ~0.6s with `daemon_session_reused=true`
  - warm `bridge.open`: success in ~1.0s with `daemon_session_reused=true`
