### PR TITLE
fix(daemon): enforce single owner with doctor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,6 +777,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,6 +3114,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "ed25519-dalek",
+ "fs2",
  "futures",
  "getrandom 0.2.17",
  "graphql_client",
@@ -3305,6 +3316,28 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ axum = { version = "0.7", optional = true, features = ["ws"] }
 # Error Handling
 anyhow = "1.0"
 thiserror = "1.0"
+fs2 = "0.4"
 
 # Logging
 tracing = "0.1"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10252,8 +10252,9 @@ impl DaemonOwnerLockGuard {
                 .into());
             }
             Err(err) => {
-                return Err(err)
-                    .with_context(|| format!("Failed to lock daemon owner lock {}", path.display()));
+                return Err(err).with_context(|| {
+                    format!("Failed to lock daemon owner lock {}", path.display())
+                });
             }
         }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -42,6 +42,7 @@ use crate::subscription_websocket::{
     self, RawFrameHandler, WebSocketRunError, WebSocketRuntimeConfig, WebSocketRuntimeObserver,
 };
 use anyhow::{anyhow, bail, Context, Result};
+use fs2::FileExt;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -49,7 +50,9 @@ use sha2::{Digest, Sha256};
 use std::collections::{HashMap, VecDeque};
 use std::ffi::OsString;
 use std::fs;
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Seek, SeekFrom, Write};
+#[cfg(unix)]
+use std::os::unix::net::UnixStream as StdUnixStream;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Component, Path, PathBuf};
@@ -70,6 +73,7 @@ const START_POLL_INTERVAL_MS: u64 = 100;
 const STOP_POLL_TRIES: usize = 50;
 const STOP_POLL_INTERVAL_MS: u64 = 100;
 const START_LOCK_STALE_SECS: u64 = 30;
+const DAEMON_OWNER_TERM_SIGNAL: i32 = 15;
 const STDIO_INIT_LOCK_STALE_SECS: u64 = 30;
 const MCP_IDLE_TTL_SECS: u64 = 600;
 const MCP_IDLE_CLEANUP_INTERVAL_MS: u64 = 500;
