### PR TITLE
chore(deps): update rustls-webpki for audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## What
- update `rustls-webpki` in `Cargo.lock` from `0.103.10` to `0.103.12`
- keep the change isolated from feature work so Security Audit can unblock unrelated PRs

## Why
- `cargo audit` is flagging `RUSTSEC-2026-0098` and `RUSTSEC-2026-0099` on `rustls-webpki 0.103.10`
- issue `#386` tracks this shared dependency-graph blocker

## How
- run `cargo update -p rustls-webpki --precise 0.103.12` on top of `main`
- leave all other dependencies unchanged

## Testing
- `cargo check -q`
- `cargo audit`
- `cargo test -- --test-threads=1`
  - locally, the suite gets through unit/integration coverage until the existing `benchmark_test` long-tail, where daemon benchmark cases fail with runtime execution errors that do not appear related to this lockfile-only change

Closes #386