### PR TITLE
fix(node): autostart daemon client only on socket errors

### DIFF
--- a/packages/uxc-daemon-client/src/index.ts
+++ b/packages/uxc-daemon-client/src/index.ts
@@ -415,7 +415,6 @@ export class UxcDaemonClient {
   }
 
   async request<T>(method: string, params?: unknown): Promise<T> {
-    await this.ensureDaemon();
     try {
       return await this.requestOnce<T>(method, params);
     } catch (error) {
@@ -432,12 +431,21 @@ export class UxcDaemonClient {
       return;
     }
     if (!this.ensureDaemonPromise || force) {
-      this.ensureDaemonPromise = execFileAsync(this.binaryPath, ["daemon", "start"], {
-        env: this.env,
-        timeout: this.requestTimeoutMs,
-      }).then(() => undefined);
+      const startPromise = this.startDaemonProcess().finally(() => {
+        if (this.ensureDaemonPromise === startPromise) {
+          this.ensureDaemonPromise = undefined;
+        }
+      });
+      this.ensureDaemonPromise = startPromise;
     }
     await this.ensureDaemonPromise;
+  }
+
+  private async startDaemonProcess(): Promise<void> {
+    await execFileAsync(this.binaryPath, ["daemon", "start"], {
+      env: this.env,
+      timeout: this.requestTimeoutMs,
+    }).then(() => undefined);
   }
 
   private async requestOnce<T>(method: string, params?: unknown): Promise<T> {

--- a/packages/uxc-daemon-client/src/index.ts
+++ b/packages/uxc-daemon-client/src/index.ts
@@ -421,16 +421,16 @@ export class UxcDaemonClient {
       if (!this.autoStart || !isSocketError(error)) {
         throw error;
       }
-      await this.ensureDaemon(true);
+      await this.ensureDaemon();
       return this.requestOnce<T>(method, params);
     }
   }
 
-  private async ensureDaemon(force = false): Promise<void> {
+  private async ensureDaemon(): Promise<void> {
     if (!this.autoStart) {
       return;
     }
-    if (!this.ensureDaemonPromise || force) {
+    if (!this.ensureDaemonPromise) {
       const startPromise = this.startDaemonProcess().finally(() => {
         if (this.ensureDaemonPromise === startPromise) {
           this.ensureDaemonPromise = undefined;

--- a/packages/uxc-daemon-client/test/client.test.ts
+++ b/packages/uxc-daemon-client/test/client.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { WebSocketServer } from "ws";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
-import { generateTypeScriptClient, UxcDaemonClient, type CodegenHostSchemaV1 } from "../src/index.js";
+import { DaemonRpcError, generateTypeScriptClient, UxcDaemonClient, type CodegenHostSchemaV1 } from "../src/index.js";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
@@ -48,6 +48,81 @@ describe("UxcDaemonClient", () => {
     const status = await client.daemonStatus();
     expect(status.running).toBe(true);
     expect(status.socket).toContain("uxc.sock");
+  });
+
+  test("request uses the live socket before attempting daemon autostart", async () => {
+    const stub = new UxcDaemonClient();
+    let startCalls = 0;
+    (stub as unknown as { requestOnce: () => Promise<unknown> }).requestOnce = async () => ({
+      running: true,
+    });
+    (stub as unknown as { startDaemonProcess: () => Promise<void> }).startDaemonProcess = async () => {
+      startCalls += 1;
+    };
+
+    const result = await stub.request("daemon.status");
+    expect(result).toEqual({ running: true });
+    expect(startCalls).toBe(0);
+  });
+
+  test("request autostarts only after a socket error and retries once", async () => {
+    const stub = new UxcDaemonClient();
+    let requestCalls = 0;
+    let startCalls = 0;
+    (stub as unknown as { requestOnce: () => Promise<unknown> }).requestOnce = async () => {
+      requestCalls += 1;
+      if (requestCalls === 1) {
+        throw new Error("connect ENOENT /tmp/uxc.sock");
+      }
+      return { running: true };
+    };
+    (stub as unknown as { startDaemonProcess: () => Promise<void> }).startDaemonProcess = async () => {
+      startCalls += 1;
+    };
+
+    const result = await stub.request("daemon.status");
+    expect(result).toEqual({ running: true });
+    expect(requestCalls).toBe(2);
+    expect(startCalls).toBe(1);
+  });
+
+  test("request does not autostart for non-socket errors", async () => {
+    const stub = new UxcDaemonClient();
+    let startCalls = 0;
+    (stub as unknown as { requestOnce: () => Promise<unknown> }).requestOnce = async () => {
+      throw new DaemonRpcError("method failed", -32000, "daemon.status");
+    };
+    (stub as unknown as { startDaemonProcess: () => Promise<void> }).startDaemonProcess = async () => {
+      startCalls += 1;
+    };
+
+    await expect(stub.request("daemon.status")).rejects.toThrow(/method failed/);
+    expect(startCalls).toBe(0);
+  });
+
+  test("failed autostart does not poison later socket recovery", async () => {
+    const stub = new UxcDaemonClient();
+    let requestCalls = 0;
+    let startCalls = 0;
+    (stub as unknown as { requestOnce: () => Promise<unknown> }).requestOnce = async () => {
+      requestCalls += 1;
+      if (requestCalls <= 2) {
+        throw new Error("connect ECONNREFUSED /tmp/uxc.sock");
+      }
+      return { running: true };
+    };
+    (stub as unknown as { startDaemonProcess: () => Promise<void> }).startDaemonProcess = async () => {
+      startCalls += 1;
+      if (startCalls === 1) {
+        throw new Error("daemon start failed");
+      }
+    };
+
+    await expect(stub.request("daemon.status")).rejects.toThrow(/daemon start failed/);
+    const result = await stub.request("daemon.status");
+    expect(result).toEqual({ running: true });
+    expect(startCalls).toBe(2);
+    expect(requestCalls).toBe(3);
   });
 
   test("daemonSessionKill sends daemon.session.kill with session key", async () => {


### PR DESCRIPTION
## What
- change `@holon-run/uxc-daemon-client` to try the daemon socket before running `uxc daemon start`
- only trigger autostart when the initial RPC failure is a socket/connectivity error
- clear failed `ensureDaemonPromise` state so a failed shell-out does not poison later retries
- add daemon-client tests covering success-first, socket-error retry, non-socket passthrough, and failed-autostart recovery

## Why
- issue `#388` reports that long-running callers like AgentInbox can fail on the preflight `uxc daemon start` shell-out even while the daemon socket is healthy
- autostart should be socket-error recovery, not an unconditional per-request shell-out

## How
- remove the unconditional `await this.ensureDaemon()` call at the start of `request()`
- keep the existing retry path, but only after `requestOnce()` fails with `isSocketError(error)`
- extract the shell-out into `startDaemonProcess()` and reset the cached promise on settle

## Testing
- `npm run --workspace @holon-run/uxc-daemon-client build`
- `cargo build -q`
- `npm run --workspace @holon-run/uxc-daemon-client test`

Closes #388