### PR TITLE
fix(openapi): don't consume `body` key as raw HTTP body when schema defines it as a property

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src/adapters/openapi.rs
+++ b/src/adapters/openapi.rs
@@ -1032,8 +1032,7 @@ impl OpenAPIAdapter {
         }
 
         let body_config = Self::request_body_config(path_item, operation_spec, root)?;
-        let should_check_body_schema =
-            explicit_body.is_none() && remaining.contains_key("body");
+        let should_check_body_schema = explicit_body.is_none() && remaining.contains_key("body");
         // Closure to check whether the request body schema for a given media
         // type defines "body" as a property.  Scoped per media type so that
         // e.g. a multipart-only `body` property does not leak into the JSON
@@ -1446,12 +1445,7 @@ impl OpenAPIAdapter {
             if let Some(sub_schemas) = schema.get(keyword).and_then(Value::as_array) {
                 for sub_schema_raw in sub_schemas {
                     let sub_schema = Self::dereference_value(sub_schema_raw, root);
-                    if Self::schema_has_property_recursive(
-                        sub_schema,
-                        root,
-                        property,
-                        depth + 1,
-                    ) {
+                    if Self::schema_has_property_recursive(sub_schema, root, property, depth + 1) {
                         return true;
                     }
                 }
@@ -3574,10 +3568,7 @@ mod tests {
         );
         // "body" must appear as a property inside the JSON object,
         // NOT as the raw HTTP body.
-        assert_eq!(
-            prepared.json_body,
-            Some(json!({"body": "Test comment"}))
-        );
+        assert_eq!(prepared.json_body, Some(json!({"body": "Test comment"})));
     }
 
     #[test]
@@ -3597,10 +3588,7 @@ mod tests {
         });
 
         let mut args = HashMap::new();
-        args.insert(
-            "body".to_string(),
-            json!({"name": "test", "value": 42}),
-        );
+        args.insert("body".to_string(), json!({"name": "test", "value": 42}));
 
         let prepared = OpenAPIAdapter::prepare_request(
             "post",
@@ -3712,10 +3700,7 @@ mod tests {
 
         // No file field → multipart_should_be_preferred returns false → JSON branch
         let mut args = HashMap::new();
-        args.insert(
-            "body".to_string(),
-            json!({"text": "hello"}),
-        );
+        args.insert("body".to_string(), json!({"text": "hello"}));
 
         let prepared = OpenAPIAdapter::prepare_request(
             "post",
@@ -3730,9 +3715,6 @@ mod tests {
 
         // JSON schema does NOT define "body" as a property, so the raw-body
         // shorthand should still work on this branch.
-        assert_eq!(
-            prepared.json_body,
-            Some(json!({"text": "hello"}))
-        );
+        assert_eq!(prepared.json_body, Some(json!({"text": "hello"})));
     }
 }

--- a/src/adapters/openapi.rs
+++ b/src/adapters/openapi.rs
@@ -1032,13 +1032,25 @@ impl OpenAPIAdapter {
         }
 
         let body_config = Self::request_body_config(path_item, operation_spec, root)?;
-        let body_is_schema_property =
-            Self::request_body_schema_has_body_property(path_item, operation_spec, root);
+        // Closure to check whether the request body schema for a given media
+        // type defines "body" as a property.  Scoped per media type so that
+        // e.g. a multipart-only `body` property does not leak into the JSON
+        // branch of a JsonOrMultipart operation.
+        let body_in_schema = |media_type: &str| {
+            Self::request_body_schema_has_body_property(
+                path_item,
+                operation_spec,
+                root,
+                media_type,
+            )
+        };
+
         let (json_body, form_body, multipart_body) = match &body_config {
             RequestBodyConfig::None => (None, None, None),
             RequestBodyConfig::FormUrlEncoded => {
+                let body_is_prop = body_in_schema("application/x-www-form-urlencoded");
                 if let Some(body) = explicit_body.or_else(|| {
-                    if body_is_schema_property {
+                    if body_is_prop {
                         None
                     } else {
                         remaining.remove("body")
@@ -1059,6 +1071,7 @@ impl OpenAPIAdapter {
                 (None, Some(form_pairs), None)
             }
             RequestBodyConfig::Json => {
+                let body_is_prop = body_in_schema("application/json");
                 if explicit_body.is_none() && remaining.is_empty() {
                     if let Some(name) = &missing_required_body_param {
                         anyhow::bail!("Missing required parameter '{}'", name);
@@ -1067,12 +1080,13 @@ impl OpenAPIAdapter {
                 let json_body = Self::json_body_from_remaining_with_explicit(
                     &mut remaining,
                     explicit_body,
-                    body_is_schema_property,
+                    body_is_prop,
                 )?;
                 (Some(json_body), None, None)
             }
             RequestBodyConfig::JsonOrMultipart(spec) => {
                 if Self::multipart_should_be_preferred(explicit_body.as_ref(), &remaining, spec) {
+                    let body_is_prop = body_in_schema("multipart/form-data");
                     if explicit_body.is_none() && remaining.is_empty() && form_pairs.is_empty() {
                         if let Some(name) = &missing_required_body_param {
                             anyhow::bail!("Missing required parameter '{}'", name);
@@ -1080,7 +1094,7 @@ impl OpenAPIAdapter {
                     }
                     if !form_pairs.is_empty() {
                         if let Some(body) = explicit_body.or_else(|| {
-                            if body_is_schema_property {
+                            if body_is_prop {
                                 None
                             } else {
                                 remaining.remove("body")
@@ -1107,12 +1121,13 @@ impl OpenAPIAdapter {
                         let multipart_body = Self::multipart_body_from_remaining_with_explicit(
                             &mut remaining,
                             explicit_body,
-                            body_is_schema_property,
+                            body_is_prop,
                             spec,
                         )?;
                         (None, None, Some(multipart_body))
                     }
                 } else {
+                    let body_is_prop = body_in_schema("application/json");
                     if explicit_body.is_none() && remaining.is_empty() {
                         if let Some(name) = &missing_required_body_param {
                             anyhow::bail!("Missing required parameter '{}'", name);
@@ -1121,12 +1136,13 @@ impl OpenAPIAdapter {
                     let json_body = Self::json_body_from_remaining_with_explicit(
                         &mut remaining,
                         explicit_body,
-                        body_is_schema_property,
+                        body_is_prop,
                     )?;
                     (Some(json_body), None, None)
                 }
             }
             RequestBodyConfig::Multipart(spec) => {
+                let body_is_prop = body_in_schema("multipart/form-data");
                 if explicit_body.is_none() && remaining.is_empty() && form_pairs.is_empty() {
                     if let Some(name) = &missing_required_body_param {
                         anyhow::bail!("Missing required parameter '{}'", name);
@@ -1134,7 +1150,7 @@ impl OpenAPIAdapter {
                 }
                 if !form_pairs.is_empty() {
                     if let Some(body) = explicit_body.or_else(|| {
-                        if body_is_schema_property {
+                        if body_is_prop {
                             None
                         } else {
                             remaining.remove("body")
@@ -1161,7 +1177,7 @@ impl OpenAPIAdapter {
                     let multipart_body = Self::multipart_body_from_remaining_with_explicit(
                         &mut remaining,
                         explicit_body,
-                        body_is_schema_property,
+                        body_is_prop,
                         spec,
                     )?;
                     (None, None, Some(multipart_body))
@@ -1350,51 +1366,69 @@ impl OpenAPIAdapter {
         Ok(RequestBodyConfig::FormUrlEncoded)
     }
 
-    /// Returns true if the request body schema defines "body" as a property name.
-    /// When true, a user-supplied `body=...` arg should be treated as a normal
-    /// schema field rather than the raw HTTP request body.
+    /// Returns true if the request body schema for a specific media type
+    /// defines "body" as a property name. When true, a user-supplied
+    /// `body=...` arg should be treated as a normal schema field rather
+    /// than the raw HTTP request body.
+    ///
+    /// The check is scoped to a single media type so that a `body` property
+    /// in a multipart schema does not accidentally disable the raw-body
+    /// shorthand on the JSON branch of a `JsonOrMultipart` operation.
     fn request_body_schema_has_body_property(
         path_item: &Value,
         operation_spec: &Value,
         root: &Value,
+        media_type: &str,
     ) -> bool {
-        // OAS3: check requestBody → content → schema → properties
+        // OAS3: check requestBody → content → <media_type> → schema
         if let Some(request_body_raw) = operation_spec.get("requestBody") {
             let request_body = Self::dereference_value(request_body_raw, root);
-            if let Some(content) = request_body.get("content").and_then(Value::as_object) {
-                for media_type in [
-                    "application/json",
-                    "multipart/form-data",
-                    "application/x-www-form-urlencoded",
-                ] {
-                    if let Some(schema_raw) = content
-                        .get(media_type)
-                        .and_then(|entry| entry.get("schema"))
-                    {
-                        let schema = Self::dereference_value(schema_raw, root);
-                        if schema
-                            .get("properties")
-                            .and_then(Value::as_object)
-                            .map_or(false, |props| props.contains_key("body"))
-                        {
-                            return true;
-                        }
-                    }
+            if let Some(schema_raw) = request_body
+                .get("content")
+                .and_then(|c| c.get(media_type))
+                .and_then(|entry| entry.get("schema"))
+            {
+                let schema = Self::dereference_value(schema_raw, root);
+                if Self::schema_has_property(schema, root, "body") {
+                    return true;
                 }
             }
         }
 
-        // Swagger 2.0: check in:body parameter → schema → properties
+        // Swagger 2.0: check in:body parameter → schema
         for parameter in Self::collect_effective_operation_parameters(path_item, operation_spec) {
             let resolved = Self::dereference_value(parameter, root);
             if resolved.get("in").and_then(Value::as_str) == Some("body") {
                 if let Some(schema_raw) = resolved.get("schema") {
                     let schema = Self::dereference_value(schema_raw, root);
-                    if schema
-                        .get("properties")
-                        .and_then(Value::as_object)
-                        .map_or(false, |props| props.contains_key("body"))
-                    {
+                    if Self::schema_has_property(schema, root, "body") {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
+    /// Checks whether `schema` (or any sub-schema reachable via `allOf`,
+    /// `oneOf`, or `anyOf`) defines the given property name.
+    fn schema_has_property(schema: &Value, root: &Value, property: &str) -> bool {
+        // Direct properties check
+        if schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .map_or(false, |props| props.contains_key(property))
+        {
+            return true;
+        }
+
+        // Walk composed schemas (allOf / oneOf / anyOf)
+        for keyword in ["allOf", "oneOf", "anyOf"] {
+            if let Some(sub_schemas) = schema.get(keyword).and_then(Value::as_array) {
+                for sub_schema_raw in sub_schemas {
+                    let sub_schema = Self::dereference_value(sub_schema_raw, root);
+                    if Self::schema_has_property(sub_schema, root, property) {
                         return true;
                     }
                 }
@@ -3559,6 +3593,123 @@ mod tests {
         assert_eq!(
             prepared.json_body,
             Some(json!({"name": "test", "value": 42}))
+        );
+    }
+
+    #[test]
+    fn prepare_request_body_property_detected_through_allof_composition() {
+        // "body" is defined inside an allOf sub-schema and must still be
+        // recognized as a schema property rather than the raw HTTP body.
+        let root = json!({
+            "components": {
+                "schemas": {
+                    "CommentBase": {
+                        "type": "object",
+                        "required": ["body"],
+                        "properties": {
+                            "body": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        });
+        let path_item = json!({});
+        let operation = json!({
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "allOf": [
+                                { "$ref": "#/components/schemas/CommentBase" },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "author_id": { "type": "string" }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        });
+
+        let mut args = HashMap::new();
+        args.insert(
+            "body".to_string(),
+            Value::String("composed comment".to_string()),
+        );
+
+        let prepared = OpenAPIAdapter::prepare_request(
+            "post",
+            "https://example.com",
+            "/comments",
+            &path_item,
+            &operation,
+            &root,
+            &args,
+        )
+        .unwrap();
+
+        assert_eq!(
+            prepared.json_body,
+            Some(json!({"body": "composed comment"}))
+        );
+    }
+
+    #[test]
+    fn prepare_request_body_property_scoped_to_selected_media_type() {
+        // "body" exists only in the multipart schema, not in JSON.
+        // On the JSON branch, body=... should still work as the raw HTTP body.
+        let root = json!({});
+        let path_item = json!({});
+        let operation = json!({
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "text": { "type": "string" }
+                            }
+                        }
+                    },
+                    "multipart/form-data": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "body": { "type": "string" },
+                                "file": { "type": "string", "format": "binary" }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // No file field → multipart_should_be_preferred returns false → JSON branch
+        let mut args = HashMap::new();
+        args.insert(
+            "body".to_string(),
+            json!({"text": "hello"}),
+        );
+
+        let prepared = OpenAPIAdapter::prepare_request(
+            "post",
+            "https://example.com",
+            "/messages",
+            &path_item,
+            &operation,
+            &root,
+            &args,
+        )
+        .unwrap();
+
+        // JSON schema does NOT define "body" as a property, so the raw-body
+        // shorthand should still work on this branch.
+        assert_eq!(
+            prepared.json_body,
+            Some(json!({"text": "hello"}))
         );
     }
 }

--- a/src/adapters/openapi.rs
+++ b/src/adapters/openapi.rs
@@ -1032,10 +1032,18 @@ impl OpenAPIAdapter {
         }
 
         let body_config = Self::request_body_config(path_item, operation_spec, root)?;
+        let body_is_schema_property =
+            Self::request_body_schema_has_body_property(path_item, operation_spec, root);
         let (json_body, form_body, multipart_body) = match &body_config {
             RequestBodyConfig::None => (None, None, None),
             RequestBodyConfig::FormUrlEncoded => {
-                if let Some(body) = explicit_body.or_else(|| remaining.remove("body")) {
+                if let Some(body) = explicit_body.or_else(|| {
+                    if body_is_schema_property {
+                        None
+                    } else {
+                        remaining.remove("body")
+                    }
+                }) {
                     if !remaining.is_empty() || !form_pairs.is_empty() {
                         anyhow::bail!("Cannot mix 'body' with form arguments for this operation");
                     }
@@ -1056,8 +1064,11 @@ impl OpenAPIAdapter {
                         anyhow::bail!("Missing required parameter '{}'", name);
                     }
                 }
-                let json_body =
-                    Self::json_body_from_remaining_with_explicit(&mut remaining, explicit_body)?;
+                let json_body = Self::json_body_from_remaining_with_explicit(
+                    &mut remaining,
+                    explicit_body,
+                    body_is_schema_property,
+                )?;
                 (Some(json_body), None, None)
             }
             RequestBodyConfig::JsonOrMultipart(spec) => {
@@ -1068,7 +1079,13 @@ impl OpenAPIAdapter {
                         }
                     }
                     if !form_pairs.is_empty() {
-                        if let Some(body) = explicit_body.or_else(|| remaining.remove("body")) {
+                        if let Some(body) = explicit_body.or_else(|| {
+                            if body_is_schema_property {
+                                None
+                            } else {
+                                remaining.remove("body")
+                            }
+                        }) {
                             if !remaining.is_empty() {
                                 anyhow::bail!(
                                     "Cannot mix 'body' with form arguments for this operation"
@@ -1090,6 +1107,7 @@ impl OpenAPIAdapter {
                         let multipart_body = Self::multipart_body_from_remaining_with_explicit(
                             &mut remaining,
                             explicit_body,
+                            body_is_schema_property,
                             spec,
                         )?;
                         (None, None, Some(multipart_body))
@@ -1103,6 +1121,7 @@ impl OpenAPIAdapter {
                     let json_body = Self::json_body_from_remaining_with_explicit(
                         &mut remaining,
                         explicit_body,
+                        body_is_schema_property,
                     )?;
                     (Some(json_body), None, None)
                 }
@@ -1114,7 +1133,13 @@ impl OpenAPIAdapter {
                     }
                 }
                 if !form_pairs.is_empty() {
-                    if let Some(body) = explicit_body.or_else(|| remaining.remove("body")) {
+                    if let Some(body) = explicit_body.or_else(|| {
+                        if body_is_schema_property {
+                            None
+                        } else {
+                            remaining.remove("body")
+                        }
+                    }) {
                         if !remaining.is_empty() {
                             anyhow::bail!(
                                 "Cannot mix 'body' with form arguments for this operation"
@@ -1136,6 +1161,7 @@ impl OpenAPIAdapter {
                     let multipart_body = Self::multipart_body_from_remaining_with_explicit(
                         &mut remaining,
                         explicit_body,
+                        body_is_schema_property,
                         spec,
                     )?;
                     (None, None, Some(multipart_body))
@@ -1324,6 +1350,60 @@ impl OpenAPIAdapter {
         Ok(RequestBodyConfig::FormUrlEncoded)
     }
 
+    /// Returns true if the request body schema defines "body" as a property name.
+    /// When true, a user-supplied `body=...` arg should be treated as a normal
+    /// schema field rather than the raw HTTP request body.
+    fn request_body_schema_has_body_property(
+        path_item: &Value,
+        operation_spec: &Value,
+        root: &Value,
+    ) -> bool {
+        // OAS3: check requestBody → content → schema → properties
+        if let Some(request_body_raw) = operation_spec.get("requestBody") {
+            let request_body = Self::dereference_value(request_body_raw, root);
+            if let Some(content) = request_body.get("content").and_then(Value::as_object) {
+                for media_type in [
+                    "application/json",
+                    "multipart/form-data",
+                    "application/x-www-form-urlencoded",
+                ] {
+                    if let Some(schema_raw) = content
+                        .get(media_type)
+                        .and_then(|entry| entry.get("schema"))
+                    {
+                        let schema = Self::dereference_value(schema_raw, root);
+                        if schema
+                            .get("properties")
+                            .and_then(Value::as_object)
+                            .map_or(false, |props| props.contains_key("body"))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Swagger 2.0: check in:body parameter → schema → properties
+        for parameter in Self::collect_effective_operation_parameters(path_item, operation_spec) {
+            let resolved = Self::dereference_value(parameter, root);
+            if resolved.get("in").and_then(Value::as_str) == Some("body") {
+                if let Some(schema_raw) = resolved.get("schema") {
+                    let schema = Self::dereference_value(schema_raw, root);
+                    if schema
+                        .get("properties")
+                        .and_then(Value::as_object)
+                        .map_or(false, |props| props.contains_key("body"))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
     fn encode_path_param_value(value: &str) -> String {
         utf8_percent_encode(value, Self::PATH_SEGMENT_ENCODE_SET).to_string()
     }
@@ -1333,14 +1413,21 @@ impl OpenAPIAdapter {
     }
 
     fn json_body_from_remaining(remaining: &mut HashMap<String, Value>) -> Result<Value> {
-        Self::json_body_from_remaining_with_explicit(remaining, None)
+        Self::json_body_from_remaining_with_explicit(remaining, None, false)
     }
 
     fn json_body_from_remaining_with_explicit(
         remaining: &mut HashMap<String, Value>,
         explicit_body: Option<Value>,
+        body_is_schema_property: bool,
     ) -> Result<Value> {
-        if let Some(body) = explicit_body.or_else(|| remaining.remove("body")) {
+        if let Some(body) = explicit_body.or_else(|| {
+            if body_is_schema_property {
+                None
+            } else {
+                remaining.remove("body")
+            }
+        }) {
             if !remaining.is_empty() {
                 anyhow::bail!(
                     "Cannot mix explicit request body with other request body arguments: {}",
@@ -1360,9 +1447,16 @@ impl OpenAPIAdapter {
     fn multipart_body_from_remaining_with_explicit(
         remaining: &mut HashMap<String, Value>,
         explicit_body: Option<Value>,
+        body_is_schema_property: bool,
         spec: &MultipartRequestSpec,
     ) -> Result<PreparedMultipartBody> {
-        let body_value = if let Some(body) = explicit_body.or_else(|| remaining.remove("body")) {
+        let body_value = if let Some(body) = explicit_body.or_else(|| {
+            if body_is_schema_property {
+                None
+            } else {
+                remaining.remove("body")
+            }
+        }) {
             if !remaining.is_empty() {
                 anyhow::bail!(
                     "Cannot mix explicit request body with other request body arguments: {}",
@@ -3365,6 +3459,106 @@ mod tests {
                 .contains("must be provided as a local file path string"),
             "unexpected error: {}",
             err
+        );
+    }
+
+    #[test]
+    fn prepare_request_body_schema_property_not_consumed_as_raw_body() {
+        // Reproduces the Front API comment endpoint case: the request body
+        // schema has a property literally named "body" which must not be
+        // consumed as the raw HTTP body.
+        let root = json!({});
+        let path_item = json!({});
+        let operation = json!({
+            "parameters": [
+                {"name": "conversation_id", "in": "path", "required": true}
+            ],
+            "requestBody": {
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "required": ["body"],
+                            "properties": {
+                                "body": { "type": "string" },
+                                "author_id": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let mut args = HashMap::new();
+        args.insert(
+            "conversation_id".to_string(),
+            Value::String("cnv_abc123".to_string()),
+        );
+        args.insert(
+            "body".to_string(),
+            Value::String("Test comment".to_string()),
+        );
+
+        let prepared = OpenAPIAdapter::prepare_request(
+            "post",
+            "https://api2.frontapp.com",
+            "/conversations/{conversation_id}/comments",
+            &path_item,
+            &operation,
+            &root,
+            &args,
+        )
+        .unwrap();
+
+        assert_eq!(
+            prepared.url,
+            "https://api2.frontapp.com/conversations/cnv_abc123/comments"
+        );
+        // "body" must appear as a property inside the JSON object,
+        // NOT as the raw HTTP body.
+        assert_eq!(
+            prepared.json_body,
+            Some(json!({"body": "Test comment"}))
+        );
+    }
+
+    #[test]
+    fn prepare_request_body_key_still_works_as_raw_body_without_schema_property() {
+        // When the schema does NOT define "body" as a property,
+        // body=... should still work as the raw HTTP body (existing behavior).
+        let root = json!({});
+        let path_item = json!({});
+        let operation = json!({
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {"type": "object"}
+                    }
+                }
+            }
+        });
+
+        let mut args = HashMap::new();
+        args.insert(
+            "body".to_string(),
+            json!({"name": "test", "value": 42}),
+        );
+
+        let prepared = OpenAPIAdapter::prepare_request(
+            "post",
+            "https://example.com",
+            "/items",
+            &path_item,
+            &operation,
+            &root,
+            &args,
+        )
+        .unwrap();
+
+        assert_eq!(
+            prepared.json_body,
+            Some(json!({"name": "test", "value": 42}))
         );
     }
 }

--- a/src/adapters/openapi.rs
+++ b/src/adapters/openapi.rs
@@ -1032,17 +1032,20 @@ impl OpenAPIAdapter {
         }
 
         let body_config = Self::request_body_config(path_item, operation_spec, root)?;
+        let should_check_body_schema =
+            explicit_body.is_none() && remaining.contains_key("body");
         // Closure to check whether the request body schema for a given media
         // type defines "body" as a property.  Scoped per media type so that
         // e.g. a multipart-only `body` property does not leak into the JSON
         // branch of a JsonOrMultipart operation.
         let body_in_schema = |media_type: &str| {
-            Self::request_body_schema_has_body_property(
-                path_item,
-                operation_spec,
-                root,
-                media_type,
-            )
+            should_check_body_schema
+                && Self::request_body_schema_has_body_property(
+                    path_item,
+                    operation_spec,
+                    root,
+                    media_type,
+                )
         };
 
         let (json_body, form_body, multipart_body) = match &body_config {
@@ -1371,9 +1374,11 @@ impl OpenAPIAdapter {
     /// `body=...` arg should be treated as a normal schema field rather
     /// than the raw HTTP request body.
     ///
-    /// The check is scoped to a single media type so that a `body` property
-    /// in a multipart schema does not accidentally disable the raw-body
-    /// shorthand on the JSON branch of a `JsonOrMultipart` operation.
+    /// For OAS3, the check is scoped to a single media type so that a
+    /// `body` property in a multipart schema does not accidentally disable
+    /// the raw-body shorthand on the JSON branch of a `JsonOrMultipart`
+    /// operation. For Swagger 2.0, the in:body parameter has a single
+    /// schema not keyed by media type, so the check applies globally.
     fn request_body_schema_has_body_property(
         path_item: &Value,
         operation_spec: &Value,
@@ -1431,7 +1436,7 @@ impl OpenAPIAdapter {
         if schema
             .get("properties")
             .and_then(Value::as_object)
-            .map_or(false, |props| props.contains_key(property))
+            .is_some_and(|props| props.contains_key(property))
         {
             return true;
         }

--- a/src/adapters/openapi.rs
+++ b/src/adapters/openapi.rs
@@ -1414,6 +1414,19 @@ impl OpenAPIAdapter {
     /// Checks whether `schema` (or any sub-schema reachable via `allOf`,
     /// `oneOf`, or `anyOf`) defines the given property name.
     fn schema_has_property(schema: &Value, root: &Value, property: &str) -> bool {
+        Self::schema_has_property_recursive(schema, root, property, 0)
+    }
+
+    fn schema_has_property_recursive(
+        schema: &Value,
+        root: &Value,
+        property: &str,
+        depth: usize,
+    ) -> bool {
+        if depth > Self::MAX_SCHEMA_EXPANSION_DEPTH {
+            return false;
+        }
+
         // Direct properties check
         if schema
             .get("properties")
@@ -1428,7 +1441,12 @@ impl OpenAPIAdapter {
             if let Some(sub_schemas) = schema.get(keyword).and_then(Value::as_array) {
                 for sub_schema_raw in sub_schemas {
                     let sub_schema = Self::dereference_value(sub_schema_raw, root);
-                    if Self::schema_has_property(sub_schema, root, property) {
+                    if Self::schema_has_property_recursive(
+                        sub_schema,
+                        root,
+                        property,
+                        depth + 1,
+                    ) {
                         return true;
                     }
                 }


### PR DESCRIPTION
## Summary

When an OpenAPI request body schema defines a property literally named `body`, uxc consumes its value as the **raw HTTP request body** instead of wrapping it in a JSON object. This is because `json_body_from_remaining_with_explicit` unconditionally calls `remaining.remove("body")` and returns the value directly.

**Real-world example:** The [Front Core API](https://dev.frontapp.com/reference/add-comment) `POST /conversations/{conversation_id}/comments` endpoint requires `{"body": "comment text"}`. Running:

```bash
uxc api2.frontapp.com post:/conversations/{conversation_id}/comments \
  conversation_id=cnv_abc123 body="Test comment"
```

sends `"Test comment"` (bare string) instead of `{"body": "Test comment"}` (JSON object), causing a 400 error. No combination of uxc syntax (`body=`, `body:=`, positional JSON, inline path) can work around this.

## Changes

- Add `request_body_schema_has_body_property()` helper that inspects OAS3 `requestBody` and Swagger 2.0 `in:body` parameter schemas for a property named `body`
- Thread a `body_is_schema_property` flag through `json_body_from_remaining_with_explicit`, `multipart_body_from_remaining_with_explicit`, and inline `remaining.remove("body")` call sites in `prepare_request`
- When the flag is true, skip `remaining.remove("body")` so the key is treated as a normal field and included in the constructed JSON object
- Existing behavior is preserved: when the schema does **not** define `body` as a property, `body=...` still works as the raw HTTP body

## Test plan

- [x] All 475 existing tests pass
- [x] New test: `prepare_request_body_schema_property_not_consumed_as_raw_body` — reproduces the Front API scenario, asserts `json_body == Some({"body": "Test comment"})`
- [x] New test: `prepare_request_body_key_still_works_as_raw_body_without_schema_property` — ensures backward compatibility

Closes #384

---

> **Disclosure:** This fix was generated using Claude Opus 4.6 (Anthropic). The PR author does not have Rust expertise. The code has been validated against the full test suite plus two new targeted tests.