### PR TITLE
feat(daemon): add session kill command

### DIFF
--- a/packages/uxc-daemon-client/src/index.ts
+++ b/packages/uxc-daemon-client/src/index.ts
@@ -255,6 +255,12 @@ export interface DaemonStatus {
   log_file?: string | null;
 }
 
+export interface DaemonSessionKillResponse {
+  session_key: string;
+  child_pid?: number | null;
+  killed: boolean;
+}
+
 export interface SubscriptionEventsResponse {
   job_id: string;
   status: string;
@@ -360,6 +366,10 @@ export class UxcDaemonClient {
 
   async daemonSessions(): Promise<unknown[]> {
     return this.request("daemon.sessions");
+  }
+
+  async daemonSessionKill(sessionKey: string): Promise<DaemonSessionKillResponse> {
+    return this.request("daemon.session.kill", { session_key: sessionKey });
   }
 
   async call(args: {

--- a/packages/uxc-daemon-client/src/index.ts
+++ b/packages/uxc-daemon-client/src/index.ts
@@ -257,7 +257,7 @@ export interface DaemonStatus {
 
 export interface DaemonSessionKillResponse {
   session_key: string;
-  child_pid?: number | null;
+  child_pid: number | null;
   killed: boolean;
 }
 

--- a/packages/uxc-daemon-client/test/client.test.ts
+++ b/packages/uxc-daemon-client/test/client.test.ts
@@ -50,6 +50,35 @@ describe("UxcDaemonClient", () => {
     expect(status.socket).toContain("uxc.sock");
   });
 
+  test("daemonSessionKill sends daemon.session.kill with session key", async () => {
+    const stub = new UxcDaemonClient({ autoStart: false });
+    const calls: Array<{ method: string; params: unknown }> = [];
+    (stub as unknown as { request: (method: string, params?: unknown) => Promise<unknown> }).request = async (
+      method,
+      params,
+    ) => {
+      calls.push({ method, params });
+      return {
+        session_key: "stdio:0123456789abcdef",
+        child_pid: 4242,
+        killed: true,
+      };
+    };
+
+    const response = await stub.daemonSessionKill("stdio:0123456789abcdef");
+    expect(response).toEqual({
+      session_key: "stdio:0123456789abcdef",
+      child_pid: 4242,
+      killed: true,
+    });
+    expect(calls).toEqual([
+      {
+        method: "daemon.session.kill",
+        params: { session_key: "stdio:0123456789abcdef" },
+      },
+    ]);
+  });
+
   test("call executes OpenAPI operations without CLI envelope parsing", async () => {
     const server = createOpenApiServer();
     await server.start();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -591,6 +591,18 @@ pub struct DaemonSessionView {
     pub recent_stderr: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonSessionKillRequest {
+    pub session_key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonSessionKillResponse {
+    pub session_key: String,
+    pub child_pid: Option<u32>,
+    pub killed: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LifecycleContractView {
     pub reap_policy: adapters::mcp::LifecycleReapPolicy,
@@ -2058,6 +2070,95 @@ impl McpSessionManager {
             .collect::<Vec<_>>();
         views.sort_by(|a, b| a.session_key.cmp(&b.session_key));
         views
+    }
+
+    async fn resolve_stdio_session_key(&self, requested_session_key: &str) -> Result<String> {
+        let map = self.stdio.lock().await;
+        let matches = map
+            .keys()
+            .filter(|session_key| {
+                session_key.as_str() == requested_session_key
+                    || display_session_key(session_key) == requested_session_key
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        drop(map);
+
+        match matches.as_slice() {
+            [session_key] => Ok(session_key.clone()),
+            [] => Err(UxcError::OperationNotFound(format!(
+                "daemon session not found: {}",
+                requested_session_key
+            ))
+            .into()),
+            _ => Err(UxcError::InvalidArguments(format!(
+                "daemon session identifier is ambiguous: {}",
+                requested_session_key
+            ))
+            .into()),
+        }
+    }
+
+    async fn kill_stdio_session(
+        &self,
+        requested_session_key: &str,
+    ) -> Result<DaemonSessionKillResponse> {
+        let session_key = self
+            .resolve_stdio_session_key(requested_session_key)
+            .await?;
+        let session = {
+            let mut map = self.stdio.lock().await;
+            map.remove(&session_key)
+        }
+        .ok_or_else(|| {
+            UxcError::OperationNotFound(format!(
+                "daemon session not found: {}",
+                requested_session_key
+            ))
+        })?;
+
+        let mut guard = session.lock().await;
+        let child_pid = guard.child_pid;
+        let recent_stderr = redact_recent_stderr(guard.client.recent_stderr_lines(5).await);
+        let kill_result = guard
+            .client
+            .kill_and_wait(Duration::from_secs(MCP_STDIO_EXIT_TIMEOUT_SECS))
+            .await;
+        drop(guard);
+
+        self.cleanup_stdio_exclusive_for_session_key(&session_key)
+            .await;
+
+        match kill_result {
+            Ok(()) => {
+                self.remove_stdio_snapshot(&session_key, "explicit_killed", None)
+                    .await;
+                Ok(DaemonSessionKillResponse {
+                    session_key: display_session_key(&session_key),
+                    child_pid,
+                    killed: true,
+                })
+            }
+            Err(err) => {
+                let error_message = format!("failed to kill daemon session: {}", err);
+                self.upsert_stdio_snapshot(&session_key, |snapshot| {
+                    snapshot.reuse_eligible = false;
+                    snapshot.last_error_summary = Some(error_message.clone());
+                    snapshot.recent_stderr = recent_stderr.clone();
+                })
+                .await;
+                self.remove_stdio_snapshot(
+                    &session_key,
+                    "explicit_kill_failed",
+                    Some(error_message.clone()),
+                )
+                .await;
+                Err(err.context(format!(
+                    "Failed to kill daemon session {}",
+                    display_session_key(&session_key)
+                )))
+            }
+        }
     }
 }
 
@@ -3941,6 +4042,13 @@ impl DaemonRuntime {
 
     pub async fn session_views(&self) -> Vec<DaemonSessionView> {
         self.mcp.session_views().await
+    }
+
+    pub async fn session_kill(
+        &self,
+        request: &DaemonSessionKillRequest,
+    ) -> Result<DaemonSessionKillResponse> {
+        self.mcp.kill_stdio_session(&request.session_key).await
     }
 
     pub async fn source_list(&self) -> Result<Vec<ManagedSourceListEntry>> {
@@ -6410,6 +6518,21 @@ pub async fn daemon_sessions_client() -> Result<Vec<DaemonSessionView>> {
 }
 
 #[cfg(unix)]
+pub async fn daemon_session_kill_client(
+    request: &DaemonSessionKillRequest,
+) -> Result<DaemonSessionKillResponse> {
+    let value = client_call("daemon.session.kill", Some(serde_json::to_value(request)?)).await?;
+    Ok(serde_json::from_value(value)?)
+}
+
+#[cfg(not(unix))]
+pub async fn daemon_session_kill_client(
+    _request: &DaemonSessionKillRequest,
+) -> Result<DaemonSessionKillResponse> {
+    bail!("uxcd daemon is not supported on this platform; run uxc inside WSL")
+}
+
+#[cfg(unix)]
 pub async fn daemon_stop_client() -> Result<()> {
     let _ = client_call("daemon.shutdown", None).await?;
     Ok(())
@@ -6858,6 +6981,46 @@ async fn handle_connection(mut stream: UnixStream, runtime: Arc<DaemonRuntime>) 
                 jsonrpc: JSONRPC_VERSION.to_string(),
                 id: req.id,
                 result: Some(serde_json::to_value(sessions)?),
+                error: None,
+            }
+        }
+        "daemon.session.kill" => {
+            let Some(params) = req.params else {
+                let resp = JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "Missing params".to_string(),
+                        data: None,
+                    }),
+                };
+                write_frame(&mut stream, &serde_json::to_value(resp)?).await?;
+                return Ok(());
+            };
+            let request: DaemonSessionKillRequest = match serde_json::from_value(params) {
+                Ok(value) => value,
+                Err(err) => {
+                    let resp = JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION.to_string(),
+                        id: req.id,
+                        result: None,
+                        error: Some(JsonRpcError {
+                            code: -32602,
+                            message: format!("Invalid params: {err}"),
+                            data: None,
+                        }),
+                    };
+                    write_frame(&mut stream, &serde_json::to_value(resp)?).await?;
+                    return Ok(());
+                }
+            };
+            let killed = runtime.session_kill(&request).await?;
+            JsonRpcResponse {
+                jsonrpc: JSONRPC_VERSION.to_string(),
+                id: req.id,
+                result: Some(serde_json::to_value(killed)?),
                 error: None,
             }
         }
@@ -7440,6 +7603,12 @@ pub async fn daemon_status_local() -> Result<DaemonStatus> {
 
 pub async fn daemon_sessions_local() -> Result<Vec<DaemonSessionView>> {
     daemon_sessions_client().await
+}
+
+pub async fn daemon_session_kill_local(
+    request: &DaemonSessionKillRequest,
+) -> Result<DaemonSessionKillResponse> {
+    daemon_session_kill_client(request).await
 }
 
 pub async fn daemon_start_local() -> Result<EnsureDaemonOutcome> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -722,6 +722,7 @@ struct McpStdioSession {
     link_skill_path: Option<String>,
     endpoint: String,
     daemon_exclusive: Vec<String>,
+    reuse_eligible: bool,
     lifecycle_contract: Option<LifecycleContractView>,
     lifecycle_contract_fetch_state: LifecycleContractFetchState,
     last_lifecycle_update_at_unix: Option<u64>,
@@ -1583,6 +1584,7 @@ impl McpSessionManager {
             link_skill_path: metadata.link_skill_path.map(str::to_string),
             endpoint: metadata.endpoint.to_string(),
             daemon_exclusive: exclusive_keys.clone(),
+            reuse_eligible: true,
             lifecycle_contract: lifecycle_contract.clone(),
             lifecycle_contract_fetch_state,
             last_lifecycle_update_at_unix: None,
@@ -1650,6 +1652,14 @@ impl McpSessionManager {
         exclusive_keys: &[String],
     ) -> Result<Option<(Arc<Mutex<McpStdioSession>>, bool)>> {
         let mut guard = session.lock().await;
+        if !guard.reuse_eligible {
+            let display_key = display_session_key(session_key);
+            return Err(UxcError::InvalidArguments(format!(
+                "Daemon-backed MCP session {} is unavailable after a failed explicit kill; retry `uxc daemon session kill {}` or run `uxc daemon stop`.",
+                display_key, display_key
+            ))
+            .into());
+        }
         let child_exited = guard.client.child_has_exited().unwrap_or(false);
         if child_exited {
             let recent_stderr = redact_recent_stderr(guard.client.recent_stderr_lines(5).await);
@@ -1688,6 +1698,7 @@ impl McpSessionManager {
         let idle_ttl_secs = guard.idle_ttl_secs;
         let last_used_at_unix = guard.last_used_at_unix;
         let daemon_exclusive = guard.daemon_exclusive.clone();
+        let reuse_eligible = guard.reuse_eligible;
         let lifecycle_contract = guard.lifecycle_contract.clone();
         let lifecycle_contract_fetch_state = guard.lifecycle_contract_fetch_state;
         let last_lifecycle_update_at_unix = guard.last_lifecycle_update_at_unix;
@@ -1703,6 +1714,7 @@ impl McpSessionManager {
             snapshot.idle_ttl_secs = idle_ttl_secs;
             snapshot.last_used_at_unix = last_used_at_unix;
             snapshot.daemon_exclusive = daemon_exclusive;
+            snapshot.reuse_eligible = reuse_eligible;
             snapshot.lifecycle_contract = lifecycle_contract;
             snapshot.lifecycle_contract_fetch_state = lifecycle_contract_fetch_state;
             snapshot.last_lifecycle_update_at_unix = last_lifecycle_update_at_unix;
@@ -2055,6 +2067,7 @@ impl McpSessionManager {
                     snapshot.last_lifecycle_update_at_unix = guard.last_lifecycle_update_at_unix;
                     snapshot.last_lifecycle_snapshot = guard.last_lifecycle_snapshot.clone();
                     snapshot.recent_stderr = recent_stderr;
+                    snapshot.reuse_eligible = guard.reuse_eligible;
                     if child_exited {
                         snapshot.reuse_eligible = false;
                     }
@@ -2107,8 +2120,8 @@ impl McpSessionManager {
             .resolve_stdio_session_key(requested_session_key)
             .await?;
         let session = {
-            let mut map = self.stdio.lock().await;
-            map.remove(&session_key)
+            let map = self.stdio.lock().await;
+            map.get(&session_key).cloned()
         }
         .ok_or_else(|| {
             UxcError::OperationNotFound(format!(
@@ -2119,18 +2132,26 @@ impl McpSessionManager {
 
         let mut guard = session.lock().await;
         let child_pid = guard.child_pid;
+        guard.reuse_eligible = false;
         let recent_stderr = redact_recent_stderr(guard.client.recent_stderr_lines(5).await);
+        self.upsert_stdio_snapshot(&session_key, |snapshot| {
+            snapshot.reuse_eligible = false;
+        })
+        .await;
         let kill_result = guard
             .client
             .kill_and_wait(Duration::from_secs(MCP_STDIO_EXIT_TIMEOUT_SECS))
             .await;
         drop(guard);
 
-        self.cleanup_stdio_exclusive_for_session_key(&session_key)
-            .await;
-
         match kill_result {
             Ok(()) => {
+                {
+                    let mut map = self.stdio.lock().await;
+                    map.remove(&session_key);
+                }
+                self.cleanup_stdio_exclusive_for_session_key(&session_key)
+                    .await;
                 self.remove_stdio_snapshot(&session_key, "explicit_killed", None)
                     .await;
                 Ok(DaemonSessionKillResponse {
@@ -2146,12 +2167,6 @@ impl McpSessionManager {
                     snapshot.last_error_summary = Some(error_message.clone());
                     snapshot.recent_stderr = recent_stderr.clone();
                 })
-                .await;
-                self.remove_stdio_snapshot(
-                    &session_key,
-                    "explicit_kill_failed",
-                    Some(error_message.clone()),
-                )
                 .await;
                 Err(err.context(format!(
                     "Failed to kill daemon session {}",
@@ -7016,12 +7031,19 @@ async fn handle_connection(mut stream: UnixStream, runtime: Arc<DaemonRuntime>) 
                     return Ok(());
                 }
             };
-            let killed = runtime.session_kill(&request).await?;
-            JsonRpcResponse {
-                jsonrpc: JSONRPC_VERSION.to_string(),
-                id: req.id,
-                result: Some(serde_json::to_value(killed)?),
-                error: None,
+            match runtime.session_kill(&request).await {
+                Ok(killed) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: Some(serde_json::to_value(killed)?),
+                    error: None,
+                },
+                Err(err) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: None,
+                    error: Some(jsonrpc_error_from_anyhow(&err)),
+                },
             }
         }
         "daemon.shutdown" => {

--- a/src/daemon_client.rs
+++ b/src/daemon_client.rs
@@ -1,12 +1,13 @@
 use crate::auth::injected_env::InjectEnvSpec;
 use crate::daemon::{
-    self, DaemonSessionView, DaemonStatus, ManagedSourceEnsureRequest, ManagedSourceEnsureResponse,
-    ManagedSourceListEntry, ManagedSourceSpec, ManagedSourceStatusRequest,
-    ManagedSourceStopResponse, ManagedSourceView, ManagedStreamInfo, ManagedStreamReadRequest,
-    ManagedStreamReadResponse, ManagedStreamTrimRequest, ManagedStreamTrimResponse, RuntimeAction,
-    RuntimeInvokeOptions, RuntimeInvokeRequest, RuntimeInvokeResponse, SubscribeStartRequest,
-    SubscribeStartResponse, SubscribeStopResponse, SubscriptionEventsRequest,
-    SubscriptionEventsResponse, SubscriptionJobView, SubscriptionMode, SubscriptionTransportHint,
+    self, DaemonSessionKillRequest, DaemonSessionKillResponse, DaemonSessionView, DaemonStatus,
+    ManagedSourceEnsureRequest, ManagedSourceEnsureResponse, ManagedSourceListEntry,
+    ManagedSourceSpec, ManagedSourceStatusRequest, ManagedSourceStopResponse, ManagedSourceView,
+    ManagedStreamInfo, ManagedStreamReadRequest, ManagedStreamReadResponse,
+    ManagedStreamTrimRequest, ManagedStreamTrimResponse, RuntimeAction, RuntimeInvokeOptions,
+    RuntimeInvokeRequest, RuntimeInvokeResponse, SubscribeStartRequest, SubscribeStartResponse,
+    SubscribeStopResponse, SubscriptionEventsRequest, SubscriptionEventsResponse,
+    SubscriptionJobView, SubscriptionMode, SubscriptionTransportHint,
 };
 use anyhow::Result;
 use serde_json::Value;
@@ -87,6 +88,16 @@ impl DaemonClient {
 
     pub async fn daemon_sessions(&self) -> Result<Vec<DaemonSessionView>> {
         daemon::daemon_sessions_client().await
+    }
+
+    pub async fn daemon_session_kill(
+        &self,
+        session_key: impl Into<String>,
+    ) -> Result<DaemonSessionKillResponse> {
+        daemon::daemon_session_kill_client(&DaemonSessionKillRequest {
+            session_key: session_key.into(),
+        })
+        .await
     }
 
     pub async fn call(

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,11 +286,26 @@ enum DaemonCommands {
     Status,
     /// List MCP daemon sessions
     Sessions,
+    /// Manage one daemon-backed MCP session
+    Session {
+        #[command(subcommand)]
+        session_command: DaemonSessionCommands,
+    },
     /// Restart daemon process (stop if running, then start)
     Restart,
     /// Internal daemon server entrypoint
     #[command(name = "_serve", hide = true)]
     Serve,
+}
+
+#[derive(Subcommand)]
+enum DaemonSessionCommands {
+    /// Kill one daemon-backed MCP session by session key
+    Kill {
+        /// Session key from `uxc daemon sessions`
+        #[arg(value_name = "SESSION_KEY")]
+        session_key: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1544,8 +1559,19 @@ fn infer_help_path_from_tokens(tokens: &[String]) -> Option<Vec<String>> {
         }
         "daemon" => {
             if let Some(level1) = tokens.get(idx).map(|s| s.as_str()) {
-                if matches!(level1, "start" | "stop" | "status" | "restart" | "_serve") {
-                    path.push(level1.to_string());
+                match level1 {
+                    "start" | "stop" | "status" | "sessions" | "restart" | "_serve" => {
+                        path.push(level1.to_string());
+                    }
+                    "session" => {
+                        path.push("session".to_string());
+                        if let Some(level2) = tokens.get(idx + 1).map(|s| s.as_str()) {
+                            if matches!(level2, "kill") {
+                                path.push(level2.to_string());
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
         }
@@ -1666,6 +1692,9 @@ fn static_help_path_from_cli(cli: &Cli) -> Option<Vec<&'static str>> {
             DaemonCommands::Stop => Some(vec!["daemon", "stop"]),
             DaemonCommands::Status => Some(vec!["daemon", "status"]),
             DaemonCommands::Sessions => Some(vec!["daemon", "sessions"]),
+            DaemonCommands::Session { session_command } => match session_command {
+                DaemonSessionCommands::Kill { .. } => Some(vec!["daemon", "session", "kill"]),
+            },
             DaemonCommands::Restart => Some(vec!["daemon", "restart"]),
             DaemonCommands::Serve => Some(vec!["daemon", "_serve"]),
         },
@@ -2176,12 +2205,13 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
         ["daemon"] => HelpData {
             path: "uxc daemon".to_string(),
             about: "Manage local runtime daemon".to_string(),
-            usage: "uxc daemon <start|stop|status|sessions|restart>".to_string(),
+            usage: "uxc daemon <start|stop|status|sessions|session|restart>".to_string(),
             commands: commands(&[
                 ("start", "Start daemon process"),
                 ("stop", "Stop daemon process"),
                 ("status", "Show daemon status"),
                 ("sessions", "List daemon MCP sessions"),
+                ("session", "Manage one daemon-backed MCP session"),
                 ("restart", "Restart daemon process"),
             ]),
             notes: vec![
@@ -2193,6 +2223,20 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
                 "uxc daemon start".to_string(),
                 "uxc daemon stop".to_string(),
                 "uxc daemon restart".to_string(),
+            ],
+        },
+        ["daemon", "session"] => HelpData {
+            path: "uxc daemon session".to_string(),
+            about: "Manage one daemon-backed MCP session".to_string(),
+            usage: "uxc daemon session <kill> ...".to_string(),
+            commands: commands(&[("kill", "Kill one daemon-backed MCP session by session key")]),
+            notes: vec![
+                "Use `uxc daemon sessions` to discover session keys before killing a session."
+                    .to_string(),
+            ],
+            examples: vec![
+                "uxc daemon sessions".to_string(),
+                "uxc daemon session kill stdio:0123456789abcdef".to_string(),
             ],
         },
         ["daemon", "start"] => HelpData {
@@ -2229,6 +2273,20 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
                     .to_string(),
             ],
             examples: vec!["uxc daemon sessions".to_string()],
+        },
+        ["daemon", "session", "kill"] => HelpData {
+            path: "uxc daemon session kill".to_string(),
+            about: "Kill one daemon-backed MCP session by session key".to_string(),
+            usage: "uxc daemon session kill <SESSION_KEY>".to_string(),
+            commands: vec![],
+            notes: vec![
+                "Session keys come from `uxc daemon sessions`; the daemon kills the backing MCP child and removes the session from reuse."
+                    .to_string(),
+            ],
+            examples: vec![
+                "uxc daemon sessions".to_string(),
+                "uxc daemon session kill stdio:0123456789abcdef".to_string(),
+            ],
         },
         ["daemon", "restart"] => HelpData {
             path: "uxc daemon restart".to_string(),
@@ -5442,6 +5500,23 @@ async fn handle_daemon_command(command: &DaemonCommands) -> Result<OutputEnvelop
                 None,
             ))
         }
+        DaemonCommands::Session { session_command } => match session_command {
+            DaemonSessionCommands::Kill { session_key } => {
+                let response =
+                    daemon::daemon_session_kill_local(&daemon::DaemonSessionKillRequest {
+                        session_key: session_key.clone(),
+                    })
+                    .await?;
+                Ok(OutputEnvelope::success(
+                    "daemon_session_kill_result",
+                    "cli",
+                    "uxc",
+                    None,
+                    serde_json::to_value(response)?,
+                    None,
+                ))
+            }
+        },
         DaemonCommands::Restart => {
             let stopped = daemon::daemon_stop_local().await?;
             let outcome = daemon::daemon_start_local().await?;

--- a/tests/cli_help_regression_test.rs
+++ b/tests/cli_help_regression_test.rs
@@ -78,6 +78,29 @@ fn global_help_flag_works() {
 
 #[test]
 #[serial]
+fn daemon_session_kill_help_outputs_json() {
+    let output = uxc_command()
+        .arg("daemon")
+        .arg("session")
+        .arg("kill")
+        .arg("-h")
+        .output()
+        .expect("failed to run uxc daemon session kill -h");
+
+    assert!(output.status.success(), "command should succeed");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["kind"], "subcommand_help");
+    assert_eq!(json["data"]["path"], "uxc daemon session kill");
+    assert_eq!(
+        json["data"]["usage"],
+        "uxc daemon session kill <SESSION_KEY>"
+    );
+}
+
+#[test]
+#[serial]
 fn help_subcommand_defaults_to_json() {
     let output = uxc_command()
         .arg("help")

--- a/tests/daemon_reuse_test.rs
+++ b/tests/daemon_reuse_test.rs
@@ -206,6 +206,124 @@ fn daemon_sessions_lists_live_stdio_session_diagnostics() {
 
 #[test]
 #[serial]
+fn daemon_session_kill_removes_live_stdio_session_from_reuse_pool() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+
+    let bin = test_server_binary("mcp-stdio");
+    let endpoint = format!("{} ok", bin.display());
+
+    let start = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("daemon start should run");
+    assert!(start.status.success());
+
+    let first = uxc_command_with_home(temp_home.path())
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"seed"}"#)
+        .output()
+        .expect("first call should run");
+    assert!(first.status.success());
+
+    let sessions = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("sessions")
+        .output()
+        .expect("daemon sessions should run");
+    assert!(sessions.status.success());
+    let sessions_json: serde_json::Value =
+        serde_json::from_slice(&sessions.stdout).expect("valid daemon sessions json");
+    let entries = sessions_json["data"]
+        .as_array()
+        .expect("session list should be an array");
+    assert_eq!(entries.len(), 1, "expected one stdio session");
+    let session_key = entries[0]["session_key"]
+        .as_str()
+        .expect("session_key should be present")
+        .to_string();
+    let first_pid = entries[0]["child_pid"]
+        .as_u64()
+        .expect("child pid should be present");
+
+    let kill = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("session")
+        .arg("kill")
+        .arg(&session_key)
+        .output()
+        .expect("daemon session kill should run");
+    assert!(
+        kill.status.success(),
+        "kill should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&kill.stdout),
+        String::from_utf8_lossy(&kill.stderr)
+    );
+    let kill_json: serde_json::Value =
+        serde_json::from_slice(&kill.stdout).expect("valid daemon session kill json");
+    assert_eq!(kill_json["ok"], true);
+    assert_eq!(kill_json["kind"], "daemon_session_kill_result");
+    assert_eq!(kill_json["data"]["session_key"], session_key);
+    assert_eq!(kill_json["data"]["killed"], true);
+    assert_eq!(
+        kill_json["data"]["child_pid"]
+            .as_u64()
+            .expect("child pid should be returned"),
+        first_pid
+    );
+
+    let sessions_after_kill = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("sessions")
+        .output()
+        .expect("daemon sessions after kill should run");
+    assert!(sessions_after_kill.status.success());
+    let sessions_after_kill_json: serde_json::Value =
+        serde_json::from_slice(&sessions_after_kill.stdout).expect("valid daemon sessions json");
+    let entries_after_kill = sessions_after_kill_json["data"]
+        .as_array()
+        .expect("session list should be an array");
+    assert!(
+        entries_after_kill.is_empty(),
+        "expected killed session to be removed from daemon sessions"
+    );
+
+    let second = uxc_command_with_home(temp_home.path())
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"after-kill"}"#)
+        .output()
+        .expect("second call should run");
+    assert!(second.status.success());
+    let second_json: serde_json::Value =
+        serde_json::from_slice(&second.stdout).expect("second stdout should be valid JSON");
+    assert_ne!(second_json["meta"]["daemon_session_reused"], true);
+
+    let sessions_after_restart = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("sessions")
+        .output()
+        .expect("daemon sessions after restart should run");
+    assert!(sessions_after_restart.status.success());
+    let sessions_after_restart_json: serde_json::Value =
+        serde_json::from_slice(&sessions_after_restart.stdout).expect("valid daemon sessions json");
+    let recreated_pid = sessions_after_restart_json["data"][0]["child_pid"]
+        .as_u64()
+        .expect("child pid should be present");
+    assert_ne!(
+        recreated_pid, first_pid,
+        "expected a fresh MCP child process"
+    );
+
+    daemon_stop_best_effort_with_home(temp_home.path());
+}
+
+#[test]
+#[serial]
 fn daemon_sessions_surface_link_source_metadata() {
     daemon_stop_best_effort();
 


### PR DESCRIPTION
## What
- add `uxc daemon session kill <SESSION_KEY>` for one daemon-backed MCP stdio session
- add daemon RPC/client support for `daemon.session.kill`
- expose a matching TS daemon client helper and regression coverage

## Why
- issue #367 asks for a minimal way to reap or restart one daemon-backed MCP session
- the smallest useful version is killing one session by the opaque key shown by `uxc daemon sessions`

## How
- resolve the requested session key against live stdio sessions, accepting the displayed redacted key from `uxc daemon sessions`
- remove the matched session from the stdio reuse map, kill the backing child, and drop the snapshot from daemon session views
- wire the command through the CLI help tree, JSON-RPC server/client, and daemon client wrappers
- add regression tests for help output, session kill behavior, and the TS client request shape

## Testing
- `cargo check -q`
- `cargo test daemon_session_kill_help_outputs_json --test cli_help_regression_test -- --test-threads=1`
- `cargo test daemon_session_kill_removes_live_stdio_session_from_reuse_pool --test daemon_reuse_test -- --test-threads=1`
- TS local test not run in this worktree because `packages/uxc-daemon-client` has no installed `node_modules` (`vitest: command not found`)

Closes #367
