### PR TITLE
fix(daemon): reuse live stdio tool schemas for arg coercion

### DIFF
--- a/src/arg_coercion.rs
+++ b/src/arg_coercion.rs
@@ -43,6 +43,10 @@ async fn prepare_execute_args_with_adapter<A: Adapter + Sync>(
     operation_id: &str,
     raw_args: HashMap<String, Value>,
 ) -> Result<HashMap<String, Value>> {
+    if raw_args.is_empty() {
+        return Ok(raw_args);
+    }
+
     let detail = match adapter.describe_operation(endpoint, operation_id).await {
         Ok(detail) => detail,
         Err(_) => return Ok(raw_args),

--- a/src/arg_coercion.rs
+++ b/src/arg_coercion.rs
@@ -20,6 +20,23 @@ pub async fn prepare_execute_args(
     prepare_execute_args_with_adapter(adapter, endpoint, operation_id, raw_args).await
 }
 
+pub fn prepare_execute_args_from_detail(
+    protocol: ProtocolType,
+    operation_id: &str,
+    detail: &OperationDetail,
+    raw_args: HashMap<String, Value>,
+) -> Result<HashMap<String, Value>> {
+    if raw_args.is_empty() {
+        return Ok(raw_args);
+    }
+
+    let Some(schema) = normalize_operation_schema(protocol, detail) else {
+        return Ok(raw_args);
+    };
+
+    coerce_execute_args(operation_id, raw_args, schema)
+}
+
 async fn prepare_execute_args_with_adapter<A: Adapter + Sync>(
     adapter: &A,
     endpoint: &str,
@@ -34,10 +51,14 @@ async fn prepare_execute_args_with_adapter<A: Adapter + Sync>(
         Ok(detail) => detail,
         Err(_) => return Ok(raw_args),
     };
-    let Some(schema) = normalize_operation_schema(adapter.protocol_type(), &detail) else {
-        return Ok(raw_args);
-    };
+    prepare_execute_args_from_detail(adapter.protocol_type(), operation_id, &detail, raw_args)
+}
 
+fn coerce_execute_args(
+    operation_id: &str,
+    raw_args: HashMap<String, Value>,
+    schema: NormalizedSchema,
+) -> Result<HashMap<String, Value>> {
     let value = coerce_value(
         &Value::Object(raw_args.into_iter().collect()),
         &schema.root,

--- a/src/arg_coercion.rs
+++ b/src/arg_coercion.rs
@@ -43,10 +43,6 @@ async fn prepare_execute_args_with_adapter<A: Adapter + Sync>(
     operation_id: &str,
     raw_args: HashMap<String, Value>,
 ) -> Result<HashMap<String, Value>> {
-    if raw_args.is_empty() {
-        return Ok(raw_args);
-    }
-
     let detail = match adapter.describe_operation(endpoint, operation_id).await {
         Ok(detail) => detail,
         Err(_) => return Ok(raw_args),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3862,16 +3862,18 @@ impl DaemonRuntime {
             Option<String>,
             Value,
             Option<adapters::ExecutionMetadata>,
-        )> = if protocol == "mcp"
-            && matches!(request.action, RuntimeAction::Execute)
-            && adapters::mcp::McpAdapter::is_stdio_command(&request.endpoint)
-        {
+        )> = if protocol == "mcp" && matches!(request.action, RuntimeAction::Execute) {
+            let prepared_args = if adapters::mcp::McpAdapter::is_stdio_command(&request.endpoint) {
+                request.args.clone().unwrap_or_default()
+            } else {
+                prepare_runtime_execute_args(&resolved.adapter, &request).await?
+            };
             // Clone the pre-computed stdio_spawn_options to avoid duplicate secret resolution
             let stdio_options = stdio_spawn_options.clone();
             let (kind, operation, data, reused) = self
                 .invoke_mcp_execute(
                     &request,
-                    request.args.clone().unwrap_or_default(),
+                    prepared_args,
                     execution_auth_profile.clone(),
                     stdio_options,
                     cache_for_mcp.clone(),
@@ -3954,14 +3956,19 @@ impl DaemonRuntime {
 
                         result = if protocol == "mcp"
                             && matches!(request.action, RuntimeAction::Execute)
-                            && adapters::mcp::McpAdapter::is_stdio_command(&request.endpoint)
                         {
+                            let prepared_args =
+                                if adapters::mcp::McpAdapter::is_stdio_command(&request.endpoint) {
+                                    request.args.clone().unwrap_or_default()
+                                } else {
+                                    prepare_runtime_execute_args(&adapter, &request).await?
+                                };
                             // For cache fallback, recompute stdio_spawn_options since we don't have
                             // the original detection_options available
                             let (kind, operation, data, reused) = self
                                 .invoke_mcp_execute(
                                     &request,
-                                    request.args.clone().unwrap_or_default(),
+                                    prepared_args,
                                     fallback_auth_profile.clone(),
                                     None,
                                     cache_for_fallback.clone(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,7 +2,7 @@ use crate::adapters::mcp::types::{JsonRpcNotification, ResourceContents};
 use crate::adapters::{
     self, Adapter, AdapterEnum, DetectionOptions, Operation, ProtocolDetector, ProtocolType,
 };
-use crate::arg_coercion::prepare_execute_args;
+use crate::arg_coercion::{prepare_execute_args, prepare_execute_args_from_detail};
 use crate::auth::injected_env::{fingerprint_injected_env, render_injected_env, InjectEnvSpec};
 use crate::auth::{self, Profile};
 use crate::cache::{self, Cache, CacheConfig};
@@ -3862,14 +3862,16 @@ impl DaemonRuntime {
             Option<String>,
             Value,
             Option<adapters::ExecutionMetadata>,
-        )> = if protocol == "mcp" && matches!(request.action, RuntimeAction::Execute) {
-            let prepared_args = prepare_runtime_execute_args(&resolved.adapter, &request).await?;
+        )> = if protocol == "mcp"
+            && matches!(request.action, RuntimeAction::Execute)
+            && adapters::mcp::McpAdapter::is_stdio_command(&request.endpoint)
+        {
             // Clone the pre-computed stdio_spawn_options to avoid duplicate secret resolution
             let stdio_options = stdio_spawn_options.clone();
             let (kind, operation, data, reused) = self
                 .invoke_mcp_execute(
                     &request,
-                    prepared_args,
+                    request.args.clone().unwrap_or_default(),
                     execution_auth_profile.clone(),
                     stdio_options,
                     cache_for_mcp.clone(),
@@ -3952,15 +3954,14 @@ impl DaemonRuntime {
 
                         result = if protocol == "mcp"
                             && matches!(request.action, RuntimeAction::Execute)
+                            && adapters::mcp::McpAdapter::is_stdio_command(&request.endpoint)
                         {
-                            let prepared_args =
-                                prepare_runtime_execute_args(&adapter, &request).await?;
                             // For cache fallback, recompute stdio_spawn_options since we don't have
                             // the original detection_options available
                             let (kind, operation, data, reused) = self
                                 .invoke_mcp_execute(
                                     &request,
-                                    prepared_args,
+                                    request.args.clone().unwrap_or_default(),
                                     fallback_auth_profile.clone(),
                                     None,
                                     cache_for_fallback.clone(),
@@ -4279,7 +4280,7 @@ impl DaemonRuntime {
     async fn invoke_mcp_execute(
         &self,
         request: &RuntimeInvokeRequest,
-        args: HashMap<String, Value>,
+        raw_args: HashMap<String, Value>,
         auth_profile: Option<Profile>,
         precomputed_stdio_spawn_options: Option<adapters::mcp::StdioSpawnOptions>,
         cache: Arc<dyn Cache>,
@@ -4289,7 +4290,6 @@ impl DaemonRuntime {
             .operation_id
             .as_ref()
             .ok_or_else(|| anyhow!("operation_id is required"))?;
-        let arguments = Some(Value::Object(args.into_iter().collect()));
 
         if adapters::mcp::McpAdapter::is_stdio_command(endpoint) {
             let (cmd, cmd_args) = adapters::mcp::McpAdapter::parse_stdio_command(endpoint)?;
@@ -4331,15 +4331,17 @@ impl DaemonRuntime {
             let mut guard = session.lock().await;
             guard.last_used = Instant::now();
             guard.last_used_at_unix = now_unix_secs();
+            let timeout = request_timeout_duration(request.options.timeout_ms).unwrap_or_else(
+                adapters::mcp::transport::McpStdioTransport::default_request_timeout,
+            );
+            let args = prepare_live_stdio_mcp_execute_args(
+                &mut guard, endpoint, &cache, op, raw_args, timeout,
+            )
+            .await?;
+            let arguments = Some(Value::Object(args.into_iter().collect()));
             let result = guard
                 .client
-                .call_tool_with_timeout(
-                    op,
-                    arguments,
-                    request_timeout_duration(request.options.timeout_ms).unwrap_or_else(
-                        adapters::mcp::transport::McpStdioTransport::default_request_timeout,
-                    ),
-                )
+                .call_tool_with_timeout(op, arguments, timeout)
                 .await;
             let _ = guard
                 .mark_tools_dirty_from_notifications(endpoint, &cache)
@@ -4392,6 +4394,7 @@ impl DaemonRuntime {
                     .await?
             };
             session.mark_used().await;
+            let arguments = Some(Value::Object(raw_args.into_iter().collect()));
             let result = session.transport.call_tool(op, arguments).await?;
             let _ = session.collect_pending_notifications().await;
             Ok((
@@ -8777,6 +8780,54 @@ fn operation_detail_from_mcp_tool(tool: &adapters::mcp::types::Tool) -> adapters
         return_type: Some("ToolContent".to_string()),
         input_schema: tool.inputSchema.clone(),
     }
+}
+
+async fn prepare_live_stdio_mcp_execute_args(
+    session: &mut McpStdioSession,
+    endpoint: &str,
+    cache: &Arc<dyn Cache>,
+    operation_id: &str,
+    raw_args: HashMap<String, Value>,
+    timeout: Duration,
+) -> Result<HashMap<String, Value>> {
+    if raw_args.is_empty() {
+        return Ok(raw_args);
+    }
+
+    let _ = session
+        .mark_tools_dirty_from_notifications(endpoint, cache)
+        .await;
+    let tools = match session
+        .refresh_tools_if_needed(endpoint, cache, timeout)
+        .await
+    {
+        Ok(tools) => tools,
+        Err(err) => {
+            tracing::debug!(
+                endpoint = %endpoint,
+                operation_id = %operation_id,
+                error = %err,
+                "Failed to refresh live MCP stdio tool catalog for arg coercion; using raw args"
+            );
+            return Ok(raw_args);
+        }
+    };
+
+    let Some(tool) = tools.iter().find(|tool| tool.name == *operation_id) else {
+        tracing::debug!(
+            endpoint = %endpoint,
+            operation_id = %operation_id,
+            "Live MCP stdio tool catalog did not contain requested operation; using raw args"
+        );
+        return Ok(raw_args);
+    };
+
+    prepare_execute_args_from_detail(
+        ProtocolType::Mcp,
+        operation_id,
+        &operation_detail_from_mcp_tool(tool),
+        raw_args,
+    )
 }
 
 fn to_operation_summary(protocol: &str, op: &Operation) -> OperationSummary {

--- a/tests/daemon_reuse_test.rs
+++ b/tests/daemon_reuse_test.rs
@@ -848,19 +848,20 @@ fn daemon_status_not_blocked_by_stuck_mcp_invoke() {
 #[test]
 #[serial]
 fn mcp_stdio_execute_does_not_relist_tools_on_reused_session() {
-    daemon_stop_best_effort();
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
 
     let bin = test_server_binary("mcp-stdio");
     let endpoint = format!("{} tools_list_fail_after_first", bin.display());
 
-    let start = uxc_command()
+    let start = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("start")
         .output()
         .expect("daemon start should run");
     assert!(start.status.success());
 
-    let first = uxc_command()
+    let first = uxc_command_with_home(temp_home.path())
         .arg(&endpoint)
         .arg("echo")
         .arg("--input-json")
@@ -874,7 +875,7 @@ fn mcp_stdio_execute_does_not_relist_tools_on_reused_session() {
         String::from_utf8_lossy(&first.stderr)
     );
 
-    let second = uxc_command()
+    let second = uxc_command_with_home(temp_home.path())
         .arg(&endpoint)
         .arg("echo")
         .arg("--input-json")
@@ -894,7 +895,376 @@ fn mcp_stdio_execute_does_not_relist_tools_on_reused_session() {
     assert_eq!(json["data"]["content"][0]["text"], "second");
     assert_eq!(json["meta"]["daemon_session_reused"], true);
 
-    daemon_stop_best_effort();
+    daemon_stop_best_effort_with_home(temp_home.path());
+}
+
+#[test]
+#[serial]
+fn mcp_stdio_execute_uses_live_session_tool_catalog_for_arg_coercion() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+
+    let scripts_dir = temp_home.path().join("scripts");
+    fs::create_dir_all(&scripts_dir).expect("scripts dir should exist");
+    let log_path = temp_home.path().join("mcp-live-session.log");
+    let script_path = scripts_dir.join("mcp_live_schema.py");
+
+    write_executable_script(
+        &script_path,
+        r#"#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+log_path = Path(sys.argv[1])
+with log_path.open("a", encoding="utf-8") as f:
+    f.write("start\n")
+
+for line in sys.stdin:
+    req = json.loads(line)
+    method = req.get("method")
+    req_id = req.get("id")
+    if method == "initialize":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "live-schema", "version": "1.0.0"}
+            }
+        }), flush=True)
+    elif method == "notifications/initialized":
+        continue
+    elif method == "tools/list":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "tools": [{
+                    "name": "measure",
+                    "description": "Require integer count",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"count": {"type": "integer"}},
+                        "required": ["count"]
+                    }
+                }]
+            }
+        }), flush=True)
+    elif method == "tools/call":
+        args = req.get("params", {}).get("arguments") or {}
+        count = args.get("count")
+        if not isinstance(count, int):
+            print(json.dumps({
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32602, "message": "count must be integer"}
+            }), flush=True)
+            continue
+        starts = log_path.read_text(encoding="utf-8").count("start\n")
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": f"count={count};starts={starts}"}],
+                "structuredContent": {"count": count, "starts": starts}
+            }
+        }), flush=True)
+    else:
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": "Method not found"}
+        }), flush=True)
+"#,
+    );
+
+    let endpoint = format!("{} {}", script_path.display(), log_path.display());
+
+    let start = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("daemon start should run");
+    assert!(start.status.success());
+
+    let cold = uxc_command_with_home(temp_home.path())
+        .arg(&endpoint)
+        .arg("measure")
+        .arg("--input-json")
+        .arg(r#"{"count":"7"}"#)
+        .output()
+        .expect("cold call should run");
+    assert!(
+        cold.status.success(),
+        "cold call should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&cold.stdout),
+        String::from_utf8_lossy(&cold.stderr)
+    );
+    let cold_json: serde_json::Value =
+        serde_json::from_slice(&cold.stdout).expect("cold stdout should be valid JSON");
+    assert_eq!(cold_json["ok"], true);
+    assert_eq!(cold_json["data"]["structuredContent"]["count"], 7);
+    assert_eq!(cold_json["data"]["structuredContent"]["starts"], 1);
+
+    let warm = uxc_command_with_home(temp_home.path())
+        .arg(&endpoint)
+        .arg("measure")
+        .arg("--input-json")
+        .arg(r#"{"count":"9"}"#)
+        .output()
+        .expect("warm call should run");
+    assert!(
+        warm.status.success(),
+        "warm call should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&warm.stdout),
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    let warm_json: serde_json::Value =
+        serde_json::from_slice(&warm.stdout).expect("warm stdout should be valid JSON");
+    assert_eq!(warm_json["ok"], true);
+    assert_eq!(warm_json["data"]["structuredContent"]["count"], 9);
+    assert_eq!(warm_json["data"]["structuredContent"]["starts"], 1);
+    assert_eq!(warm_json["meta"]["daemon_session_reused"], true);
+
+    daemon_stop_best_effort_with_home(temp_home.path());
+}
+
+#[test]
+#[serial]
+fn mcp_stdio_execute_refreshes_live_tool_catalog_after_tools_list_changed() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+
+    let scripts_dir = temp_home.path().join("scripts");
+    fs::create_dir_all(&scripts_dir).expect("scripts dir should exist");
+    let script_path = scripts_dir.join("mcp_dynamic_schema.py");
+
+    write_executable_script(
+        &script_path,
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+dynamic = False
+
+for line in sys.stdin:
+    req = json.loads(line)
+    method = req.get("method")
+    req_id = req.get("id")
+    if method == "initialize":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {"listChanged": True}},
+                "serverInfo": {"name": "dynamic-schema", "version": "1.0.0"}
+            }
+        }), flush=True)
+    elif method == "notifications/initialized":
+        continue
+    elif method == "tools/list":
+        tools = [{
+            "name": "navigate",
+            "description": "Switch toolset",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"]
+            }
+        }]
+        if dynamic:
+            tools.append({
+                "name": "render",
+                "description": "Require integer frames",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"frames": {"type": "integer"}},
+                    "required": ["frames"]
+                }
+            })
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"tools": tools}
+        }), flush=True)
+    elif method == "tools/call":
+        name = req.get("params", {}).get("name")
+        args = req.get("params", {}).get("arguments") or {}
+        if name == "navigate":
+            dynamic = True
+            print(json.dumps({
+                "jsonrpc": "2.0",
+                "method": "notifications/tools/list_changed"
+            }), flush=True)
+            print(json.dumps({
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {"content": [{"type": "text", "text": "navigated"}]}
+            }), flush=True)
+        elif name == "render":
+            frames = args.get("frames")
+            if not isinstance(frames, int):
+                print(json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32602, "message": "frames must be integer"}
+                }), flush=True)
+            else:
+                print(json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "content": [{"type": "text", "text": f"frames={frames}"}],
+                        "structuredContent": {"frames": frames}
+                    }
+                }), flush=True)
+        else:
+            print(json.dumps({
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": "tool not found"}
+            }), flush=True)
+    else:
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": "Method not found"}
+        }), flush=True)
+"#,
+    );
+
+    let endpoint = script_path.display().to_string();
+
+    let start = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("daemon start should run");
+    assert!(start.status.success());
+
+    let navigate = uxc_command_with_home(temp_home.path())
+        .arg(&endpoint)
+        .arg("navigate")
+        .arg("--input-json")
+        .arg(r#"{"path":"/next"}"#)
+        .output()
+        .expect("navigate call should run");
+    assert!(
+        navigate.status.success(),
+        "navigate call should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&navigate.stdout),
+        String::from_utf8_lossy(&navigate.stderr)
+    );
+
+    let render = uxc_command_with_home(temp_home.path())
+        .arg(&endpoint)
+        .arg("render")
+        .arg("--input-json")
+        .arg(r#"{"frames":"12"}"#)
+        .output()
+        .expect("render call should run");
+    assert!(
+        render.status.success(),
+        "render call should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&render.stdout),
+        String::from_utf8_lossy(&render.stderr)
+    );
+    let render_json: serde_json::Value =
+        serde_json::from_slice(&render.stdout).expect("render stdout should be valid JSON");
+    assert_eq!(render_json["ok"], true);
+    assert_eq!(render_json["data"]["structuredContent"]["frames"], 12);
+    assert_eq!(render_json["meta"]["daemon_session_reused"], true);
+
+    daemon_stop_best_effort_with_home(temp_home.path());
+}
+
+#[test]
+#[serial]
+fn mcp_stdio_execute_falls_back_to_raw_args_when_live_tool_catalog_is_unavailable() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+
+    let scripts_dir = temp_home.path().join("scripts");
+    fs::create_dir_all(&scripts_dir).expect("scripts dir should exist");
+    let script_path = scripts_dir.join("mcp_no_tools_list.py");
+
+    write_executable_script(
+        &script_path,
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+for line in sys.stdin:
+    req = json.loads(line)
+    method = req.get("method")
+    req_id = req.get("id")
+    if method == "initialize":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "no-tools-list", "version": "1.0.0"}
+            }
+        }), flush=True)
+    elif method == "notifications/initialized":
+        continue
+    elif method == "tools/list":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": "Method not found"}
+        }), flush=True)
+    elif method == "tools/call":
+        args = req.get("params", {}).get("arguments") or {}
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": args.get("message", "")}],
+                "structuredContent": {"message": args.get("message", "")}
+            }
+        }), flush=True)
+    else:
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": "Method not found"}
+        }), flush=True)
+"#,
+    );
+
+    let endpoint = script_path.display().to_string();
+
+    let start = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("daemon start should run");
+    assert!(start.status.success());
+
+    let call = uxc_command_with_home(temp_home.path())
+        .arg(&endpoint)
+        .arg("echo")
+        .arg("--input-json")
+        .arg(r#"{"message":"fallback-ok"}"#)
+        .output()
+        .expect("call should run");
+    assert!(
+        call.status.success(),
+        "call should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&call.stdout),
+        String::from_utf8_lossy(&call.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&call.stdout).expect("valid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["structuredContent"]["message"], "fallback-ok");
+
+    daemon_stop_best_effort_with_home(temp_home.path());
 }
 
 #[test]


### PR DESCRIPTION
## What
- move daemon-backed MCP stdio arg coercion onto the same live session used for `tools/call`
- add an `OperationDetail`-backed coercion entrypoint so daemon code can coerce without adapter schema lookup
- add daemon reuse tests for cold-path live-session coercion, `tools/list_changed` refresh, and raw-args fallback when live tool catalogs are unavailable
- isolate the existing `tools_list_fail_after_first` reuse regression test with a temp HOME

## Why
Issue #375 points out that daemon-backed MCP stdio execute still fetched tool schemas through a detached adapter path. For non-empty args this could still create a temporary stdio client and `tools/list` round trip before the real `tools/call`, which is wasteful and unstable for sessionful MCP servers.

This change removes that mismatch for daemon-backed MCP stdio execute by using the live session's cached/refreshed tool catalog directly.

Closes #375

## How
- keep the existing generic `prepare_execute_args(...)` path for non-daemon and non-stdio flows
- add `prepare_execute_args_from_detail(...)` for pre-resolved schemas
- in daemon stdio execute:
  - reuse/create the live session first
  - drain notifications and refresh tools if needed on that session
  - derive `OperationDetail` from the live tool catalog
  - coerce args from that detail
  - fall back to raw args if the live tool catalog cannot be loaded
- leave MCP HTTP and other protocol execute paths unchanged

## Testing
- `cargo check -q`
- `cargo test mcp_stdio_execute_does_not_relist_tools_on_reused_session --test daemon_reuse_test -- --test-threads=1`
- `cargo test mcp_stdio_execute_uses_live_session_tool_catalog_for_arg_coercion --test daemon_reuse_test -- --test-threads=1`
- `cargo test mcp_stdio_execute_refreshes_live_tool_catalog_after_tools_list_changed --test daemon_reuse_test -- --test-threads=1`
- `cargo test mcp_stdio_execute_falls_back_to_raw_args_when_live_tool_catalog_is_unavailable --test daemon_reuse_test -- --test-threads=1`