@@ -110,6 +114,7 @@ const ERR_RUNTIME_GENERIC: i32 = -32030;
 #[cfg(unix)]
 unsafe extern "C" {
     fn setsid() -> std::ffi::c_int;
+    fn kill(pid: i32, sig: i32) -> std::ffi::c_int;
 }
 
 pub fn daemon_supported() -> bool {
@@ -537,6 +542,52 @@ pub struct DaemonStatus {
     pub managed_streams: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_lock_held: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_pid_alive: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_socket: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_started_at_unix: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub socket_exists: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DaemonOwnerMetadata {
+    pid: u32,
+    version: String,
+    socket: String,
+    started_at_unix: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DaemonLocalDiagnostics {
+    pub socket: String,
+    pub socket_exists: bool,
+    pub owner_lock_held: bool,
+    pub owner_pid: Option<u32>,
+    pub owner_pid_alive: bool,
+    pub owner_version: Option<String>,
+    pub owner_socket: Option<String>,
+    pub owner_started_at_unix: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonDoctorResponse {
+    pub status: String,
+    pub repaired: bool,
+    pub socket_removed: bool,
+    pub owner_metadata_cleared: bool,
+    pub socket: String,
+    pub diagnostics: DaemonLocalDiagnostics,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -4052,6 +4103,13 @@ impl DaemonRuntime {
             managed_sources_running,
             managed_streams,
             log_file,
+            owner_lock_held: Some(true),
+            owner_pid: Some(std::process::id()),
+            owner_pid_alive: Some(true),
+            owner_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            owner_socket: Some(socket_path().display().to_string()),
+            owner_started_at_unix: Some(state.started_at_unix),
+            socket_exists: Some(socket_path().exists()),
         }
     }
 
@@ -6760,6 +6818,30 @@ async fn start_daemon_process() -> Result<()> {
     let start_lock = try_acquire_start_lock(&lock_path)?;
     let got_lock = start_lock.is_some();
 
+    let diagnostics = inspect_daemon_local_diagnostics()?;
+    if diagnostics.owner_lock_held {
+        let code = if diagnostics.owner_pid_alive {
+            "DAEMON_OWNER_UNREACHABLE"
+        } else {
+            "DAEMON_OWNER_HELD"
+        };
+        let message = if diagnostics.owner_pid_alive {
+            format!(
+                "A live daemon owner already exists (pid={}) but is unreachable. Refusing to start a second daemon. Run `uxc daemon doctor`.",
+                diagnostics
+                    .owner_pid
+                    .map(|pid| pid.to_string())
+                    .unwrap_or_else(|| "unknown".to_string())
+            )
+        } else {
+            "A daemon owner lock is still held. Refusing to start a second daemon. Run `uxc daemon doctor`."
+                .to_string()
+        };
+        return Err(
+            StructuredError::new(code, message, Some(serde_json::to_value(&diagnostics)?)).into(),
+        );
+    }
+
     if got_lock {
         let current_exe = std::env::current_exe().context("Cannot resolve current executable")?;
         let mut child_cmd = std::process::Command::new(current_exe);
@@ -6797,7 +6879,17 @@ async fn start_daemon_process() -> Result<()> {
         }
     }
 
+    let diagnostics = inspect_daemon_local_diagnostics()?;
     drop(start_lock);
+    if diagnostics.owner_lock_held {
+        return Err(StructuredError::new(
+            "DAEMON_OWNER_UNREACHABLE",
+            "Daemon owner exists but did not become reachable in time. Run `uxc daemon doctor`."
+                .to_string(),
+            Some(serde_json::to_value(diagnostics)?),
+        )
+        .into());
+    }
     bail!("Daemon failed to start. Run `uxc daemon status` for diagnostics.")
 }
 
@@ -6870,6 +6962,15 @@ pub async fn run_daemon_server() -> Result<()> {
     let dir = daemon_dir();
     ensure_private_dir(&dir)?;
     let socket = socket_path();
+    let mut owner_lock = DaemonOwnerLockGuard::acquire(
+        &daemon_lock_path(),
+        &DaemonOwnerMetadata {
+            pid: std::process::id(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            socket: socket.display().to_string(),
+            started_at_unix: now_unix_secs(),
+        },
+    )?;
     if socket.exists() {
         let _ = fs::remove_file(&socket);
     }
@@ -6925,6 +7026,7 @@ pub async fn run_daemon_server() -> Result<()> {
         .log(DaemonLogEntry::new(DaemonEventType::DaemonStop))
         .await;
 
+    owner_lock.clear_metadata();
     let _ = fs::remove_file(&socket);
     Ok(())
 }
@@ -7633,13 +7735,65 @@ pub async fn daemon_session_kill_local(
     daemon_session_kill_client(request).await
 }
 
+pub fn daemon_doctor_local_result() -> Result<DaemonDoctorResponse> {
+    daemon_doctor_local()
+}
+
 pub async fn daemon_start_local() -> Result<EnsureDaemonOutcome> {
     ensure_compatible_daemon_running().await
 }
 
 pub async fn daemon_stop_local() -> Result<bool> {
     if daemon_status_client().await.is_err() {
-        return Ok(false);
+        let diagnostics = inspect_daemon_local_diagnostics()?;
+        if !diagnostics.owner_lock_held {
+            return Ok(false);
+        }
+
+        let pid = diagnostics.owner_pid.ok_or_else(|| {
+            StructuredError::new(
+                "DAEMON_OWNER_METADATA_MISSING",
+                "Daemon owner lock is held but owner pid metadata is missing. Run `uxc daemon doctor`."
+                    .to_string(),
+                Some(serde_json::to_value(&diagnostics).unwrap_or(Value::Null)),
+            )
+        })?;
+
+        if !diagnostics.owner_pid_alive {
+            return Err(StructuredError::new(
+                "DAEMON_OWNER_STALE",
+                "Daemon owner metadata is stale. Run `uxc daemon doctor`.".to_string(),
+                Some(serde_json::to_value(&diagnostics)?),
+            )
+            .into());
+        }
+
+        // SAFETY: kill with SIGTERM targets the owner pid discovered from local metadata.
+        if unsafe { kill(pid as i32, DAEMON_OWNER_TERM_SIGNAL) } == -1 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+
+        for _ in 0..STOP_POLL_TRIES {
+            tokio::time::sleep(Duration::from_millis(STOP_POLL_INTERVAL_MS)).await;
+            let diagnostics = inspect_daemon_local_diagnostics()?;
+            if !diagnostics.owner_lock_held {
+                let _ = clear_daemon_owner_metadata_path(&daemon_lock_path());
+                if socket_path().exists() {
+                    let _ = fs::remove_file(socket_path());
+                }
+                return Ok(true);
+            }
+        }
+
+        return Err(StructuredError::new(
+            "DAEMON_STOP_TIMEOUT",
+            format!(
+                "Daemon owner pid {} did not stop in time. Run `uxc daemon doctor`.",
+                pid
+            ),
+            Some(serde_json::to_value(diagnostics)?),
+        )
+        .into());
     }
     daemon_stop_client().await?;
     for _ in 0..STOP_POLL_TRIES {
@@ -7825,6 +7979,10 @@ fn daemon_dir() -> PathBuf {
 
 pub fn socket_path() -> PathBuf {
     daemon_dir().join("uxc.sock")
+}
+
+fn daemon_lock_path() -> PathBuf {
+    daemon_dir().join("daemon.lock")
 }
 
 fn subscription_store_path() -> PathBuf {
@@ -10046,6 +10204,53 @@ impl Drop for StartLockGuard {
     }
 }
 
+struct DaemonOwnerLockGuard {
+    file: fs::File,
+    path: PathBuf,
+}
+
+impl DaemonOwnerLockGuard {
+    fn acquire(path: &Path, metadata: &DaemonOwnerMetadata) -> Result<Self> {
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(path)
+            .with_context(|| format!("Failed to open daemon owner lock {}", path.display()))?;
+
+        file.try_lock_exclusive().map_err(|_| {
+            StructuredError::new(
+                "DAEMON_OWNER_HELD",
+                format!(
+                    "Another daemon owner already holds {}. Run `uxc daemon doctor` for diagnostics.",
+                    path.display()
+                ),
+                Some(json!({
+                    "lock_path": path.display().to_string(),
+                })),
+            )
+        })?;
+
+        write_daemon_owner_metadata(&mut file, metadata)?;
+        Ok(Self {
+            file,
+            path: path.to_path_buf(),
+        })
+    }
+
+    fn clear_metadata(&mut self) {
+        let _ = clear_daemon_owner_metadata_file(&mut self.file);
+    }
+}
+
+impl Drop for DaemonOwnerLockGuard {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+        let _ = &self.path;
+    }
+}
+
 fn try_acquire_start_lock(path: &Path) -> Result<Option<StartLockGuard>> {
     match fs::OpenOptions::new()
         .create_new(true)
@@ -10079,6 +10284,279 @@ fn lock_is_stale(path: &Path, max_age: Duration) -> Result<bool> {
         .duration_since(modified)
         .unwrap_or_default();
     Ok(age > max_age)
+}
+
+fn write_daemon_owner_metadata(file: &mut fs::File, metadata: &DaemonOwnerMetadata) -> Result<()> {
+    file.seek(SeekFrom::Start(0))?;
+    file.set_len(0)?;
+    file.write_all(&serde_json::to_vec(metadata)?)?;
+    file.flush()?;
+    Ok(())
+}
+
+fn clear_daemon_owner_metadata_file(file: &mut fs::File) -> Result<()> {
+    file.seek(SeekFrom::Start(0))?;
+    file.set_len(0)?;
+    file.flush()?;
+    Ok(())
+}
+
+fn clear_daemon_owner_metadata_path(path: &Path) -> Result<()> {
+    let mut file = match fs::OpenOptions::new().read(true).write(true).open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err.into()),
+    };
+    clear_daemon_owner_metadata_file(&mut file)
+}
+
+fn read_daemon_owner_metadata(path: &Path) -> Result<Option<DaemonOwnerMetadata>> {
+    let contents = match fs::read(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    if contents.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(serde_json::from_slice(&contents)?))
+}
+
+fn daemon_lock_is_held(path: &Path) -> Result<bool> {
+    let file = match fs::OpenOptions::new().read(true).write(true).open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err.into()),
+    };
+
+    match file.try_lock_exclusive() {
+        Ok(()) => {
+            file.unlock()?;
+            Ok(false)
+        }
+        Err(err) if err.kind() == ErrorKind::WouldBlock => Ok(true),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[cfg(unix)]
+fn is_process_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    // SAFETY: kill(pid, 0) is a pure liveness probe.
+    let rc = unsafe { kill(pid as i32, 0) };
+    if rc == 0 {
+        return true;
+    }
+    match std::io::Error::last_os_error().raw_os_error() {
+        Some(1) => true,  // EPERM
+        Some(3) => false, // ESRCH
+        _ => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn is_process_alive(_pid: u32) -> bool {
+    false
+}
+
+fn inspect_daemon_local_diagnostics() -> Result<DaemonLocalDiagnostics> {
+    let lock_path = daemon_lock_path();
+    let socket = socket_path();
+    let metadata = read_daemon_owner_metadata(&lock_path)?;
+    let owner_lock_held = daemon_lock_is_held(&lock_path)?;
+    let owner_pid = metadata.as_ref().map(|m| m.pid);
+    let owner_pid_alive = owner_pid.map(is_process_alive).unwrap_or(false);
+
+    Ok(DaemonLocalDiagnostics {
+        socket: socket.display().to_string(),
+        socket_exists: socket.exists(),
+        owner_lock_held,
+        owner_pid,
+        owner_pid_alive,
+        owner_version: metadata.as_ref().map(|m| m.version.clone()),
+        owner_socket: metadata.as_ref().map(|m| m.socket.clone()),
+        owner_started_at_unix: metadata.as_ref().map(|m| m.started_at_unix),
+    })
+}
+
+pub fn daemon_status_from_diagnostics(diagnostics: &DaemonLocalDiagnostics) -> DaemonStatus {
+    DaemonStatus {
+        running: false,
+        pid: None,
+        socket: diagnostics.socket.clone(),
+        version: None,
+        started_at_unix: None,
+        request_count: 0,
+        mcp_stdio_sessions: 0,
+        mcp_http_sessions: 0,
+        mcp_reuse_hits: 0,
+        managed_sources: 0,
+        managed_sources_running: 0,
+        managed_streams: 0,
+        log_file: None,
+        owner_lock_held: Some(diagnostics.owner_lock_held),
+        owner_pid: diagnostics.owner_pid,
+        owner_pid_alive: Some(diagnostics.owner_pid_alive),
+        owner_version: diagnostics.owner_version.clone(),
+        owner_socket: diagnostics.owner_socket.clone(),
+        owner_started_at_unix: diagnostics.owner_started_at_unix,
+        socket_exists: Some(diagnostics.socket_exists),
+    }
+}
+
+fn doctor_message_for_diagnostics(diagnostics: &DaemonLocalDiagnostics, status: &str) -> String {
+    match status {
+        "healthy" => "Daemon is healthy.".to_string(),
+        "owner_unreachable" => format!(
+            "Live daemon owner exists (pid={}) but the daemon socket is unreachable. Refusing repair; run `uxc daemon stop` or inspect the owner process.",
+            diagnostics
+                .owner_pid
+                .map(|pid| pid.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        ),
+        "repaired" => "Removed stale daemon artifacts.".to_string(),
+        _ => "No live daemon owner found.".to_string(),
+    }
+}
+
+pub fn daemon_local_diagnostics() -> Result<DaemonLocalDiagnostics> {
+    inspect_daemon_local_diagnostics()
+}
+
+pub fn daemon_doctor_local() -> Result<DaemonDoctorResponse> {
+    if daemon_status_client_blocking().is_ok() {
+        let diagnostics = inspect_daemon_local_diagnostics()?;
+        return Ok(DaemonDoctorResponse {
+            status: "healthy".to_string(),
+            repaired: false,
+            socket_removed: false,
+            owner_metadata_cleared: false,
+            socket: diagnostics.socket.clone(),
+            diagnostics: diagnostics.clone(),
+            message: Some(doctor_message_for_diagnostics(&diagnostics, "healthy")),
+        });
+    }
+
+    let diagnostics = inspect_daemon_local_diagnostics()?;
+    if diagnostics.owner_lock_held && diagnostics.owner_pid_alive {
+        return Ok(DaemonDoctorResponse {
+            status: "owner_unreachable".to_string(),
+            repaired: false,
+            socket_removed: false,
+            owner_metadata_cleared: false,
+            socket: diagnostics.socket.clone(),
+            diagnostics: diagnostics.clone(),
+            message: Some(doctor_message_for_diagnostics(
+                &diagnostics,
+                "owner_unreachable",
+            )),
+        });
+    }
+
+    let mut repaired = false;
+    let mut socket_removed = false;
+    let mut owner_metadata_cleared = false;
+    let socket = socket_path();
+    if socket.exists() {
+        fs::remove_file(&socket).with_context(|| {
+            format!("Failed to remove stale daemon socket {}", socket.display())
+        })?;
+        repaired = true;
+        socket_removed = true;
+    }
+
+    let lock_path = daemon_lock_path();
+    if lock_path.exists() {
+        fs::remove_file(&lock_path).with_context(|| {
+            format!(
+                "Failed to remove stale daemon owner metadata {}",
+                lock_path.display()
+            )
+        })?;
+        repaired = true;
+        owner_metadata_cleared = true;
+    }
+
+    let diagnostics = inspect_daemon_local_diagnostics()?;
+    let status = if repaired { "repaired" } else { "clean" }.to_string();
+    Ok(DaemonDoctorResponse {
+        status: status.clone(),
+        repaired,
+        socket_removed,
+        owner_metadata_cleared,
+        socket: diagnostics.socket.clone(),
+        diagnostics: diagnostics.clone(),
+        message: Some(doctor_message_for_diagnostics(&diagnostics, &status)),
+    })
+}
+
+#[cfg(unix)]
+fn daemon_status_client_blocking() -> Result<DaemonStatus> {
+    let socket = socket_path();
+    let mut stream = StdUnixStream::connect(&socket)
+        .with_context(|| format!("Failed to connect daemon socket {}", socket.display()))?;
+    stream.set_read_timeout(Some(Duration::from_secs(CONNECT_TIMEOUT_SECS)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(CONNECT_TIMEOUT_SECS)))?;
+    let request = json!({
+        "jsonrpc": JSONRPC_VERSION,
+        "id": 1,
+        "method": "daemon.status",
+        "params": Value::Null,
+    });
+    write_frame_blocking(&mut stream, &request)?;
+    let resp_val = read_frame_blocking(&mut stream)?;
+    let resp: JsonRpcResponse = serde_json::from_value(resp_val)?;
+    if let Some(err) = resp.error {
+        bail!("{}", err.message);
+    }
+    Ok(serde_json::from_value(resp.result.unwrap_or(Value::Null))?)
+}
+
+#[cfg(not(unix))]
+fn daemon_status_client_blocking() -> Result<DaemonStatus> {
+    bail!("uxcd daemon is not supported on this platform; run uxc inside WSL")
+}
+
+#[cfg(unix)]
+fn write_frame_blocking(stream: &mut StdUnixStream, value: &Value) -> Result<()> {
+    let body = serde_json::to_vec(value)?;
+    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+    stream.write_all(header.as_bytes())?;
+    stream.write_all(&body)?;
+    stream.flush()?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn read_frame_blocking(stream: &mut StdUnixStream) -> Result<Value> {
+    use std::io::Read;
+
+    let mut header = Vec::new();
+    let mut byte = [0_u8; 1];
+    loop {
+        let n = stream.read(&mut byte)?;
+        if n == 0 {
+            bail!("EOF while reading frame header");
+        }
+        header.push(byte[0]);
+        if header.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let header_str = String::from_utf8(header)?;
+    let mut content_len = None;
+    for line in header_str.split("\r\n") {
+        if let Some(rest) = line.trim().strip_prefix("Content-Length:") {
+            content_len = Some(rest.trim().parse::<usize>()?);
+        }
+    }
+    let len = content_len.ok_or_else(|| anyhow!("Missing Content-Length header"))?;
+    let mut body = vec![0_u8; len];
+    stream.read_exact(&mut body)?;
+    Ok(serde_json::from_slice(&body)?)
 }
 
 fn ensure_private_dir(path: &Path) -> Result<()> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7735,8 +7735,10 @@ pub async fn daemon_session_kill_local(
     daemon_session_kill_client(request).await
 }
 
-pub fn daemon_doctor_local_result() -> Result<DaemonDoctorResponse> {
-    daemon_doctor_local()
+pub async fn daemon_doctor_local_result() -> Result<DaemonDoctorResponse> {
+    tokio::task::spawn_blocking(daemon_doctor_local_blocking)
+        .await
+        .map_err(|err| anyhow!("daemon doctor task failed: {err}"))?
 }
 
 pub async fn daemon_start_local() -> Result<EnsureDaemonOutcome> {
@@ -7768,32 +7770,48 @@ pub async fn daemon_stop_local() -> Result<bool> {
             .into());
         }
 
-        // SAFETY: kill with SIGTERM targets the owner pid discovered from local metadata.
-        if unsafe { kill(pid as i32, DAEMON_OWNER_TERM_SIGNAL) } == -1 {
-            return Err(std::io::Error::last_os_error().into());
-        }
-
-        for _ in 0..STOP_POLL_TRIES {
-            tokio::time::sleep(Duration::from_millis(STOP_POLL_INTERVAL_MS)).await;
-            let diagnostics = inspect_daemon_local_diagnostics()?;
-            if !diagnostics.owner_lock_held {
-                let _ = clear_daemon_owner_metadata_path(&daemon_lock_path());
-                if socket_path().exists() {
-                    let _ = fs::remove_file(socket_path());
-                }
-                return Ok(true);
+        #[cfg(unix)]
+        {
+            // SAFETY: kill with SIGTERM targets the owner pid discovered from local metadata.
+            if unsafe { kill(pid as i32, DAEMON_OWNER_TERM_SIGNAL) } == -1 {
+                return Err(std::io::Error::last_os_error().into());
             }
+
+            for _ in 0..STOP_POLL_TRIES {
+                tokio::time::sleep(Duration::from_millis(STOP_POLL_INTERVAL_MS)).await;
+                let diagnostics = inspect_daemon_local_diagnostics()?;
+                if !diagnostics.owner_lock_held {
+                    let _ = clear_daemon_owner_metadata_path(&daemon_lock_path());
+                    if socket_path().exists() {
+                        let _ = fs::remove_file(socket_path());
+                    }
+                    return Ok(true);
+                }
+            }
+
+            return Err(StructuredError::new(
+                "DAEMON_STOP_TIMEOUT",
+                format!(
+                    "Daemon owner pid {} did not stop in time. Run `uxc daemon doctor`.",
+                    pid
+                ),
+                Some(serde_json::to_value(diagnostics)?),
+            )
+            .into());
         }
 
-        return Err(StructuredError::new(
-            "DAEMON_STOP_TIMEOUT",
-            format!(
-                "Daemon owner pid {} did not stop in time. Run `uxc daemon doctor`.",
-                pid
-            ),
-            Some(serde_json::to_value(diagnostics)?),
-        )
-        .into());
+        #[cfg(not(unix))]
+        {
+            return Err(StructuredError::new(
+                "DAEMON_STOP_UNSUPPORTED_PLATFORM",
+                format!(
+                    "Daemon owner pid {} cannot be stopped via Unix signals on this platform.",
+                    pid
+                ),
+                Some(serde_json::to_value(&diagnostics)?),
+            )
+            .into());
+        }
     }
     daemon_stop_client().await?;
     for _ in 0..STOP_POLL_TRIES {
@@ -10206,7 +10224,6 @@ impl Drop for StartLockGuard {
 
 struct DaemonOwnerLockGuard {
     file: fs::File,
-    path: PathBuf,
 }
 
 impl DaemonOwnerLockGuard {
@@ -10219,24 +10236,29 @@ impl DaemonOwnerLockGuard {
             .open(path)
             .with_context(|| format!("Failed to open daemon owner lock {}", path.display()))?;
 
-        file.try_lock_exclusive().map_err(|_| {
-            StructuredError::new(
-                "DAEMON_OWNER_HELD",
-                format!(
-                    "Another daemon owner already holds {}. Run `uxc daemon doctor` for diagnostics.",
-                    path.display()
-                ),
-                Some(json!({
-                    "lock_path": path.display().to_string(),
-                })),
-            )
-        })?;
+        match file.try_lock_exclusive() {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                return Err(StructuredError::new(
+                    "DAEMON_OWNER_HELD",
+                    format!(
+                        "Another daemon owner already holds {}. Run `uxc daemon doctor` for diagnostics.",
+                        path.display()
+                    ),
+                    Some(json!({
+                        "lock_path": path.display().to_string(),
+                    })),
+                )
+                .into());
+            }
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("Failed to lock daemon owner lock {}", path.display()));
+            }
+        }
 
         write_daemon_owner_metadata(&mut file, metadata)?;
-        Ok(Self {
-            file,
-            path: path.to_path_buf(),
-        })
+        Ok(Self { file })
     }
 
     fn clear_metadata(&mut self) {
@@ -10247,7 +10269,6 @@ impl DaemonOwnerLockGuard {
 impl Drop for DaemonOwnerLockGuard {
     fn drop(&mut self) {
         let _ = self.file.unlock();
-        let _ = &self.path;
     }
 }
 
@@ -10416,6 +10437,7 @@ fn doctor_message_for_diagnostics(diagnostics: &DaemonLocalDiagnostics, status: 
                 .map(|pid| pid.to_string())
                 .unwrap_or_else(|| "unknown".to_string())
         ),
+        "owner_held" => "Daemon owner lock is still held but owner metadata is stale or incomplete. Refusing repair; wait for the owner to exit or inspect the lock holder.".to_string(),
         "repaired" => "Removed stale daemon artifacts.".to_string(),
         _ => "No live daemon owner found.".to_string(),
     }
@@ -10425,7 +10447,7 @@ pub fn daemon_local_diagnostics() -> Result<DaemonLocalDiagnostics> {
     inspect_daemon_local_diagnostics()
 }
 
-pub fn daemon_doctor_local() -> Result<DaemonDoctorResponse> {
+fn daemon_doctor_local_blocking() -> Result<DaemonDoctorResponse> {
     if daemon_status_client_blocking().is_ok() {
         let diagnostics = inspect_daemon_local_diagnostics()?;
         return Ok(DaemonDoctorResponse {
@@ -10440,18 +10462,20 @@ pub fn daemon_doctor_local() -> Result<DaemonDoctorResponse> {
     }
 
     let diagnostics = inspect_daemon_local_diagnostics()?;
-    if diagnostics.owner_lock_held && diagnostics.owner_pid_alive {
+    if diagnostics.owner_lock_held {
+        let status = if diagnostics.owner_pid_alive {
+            "owner_unreachable"
+        } else {
+            "owner_held"
+        };
         return Ok(DaemonDoctorResponse {
-            status: "owner_unreachable".to_string(),
+            status: status.to_string(),
             repaired: false,
             socket_removed: false,
             owner_metadata_cleared: false,
             socket: diagnostics.socket.clone(),
             diagnostics: diagnostics.clone(),
-            message: Some(doctor_message_for_diagnostics(
-                &diagnostics,
-                "owner_unreachable",
-            )),
+            message: Some(doctor_message_for_diagnostics(&diagnostics, status)),
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,8 @@ enum DaemonCommands {
     Start,
     /// Stop daemon process
     Stop,
+    /// Diagnose and safely repair stale local daemon state
+    Doctor,
     /// Show daemon status
     Status,
     /// List MCP daemon sessions
@@ -1690,6 +1692,7 @@ fn static_help_path_from_cli(cli: &Cli) -> Option<Vec<&'static str>> {
         Some(Commands::Daemon { daemon_command }) => match daemon_command {
             DaemonCommands::Start => Some(vec!["daemon", "start"]),
             DaemonCommands::Stop => Some(vec!["daemon", "stop"]),
+            DaemonCommands::Doctor => Some(vec!["daemon", "doctor"]),
             DaemonCommands::Status => Some(vec!["daemon", "status"]),
             DaemonCommands::Sessions => Some(vec!["daemon", "sessions"]),
             DaemonCommands::Session { session_command } => match session_command {
@@ -2205,10 +2208,11 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
         ["daemon"] => HelpData {
             path: "uxc daemon".to_string(),
             about: "Manage local runtime daemon".to_string(),
-            usage: "uxc daemon <start|stop|status|sessions|session|restart>".to_string(),
+            usage: "uxc daemon <start|stop|doctor|status|sessions|session|restart>".to_string(),
             commands: commands(&[
                 ("start", "Start daemon process"),
                 ("stop", "Stop daemon process"),
+                ("doctor", "Diagnose and safely repair local daemon state"),
                 ("status", "Show daemon status"),
                 ("sessions", "List daemon MCP sessions"),
                 ("session", "Manage one daemon-backed MCP session"),
@@ -2222,6 +2226,7 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
                 "uxc daemon status".to_string(),
                 "uxc daemon start".to_string(),
                 "uxc daemon stop".to_string(),
+                "uxc daemon doctor".to_string(),
                 "uxc daemon restart".to_string(),
             ],
         },
@@ -2254,6 +2259,17 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
             commands: vec![],
             notes: vec![],
             examples: vec!["uxc daemon stop".to_string()],
+        },
+        ["daemon", "doctor"] => HelpData {
+            path: "uxc daemon doctor".to_string(),
+            about: "Diagnose and safely repair local daemon state".to_string(),
+            usage: "uxc daemon doctor".to_string(),
+            commands: vec![],
+            notes: vec![
+                "Inspects the daemon owner lock, owner pid metadata, and socket path. Removes stale local artifacts only when no live daemon owner exists."
+                    .to_string(),
+            ],
+            examples: vec!["uxc daemon doctor".to_string()],
         },
         ["daemon", "status"] => HelpData {
             path: "uxc daemon status".to_string(),
@@ -3017,6 +3033,22 @@ fn render_text_output(envelope: &OutputEnvelope) -> Result<()> {
             }
             Ok(())
         }
+        Some("daemon_doctor_result") => {
+            let data = envelope.data.clone().unwrap_or(Value::Null);
+            if let Some(status) = data.get("status").and_then(Value::as_str) {
+                println!("Status: {}", status);
+            }
+            if let Some(message) = data.get("message").and_then(Value::as_str) {
+                println!("Message: {}", message);
+            }
+            if let Some(socket) = data.get("socket").and_then(Value::as_str) {
+                println!("Socket: {}", socket);
+            }
+            if let Some(repaired) = data.get("repaired").and_then(Value::as_bool) {
+                println!("Repaired: {}", repaired);
+            }
+            Ok(())
+        }
         Some("daemon_status") => {
             let data = envelope.data.clone().unwrap_or(Value::Null);
             let running = data
@@ -3048,6 +3080,15 @@ fn render_text_output(envelope: &OutputEnvelope) -> Result<()> {
             }
             if let Some(requests) = data.get("request_count").and_then(Value::as_u64) {
                 println!("Requests: {}", requests);
+            }
+            if let Some(owner_lock_held) = data.get("owner_lock_held").and_then(Value::as_bool) {
+                println!("Owner Lock Held: {}", owner_lock_held);
+            }
+            if let Some(owner_pid) = data.get("owner_pid").and_then(Value::as_u64) {
+                println!("Owner PID: {}", owner_pid);
+            }
+            if let Some(owner_pid_alive) = data.get("owner_pid_alive").and_then(Value::as_bool) {
+                println!("Owner PID Alive: {}", owner_pid_alive);
             }
             Ok(())
         }
@@ -5447,6 +5488,17 @@ async fn handle_daemon_command(command: &DaemonCommands) -> Result<OutputEnvelop
                 None,
             ))
         }
+        DaemonCommands::Doctor => {
+            let result = daemon::daemon_doctor_local_result()?;
+            Ok(OutputEnvelope::success(
+                "daemon_doctor_result",
+                "cli",
+                "uxc",
+                None,
+                serde_json::to_value(result)?,
+                None,
+            ))
+        }
         DaemonCommands::Status => {
             let status = match daemon::daemon_status_local().await {
                 Ok(status) => {
@@ -5466,19 +5518,31 @@ async fn handle_daemon_command(command: &DaemonCommands) -> Result<OutputEnvelop
                     }
                     value
                 }
-                Err(err) => json!({
-                    "running": false,
-                    "socket": daemon::socket_path().display().to_string(),
-                    "client_version": env!("CARGO_PKG_VERSION"),
-                    "version_mismatch": false,
-                    "managed_sources": 0,
-                    "managed_sources_running": 0,
-                    "managed_streams": 0,
-                    "error": {
-                        "code": "DAEMON_UNREACHABLE",
-                        "message": err.to_string()
+                Err(err) => {
+                    let diagnostics = daemon::daemon_local_diagnostics()?;
+                    let mut value =
+                        serde_json::to_value(daemon::daemon_status_from_diagnostics(&diagnostics))?;
+                    let error_code = if diagnostics.owner_lock_held && diagnostics.owner_pid_alive {
+                        "DAEMON_OWNER_UNREACHABLE"
+                    } else {
+                        "DAEMON_UNREACHABLE"
+                    };
+                    if let Some(obj) = value.as_object_mut() {
+                        obj.insert(
+                            "client_version".to_string(),
+                            Value::String(env!("CARGO_PKG_VERSION").to_string()),
+                        );
+                        obj.insert("version_mismatch".to_string(), Value::Bool(false));
+                        obj.insert(
+                            "error".to_string(),
+                            json!({
+                                "code": error_code,
+                                "message": err.to_string()
+                            }),
+                        );
                     }
-                }),
+                    value
+                }
             };
             Ok(OutputEnvelope::success(
                 "daemon_status",

--- a/src/main.rs
+++ b/src/main.rs
@@ -5489,7 +5489,7 @@ async fn handle_daemon_command(command: &DaemonCommands) -> Result<OutputEnvelop
             ))
         }
         DaemonCommands::Doctor => {
-            let result = daemon::daemon_doctor_local_result()?;
+            let result = daemon::daemon_doctor_local_result().await?;
             Ok(OutputEnvelope::success(
                 "daemon_doctor_result",
                 "cli",

--- a/tests/cli_help_regression_test.rs
+++ b/tests/cli_help_regression_test.rs
@@ -101,6 +101,25 @@ fn daemon_session_kill_help_outputs_json() {
 
 #[test]
 #[serial]
+fn daemon_doctor_help_outputs_json() {
+    let output = uxc_command()
+        .arg("daemon")
+        .arg("doctor")
+        .arg("-h")
+        .output()
+        .expect("failed to run uxc daemon doctor -h");
+
+    assert!(output.status.success(), "command should succeed");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["kind"], "subcommand_help");
+    assert_eq!(json["data"]["path"], "uxc daemon doctor");
+    assert_eq!(json["data"]["usage"], "uxc daemon doctor");
+}
+
+#[test]
+#[serial]
 fn help_subcommand_defaults_to_json() {
     let output = uxc_command()
         .arg("help")

--- a/tests/daemon_cli_test.rs
+++ b/tests/daemon_cli_test.rs
@@ -425,6 +425,7 @@ fn daemon_start_fails_closed_when_owner_lock_is_held() {
         .create(true)
         .read(true)
         .write(true)
+        .truncate(false)
         .open(&lock_path)
         .expect("daemon lock should open");
     lock_file
@@ -468,6 +469,7 @@ fn daemon_status_surfaces_owner_diagnostics_when_owner_is_unreachable() {
         .create(true)
         .read(true)
         .write(true)
+        .truncate(false)
         .open(&lock_path)
         .expect("daemon lock should open");
     lock_file

--- a/tests/daemon_cli_test.rs
+++ b/tests/daemon_cli_test.rs
@@ -363,6 +363,57 @@ fn daemon_doctor_repairs_stale_socket_and_owner_metadata() {
 
 #[test]
 #[serial]
+fn daemon_doctor_refuses_repair_when_owner_lock_is_held() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+
+    let daemon_dir = daemon_runtime_dir(temp_home.path());
+    fs::create_dir_all(&daemon_dir).expect("daemon dir should exist");
+    fs::write(daemon_socket_path(temp_home.path()), b"stale").expect("stale socket marker");
+
+    let mut lock_file = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(daemon_lock_path(temp_home.path()))
+        .expect("daemon lock should open");
+    lock_file
+        .try_lock_exclusive()
+        .expect("daemon lock should be acquirable");
+    writeln!(
+        lock_file,
+        "{}",
+        serde_json::json!({
+            "pid": 999999_u32,
+            "version": "0.0.0",
+            "socket": daemon_socket_path(temp_home.path()).display().to_string(),
+            "started_at_unix": 1_u64,
+        })
+    )
+    .expect("owner metadata should write");
+    lock_file.flush().expect("owner metadata should flush");
+
+    let output = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("doctor")
+        .output()
+        .expect("daemon doctor should run");
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["kind"], "daemon_doctor_result");
+    assert_eq!(json["data"]["status"], "owner_held");
+    assert_eq!(json["data"]["repaired"], false);
+    assert_eq!(json["data"]["socket_removed"], false);
+    assert_eq!(json["data"]["owner_metadata_cleared"], false);
+    assert!(daemon_socket_path(temp_home.path()).exists());
+    assert!(daemon_lock_path(temp_home.path()).exists());
+}
+
+#[test]
+#[serial]
 fn daemon_start_fails_closed_when_owner_lock_is_held() {
     let temp_home = tempfile::tempdir().expect("temp home should be created");
     daemon_stop_best_effort_with_home(temp_home.path());

--- a/tests/daemon_cli_test.rs
+++ b/tests/daemon_cli_test.rs
@@ -1,28 +1,92 @@
+mod common;
+
 use assert_cmd::Command;
+use fs2::FileExt;
 use serial_test::serial;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command as StdCommand, Stdio};
+use std::time::{Duration, Instant};
+
+use common::{uxc_binary, uxc_command_with_home};
 
 #[allow(deprecated)]
 fn uxc_command() -> Command {
     Command::cargo_bin("uxc").expect("uxc binary should build")
 }
 
-fn daemon_stop_best_effort() {
-    let _ = uxc_command().arg("daemon").arg("stop").output();
+fn daemon_stop_best_effort_with_home(home: &Path) {
+    let _ = uxc_command_with_home(home)
+        .arg("daemon")
+        .arg("stop")
+        .output();
+}
+
+fn daemon_runtime_dir(home: &Path) -> PathBuf {
+    home.join("runtime").join("uxc")
+}
+
+fn daemon_socket_path(home: &Path) -> PathBuf {
+    daemon_runtime_dir(home).join("uxc.sock")
+}
+
+fn daemon_lock_path(home: &Path) -> PathBuf {
+    daemon_runtime_dir(home).join("daemon.lock")
+}
+
+fn spawn_daemon_serve(home: &Path) -> Child {
+    let runtime_dir = home.join("runtime");
+    fs::create_dir_all(&runtime_dir).expect("runtime dir should exist");
+    StdCommand::new(uxc_binary())
+        .arg("daemon")
+        .arg("_serve")
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("daemon _serve should spawn")
+}
+
+fn wait_for_path(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("path did not appear: {}", path.display());
+}
+
+fn wait_for_exit(child: &mut Child) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if child.try_wait().expect("try_wait should succeed").is_some() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("child did not exit in time");
 }
 
 #[test]
 #[serial]
 fn daemon_start_status_stop_lifecycle() {
-    daemon_stop_best_effort();
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
 
-    let start = uxc_command()
+    let start = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("start")
         .output()
         .expect("daemon start should run");
     assert!(start.status.success());
 
-    let status = uxc_command()
+    let status = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("status")
         .output()
@@ -39,7 +103,7 @@ fn daemon_start_status_stop_lifecycle() {
     assert!(json["data"]["managed_sources_running"].is_number());
     assert!(json["data"]["managed_streams"].is_number());
 
-    let stop = uxc_command()
+    let stop = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("stop")
         .output()
@@ -47,7 +111,7 @@ fn daemon_start_status_stop_lifecycle() {
     assert!(stop.status.success());
 
     // Stop path should wait for daemon to become unreachable.
-    let status_after_stop = uxc_command()
+    let status_after_stop = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("status")
         .output()
@@ -68,7 +132,8 @@ fn daemon_start_status_stop_lifecycle() {
 #[test]
 #[serial]
 fn endpoint_host_help_autostarts_daemon_and_sets_meta() {
-    daemon_stop_best_effort();
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
 
     let mut server = mockito::Server::new();
     let _schema = server
@@ -84,7 +149,7 @@ fn endpoint_host_help_autostarts_daemon_and_sets_meta() {
         )
         .create();
 
-    let output = uxc_command()
+    let output = uxc_command_with_home(temp_home.path())
         .arg(server.url())
         .arg("--no-cache")
         .arg("-h")
@@ -98,15 +163,16 @@ fn endpoint_host_help_autostarts_daemon_and_sets_meta() {
     assert_eq!(json["meta"]["daemon_autostarted"], true);
     assert_eq!(json["meta"]["daemon_restarted_for_version_mismatch"], false);
 
-    daemon_stop_best_effort();
+    daemon_stop_best_effort_with_home(temp_home.path());
 }
 
 #[test]
 #[serial]
 fn daemon_start_reports_started_now_and_already_running() {
-    daemon_stop_best_effort();
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
 
-    let first = uxc_command()
+    let first = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("start")
         .output()
@@ -120,7 +186,7 @@ fn daemon_start_reports_started_now_and_already_running() {
     assert_eq!(first_json["data"]["restarted_for_version_mismatch"], false);
     assert_eq!(first_json["data"]["version"], env!("CARGO_PKG_VERSION"));
 
-    let second = uxc_command()
+    let second = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("start")
         .output()
@@ -135,16 +201,17 @@ fn daemon_start_reports_started_now_and_already_running() {
     assert_eq!(second_json["data"]["restarted_for_version_mismatch"], false);
     assert_eq!(second_json["data"]["version"], env!("CARGO_PKG_VERSION"));
 
-    daemon_stop_best_effort();
+    daemon_stop_best_effort_with_home(temp_home.path());
 }
 
 #[test]
 #[serial]
 fn daemon_restart_when_running() {
-    daemon_stop_best_effort();
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
 
     // Start daemon first
-    let start = uxc_command()
+    let start = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("start")
         .output()
@@ -152,7 +219,7 @@ fn daemon_restart_when_running() {
     assert!(start.status.success());
 
     // Restart should stop and start
-    let restart = uxc_command()
+    let restart = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("restart")
         .output()
@@ -167,7 +234,7 @@ fn daemon_restart_when_running() {
     assert!(restart_json["data"]["socket"].as_str().is_some());
 
     // Verify daemon is running after restart
-    let status = uxc_command()
+    let status = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("status")
         .output()
@@ -177,16 +244,17 @@ fn daemon_restart_when_running() {
         serde_json::from_slice(&status.stdout).expect("valid json");
     assert_eq!(status_json["data"]["running"], true);
 
-    daemon_stop_best_effort();
+    daemon_stop_best_effort_with_home(temp_home.path());
 }
 
 #[test]
 #[serial]
 fn daemon_restart_when_not_running() {
-    daemon_stop_best_effort();
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
 
     // Restart when daemon is not running should just start it
-    let restart = uxc_command()
+    let restart = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("restart")
         .output()
@@ -201,7 +269,7 @@ fn daemon_restart_when_not_running() {
     assert!(restart_json["data"]["socket"].as_str().is_some());
 
     // Verify daemon is running after restart
-    let status = uxc_command()
+    let status = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("status")
         .output()
@@ -211,7 +279,7 @@ fn daemon_restart_when_not_running() {
         serde_json::from_slice(&status.stdout).expect("valid json");
     assert_eq!(status_json["data"]["running"], true);
 
-    daemon_stop_best_effort();
+    daemon_stop_best_effort_with_home(temp_home.path());
 }
 
 #[test]
@@ -240,10 +308,11 @@ fn daemon_restart_help_shows_restart_subcommand_help() {
 #[test]
 #[serial]
 fn daemon_restart_text_output_renders_correctly() {
-    daemon_stop_best_effort();
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
 
     // Test restart when daemon is not running
-    let restart = uxc_command()
+    let restart = uxc_command_with_home(temp_home.path())
         .arg("daemon")
         .arg("restart")
         .arg("--text")
@@ -256,5 +325,169 @@ fn daemon_restart_text_output_renders_correctly() {
     assert!(stdout.contains("Daemon started."));
     assert!(stdout.contains("Socket:"));
 
-    daemon_stop_best_effort();
+    daemon_stop_best_effort_with_home(temp_home.path());
+}
+
+#[test]
+#[serial]
+fn daemon_doctor_repairs_stale_socket_and_owner_metadata() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+
+    let daemon_dir = daemon_runtime_dir(temp_home.path());
+    fs::create_dir_all(&daemon_dir).expect("daemon dir should exist");
+    fs::write(daemon_socket_path(temp_home.path()), b"stale").expect("stale socket marker");
+    fs::write(
+        daemon_lock_path(temp_home.path()),
+        r#"{"pid":999999,"version":"0.0.0","socket":"/tmp/old.sock","started_at_unix":1}"#,
+    )
+    .expect("stale owner metadata");
+
+    let output = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("doctor")
+        .output()
+        .expect("daemon doctor should run");
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["kind"], "daemon_doctor_result");
+    assert_eq!(json["data"]["status"], "repaired");
+    assert_eq!(json["data"]["repaired"], true);
+    assert_eq!(json["data"]["socket_removed"], true);
+    assert_eq!(json["data"]["owner_metadata_cleared"], true);
+    assert!(!daemon_socket_path(temp_home.path()).exists());
+    assert!(!daemon_lock_path(temp_home.path()).exists());
+}
+
+#[test]
+#[serial]
+fn daemon_start_fails_closed_when_owner_lock_is_held() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+
+    let daemon_dir = daemon_runtime_dir(temp_home.path());
+    fs::create_dir_all(&daemon_dir).expect("daemon dir should exist");
+    let lock_path = daemon_lock_path(temp_home.path());
+    let mut lock_file = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .expect("daemon lock should open");
+    lock_file
+        .try_lock_exclusive()
+        .expect("test process should hold daemon owner lock");
+    writeln!(
+        lock_file,
+        "{{\"pid\":{},\"version\":\"{}\",\"socket\":\"{}\",\"started_at_unix\":1}}",
+        std::process::id(),
+        env!("CARGO_PKG_VERSION"),
+        daemon_socket_path(temp_home.path()).display()
+    )
+    .expect("owner metadata should write");
+    lock_file.flush().expect("owner metadata should flush");
+
+    let output = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("daemon start should run");
+    assert!(!output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "DAEMON_OWNER_UNREACHABLE");
+    assert!(json["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("Refusing to start a second daemon")));
+}
+
+#[test]
+#[serial]
+fn daemon_status_surfaces_owner_diagnostics_when_owner_is_unreachable() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+
+    let daemon_dir = daemon_runtime_dir(temp_home.path());
+    fs::create_dir_all(&daemon_dir).expect("daemon dir should exist");
+    let lock_path = daemon_lock_path(temp_home.path());
+    let mut lock_file = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .expect("daemon lock should open");
+    lock_file
+        .try_lock_exclusive()
+        .expect("test process should hold daemon owner lock");
+    writeln!(
+        lock_file,
+        "{{\"pid\":{},\"version\":\"{}\",\"socket\":\"{}\",\"started_at_unix\":1}}",
+        std::process::id(),
+        env!("CARGO_PKG_VERSION"),
+        daemon_socket_path(temp_home.path()).display()
+    )
+    .expect("owner metadata should write");
+    lock_file.flush().expect("owner metadata should flush");
+
+    let output = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("status")
+        .output()
+        .expect("daemon status should run");
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["running"], false);
+    assert_eq!(json["data"]["owner_lock_held"], true);
+    assert_eq!(json["data"]["owner_pid"], std::process::id());
+    assert_eq!(json["data"]["owner_pid_alive"], true);
+    assert_eq!(json["data"]["error"]["code"], "DAEMON_OWNER_UNREACHABLE");
+}
+
+#[test]
+#[serial]
+fn daemon_stop_falls_back_to_owner_pid_when_socket_is_missing() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+
+    let mut child = spawn_daemon_serve(temp_home.path());
+    wait_for_path(&daemon_socket_path(temp_home.path()));
+    fs::remove_file(daemon_socket_path(temp_home.path())).expect("socket path should be removed");
+
+    let output = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("stop")
+        .output()
+        .expect("daemon stop should run");
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["stopped"], true);
+
+    wait_for_exit(&mut child);
+    assert!(!daemon_socket_path(temp_home.path()).exists());
+
+    let status_output = uxc_command_with_home(temp_home.path())
+        .arg("daemon")
+        .arg("status")
+        .output()
+        .expect("daemon status should run");
+    assert!(status_output.status.success());
+
+    let status_json: serde_json::Value =
+        serde_json::from_slice(&status_output.stdout).expect("valid status json");
+    assert_eq!(status_json["ok"], true);
+    assert_eq!(status_json["data"]["running"], false);
+    assert_eq!(status_json["data"]["owner_lock_held"], false);
+
+    if daemon_lock_path(temp_home.path()).exists() {
+        let lock_contents = fs::read_to_string(daemon_lock_path(temp_home.path()))
+            .expect("lock should be readable");
+        assert!(lock_contents.trim().is_empty());
+    }
 }


### PR DESCRIPTION
## What
- add a long-lived daemon owner lock and local owner diagnostics
- make daemon start fail closed when an owner exists but the daemon is unreachable
- add `uxc daemon doctor` for safe diagnosis and stale-state repair
- tighten stop fallback and isolate daemon CLI lifecycle tests per HOME

## Why
- current daemon startup can create duplicate `_serve` owners for the same socket path
- once that happens, the new process can steal the socket pathname and leave the old owner alive
- users need a safe way to diagnose and repair stale socket/lock state without starting a second owner

## How
- hold `~/.uxc/.../daemon.lock` with an OS file lock for the `_serve` lifecycle and persist owner metadata
- surface owner lock diagnostics in daemon status fallbacks and start/stop error paths
- use local owner metadata as the fallback path for `daemon stop`
- add `daemon doctor` CLI output/help and repair behavior
- add regression coverage for stale socket repair, owner-held start failure, owner-unreachable status, and stop fallback

## Testing
- `cargo check -q`
- `cargo test --test daemon_cli_test -- --test-threads=1`
- `cargo test daemon_doctor_help_outputs_json --test cli_help_regression_test -- --test-threads=1`
- `cargo test --test daemon_version_mismatch_test -- --test-threads=1`

Closes #378
