### PR TITLE
feat(source): add managed source diagnostics

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -257,6 +257,7 @@ pub struct SubscriptionJobView {
     pub created_at_unix: u64,
     pub started_at_unix: Option<u64>,
     pub stopped_at_unix: Option<u64>,
+    pub last_success_at_unix: Option<u64>,
     pub last_event_at_unix: Option<u64>,
     pub last_error: Option<String>,
     #[serde(default)]
@@ -332,6 +333,32 @@ pub struct ManagedSourceStatusRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedSourceCheckpointSummary {
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub watermark: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tie_breaker: Option<Value>,
+    #[serde(default)]
+    pub seen_window_len: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub etag: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedSourceStreamSummary {
+    pub event_count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub earliest_offset: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_offset: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_event_at_unix: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManagedSourceView {
     pub namespace: String,
     pub source_key: String,
@@ -344,6 +371,28 @@ pub struct ManagedSourceView {
     pub started_at_unix: Option<u64>,
     pub stopped_at_unix: Option<u64>,
     pub last_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<SubscriptionMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_uri: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub poll_interval_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_success_at_unix: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_event_at_unix: Option<u64>,
+    #[serde(default)]
+    pub reconnect_count: u64,
+    #[serde(default)]
+    pub written_events: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<ManagedSourceCheckpointSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream: Option<ManagedSourceStreamSummary>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -369,6 +418,34 @@ pub struct ManagedSourceDeleteResponse {
     pub namespace: String,
     pub source_key: String,
     pub deleted: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedSourceDoctorIssue {
+    pub severity: String,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedSourceDoctorResponse {
+    pub namespace: String,
+    pub source_key: String,
+    pub observed_at_unix: u64,
+    pub status: String,
+    pub runner_active: bool,
+    pub stream_exists: bool,
+    pub legacy_checkpoint_file_present: bool,
+    pub legacy_cursor_file_present: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seconds_since_last_success: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seconds_since_last_event: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stall_threshold_secs: Option<u64>,
+    pub source: ManagedSourceView,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub issues: Vec<ManagedSourceDoctorIssue>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -404,6 +481,8 @@ pub struct ManagedStreamInfo {
     pub created_at_unix: u64,
     pub earliest_offset: Option<u64>,
     pub latest_offset: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_event_at_unix: Option<u64>,
     pub event_count: u64,
     pub retention_max_rows: u64,
     pub retention_max_age_secs: u64,
@@ -822,6 +901,7 @@ struct ManagedSourceEntry {
     source_key: String,
     stream_id: String,
     state: Arc<Mutex<ManagedSourceView>>,
+    runtime_view: Mutex<Option<Arc<Mutex<SubscriptionJobView>>>>,
     stop_tx: Mutex<watch::Sender<bool>>,
     task: Mutex<Option<JoinHandle<()>>>,
 }
@@ -832,6 +912,10 @@ struct ManagedSourceRuntimeStateSnapshot {
     started_at_unix: Option<u64>,
     stopped_at_unix: Option<u64>,
     last_error: Option<String>,
+    last_success_at_unix: Option<u64>,
+    last_event_at_unix: Option<u64>,
+    reconnect_count: u64,
+    written_events: u64,
 }
 
 impl McpStdioSession {
@@ -2248,6 +2332,10 @@ impl ManagedSourceManager {
                     started_at_unix: None,
                     stopped_at_unix: None,
                     last_error: None,
+                    last_success_at_unix: None,
+                    last_event_at_unix: None,
+                    reconnect_count: 0,
+                    written_events: 0,
                 }
             }
         } else {
@@ -2264,6 +2352,10 @@ impl ManagedSourceManager {
                 started_at_unix: None,
                 stopped_at_unix: None,
                 last_error: None,
+                last_success_at_unix: None,
+                last_event_at_unix: None,
+                reconnect_count: 0,
+                written_events: 0,
             }
         };
 
@@ -2282,10 +2374,6 @@ impl ManagedSourceManager {
     }
 
     async fn status(&self, namespace: &str, source_key: &str) -> Result<ManagedSourceView> {
-        let identity_key = managed_source_identity_key(namespace, source_key);
-        if let Some(entry) = self.entries.lock().await.get(&identity_key).cloned() {
-            return Ok(entry.state.lock().await.clone());
-        }
         let record = self
             .store
             .get_source(namespace, source_key)
@@ -2296,7 +2384,7 @@ impl ManagedSourceManager {
                     namespace, source_key
                 ))
             })?;
-        Ok(view_from_record(&record))
+        self.build_status_view(&record).await
     }
 
     async fn list(&self) -> Result<Vec<ManagedSourceListEntry>> {
@@ -2311,6 +2399,213 @@ impl ManagedSourceManager {
             summary.running_source_count,
             summary.stream_count,
         ))
+    }
+
+    async fn build_status_view(&self, record: &ManagedSourceRecord) -> Result<ManagedSourceView> {
+        let mut view = view_from_record(record);
+        let identity_key = managed_source_identity_key(&record.namespace, &record.source_key);
+        let active_entry = { self.entries.lock().await.get(&identity_key).cloned() };
+        if let Some(entry) = active_entry {
+            let current = entry.state.lock().await.clone();
+            view.status = current.status;
+            view.updated_at_unix = current.updated_at_unix;
+            view.started_at_unix = current.started_at_unix;
+            view.stopped_at_unix = current.stopped_at_unix;
+            view.last_error = current.last_error;
+            view.last_success_at_unix = current.last_success_at_unix;
+            view.last_event_at_unix = current.last_event_at_unix;
+            view.reconnect_count = current.reconnect_count;
+            view.written_events = current.written_events;
+            if let Some(runtime_view) = entry.runtime_view.lock().await.clone() {
+                let snapshot = runtime_view.lock().await.clone();
+                view.status = snapshot.status;
+                view.started_at_unix = snapshot.started_at_unix;
+                view.stopped_at_unix = snapshot.stopped_at_unix;
+                view.last_error = snapshot.last_error;
+                view.last_success_at_unix = snapshot.last_success_at_unix;
+                view.last_event_at_unix = snapshot.last_event_at_unix;
+                view.reconnect_count = snapshot.reconnect_count;
+                view.written_events = snapshot.written_events;
+            }
+        }
+
+        enrich_managed_source_view_from_spec(&mut view, &record.spec_json);
+        if let Some(stream_info) = self.store.stream_info(&record.stream_id).await? {
+            view.stream = Some(ManagedSourceStreamSummary {
+                event_count: stream_info.event_count,
+                earliest_offset: stream_info.earliest_offset,
+                latest_offset: stream_info.latest_offset,
+                latest_event_at_unix: stream_info.latest_event_at_unix,
+            });
+        }
+        if view.mode == Some(SubscriptionMode::Poll) {
+            if let Some(checkpoint) = self
+                .store
+                .load_poll_checkpoint(&record.namespace, &record.source_key, &record.run_id)
+                .await?
+            {
+                view.checkpoint = Some(checkpoint_summary_from_state(
+                    managed_source_checkpoint_kind(&record.spec_json),
+                    checkpoint,
+                ));
+            }
+        }
+
+        Ok(view)
+    }
+
+    async fn doctor(
+        &self,
+        runtime: &DaemonRuntime,
+        request: &ManagedSourceStatusRequest,
+    ) -> Result<ManagedSourceDoctorResponse> {
+        validate_managed_source_identity(&request.namespace, &request.source_key)?;
+        let record = self
+            .store
+            .get_source(&request.namespace, &request.source_key)
+            .await?
+            .ok_or_else(|| {
+                UxcError::OperationNotFound(format!(
+                    "managed source not found: {}/{}",
+                    request.namespace, request.source_key
+                ))
+            })?;
+        let source = self.build_status_view(&record).await?;
+        let runner_active = self
+            .entries
+            .lock()
+            .await
+            .contains_key(&managed_source_identity_key(
+                &request.namespace,
+                &request.source_key,
+            ));
+        let stream_exists = self.store.stream_info(&record.stream_id).await?.is_some();
+        let legacy_checkpoint_file_present = runtime
+            .managed_source_checkpoint_path(&record.run_id)
+            .exists();
+        let legacy_cursor_file_present =
+            runtime.managed_source_cursor_path(&record.run_id).exists();
+        let observed_at_unix = now_unix_secs();
+        let seconds_since_last_success = source
+            .last_success_at_unix
+            .map(|ts| observed_at_unix.saturating_sub(ts));
+        let seconds_since_last_event = source
+            .last_event_at_unix
+            .map(|ts| observed_at_unix.saturating_sub(ts));
+        let stall_threshold_secs = source
+            .poll_interval_secs
+            .map(|interval| interval.saturating_mul(3).max(60))
+            .or_else(|| {
+                matches!(
+                    source.status.as_str(),
+                    "running" | "reconnecting" | "starting"
+                )
+                .then_some(300)
+            });
+
+        let mut issues = Vec::new();
+        if !stream_exists {
+            issues.push(ManagedSourceDoctorIssue {
+                severity: "error".to_string(),
+                code: "stream_missing".to_string(),
+                message: format!(
+                    "Managed source {} / {} points to missing stream {}",
+                    request.namespace, request.source_key, record.stream_id
+                ),
+            });
+        }
+        if matches!(
+            source.status.as_str(),
+            "running" | "reconnecting" | "starting"
+        ) && !runner_active
+        {
+            issues.push(ManagedSourceDoctorIssue {
+                severity: "warn".to_string(),
+                code: "runner_inactive".to_string(),
+                message: "Source record reports an active runtime state, but no live runner is registered in the daemon.".to_string(),
+            });
+        }
+        if legacy_checkpoint_file_present {
+            issues.push(ManagedSourceDoctorIssue {
+                severity: "warn".to_string(),
+                code: "legacy_checkpoint_file_present".to_string(),
+                message:
+                    "A legacy managed source checkpoint file is still present for the current run."
+                        .to_string(),
+            });
+        }
+        if legacy_cursor_file_present {
+            issues.push(ManagedSourceDoctorIssue {
+                severity: "warn".to_string(),
+                code: "legacy_cursor_file_present".to_string(),
+                message:
+                    "A legacy managed source cursor file is still present for the current run."
+                        .to_string(),
+            });
+        }
+        if source.mode == Some(SubscriptionMode::Poll)
+            && source
+                .stream
+                .as_ref()
+                .is_some_and(|stream| stream.event_count > 0)
+            && source.checkpoint.is_none()
+            && !legacy_checkpoint_file_present
+        {
+            issues.push(ManagedSourceDoctorIssue {
+                severity: "warn".to_string(),
+                code: "checkpoint_missing".to_string(),
+                message: "Poll source has durable events but no persisted checkpoint summary."
+                    .to_string(),
+            });
+        }
+        if matches!(source.status.as_str(), "running" | "reconnecting")
+            && stall_threshold_secs.is_some()
+        {
+            let progress_age = seconds_since_last_success
+                .or(seconds_since_last_event)
+                .or_else(|| {
+                    source
+                        .started_at_unix
+                        .map(|ts| observed_at_unix.saturating_sub(ts))
+                });
+            if let (Some(age), Some(threshold)) = (progress_age, stall_threshold_secs) {
+                if age > threshold {
+                    issues.push(ManagedSourceDoctorIssue {
+                        severity: "warn".to_string(),
+                        code: "stalled".to_string(),
+                        message: format!(
+                            "Source has been {} seconds without observed progress; threshold is {} seconds.",
+                            age, threshold
+                        ),
+                    });
+                }
+            }
+        }
+
+        let status = if issues.iter().any(|issue| issue.severity == "error") {
+            "error"
+        } else if issues.iter().any(|issue| issue.severity == "warn") {
+            "warn"
+        } else {
+            "healthy"
+        }
+        .to_string();
+
+        Ok(ManagedSourceDoctorResponse {
+            namespace: request.namespace.clone(),
+            source_key: request.source_key.clone(),
+            observed_at_unix,
+            status,
+            runner_active,
+            stream_exists,
+            legacy_checkpoint_file_present,
+            legacy_cursor_file_present,
+            seconds_since_last_success,
+            seconds_since_last_event,
+            stall_threshold_secs,
+            source,
+            issues,
+        })
     }
 
     async fn stop(
@@ -2481,6 +2776,7 @@ impl ManagedSourceManager {
             source_key: record.source_key.clone(),
             stream_id: record.stream_id.clone(),
             state: state.clone(),
+            runtime_view: Mutex::new(None),
             stop_tx: Mutex::new(stop_tx),
             task: Mutex::new(None),
         });
@@ -2513,6 +2809,7 @@ impl ManagedSourceManager {
         let runtime_view = Arc::new(Mutex::new(subscription_view_for_managed_source(
             &record, &request,
         )));
+        *entry.runtime_view.lock().await = Some(runtime_view.clone());
         if spec.mode == SubscriptionMode::Poll {
             self.run_managed_source_poll(
                 &runtime,
@@ -2523,6 +2820,7 @@ impl ManagedSourceManager {
                 stop_rx,
             )
             .await;
+            *entry.runtime_view.lock().await = None;
             self.entries.lock().await.remove(&identity_key);
             return;
         }
@@ -2592,6 +2890,7 @@ impl ManagedSourceManager {
         }
 
         let _ = runner_task.await;
+        *entry.runtime_view.lock().await = None;
         self.entries.lock().await.remove(&identity_key);
     }
 
@@ -2666,6 +2965,7 @@ impl ManagedSourceManager {
                     .unwrap_or(default_interval_secs);
 
                     if result.status_code == Some(304) {
+                        note_subscription_success(runtime_view, now_unix_secs()).await;
                         update_subscription_view(runtime_view, Some("running"), None, false).await;
                         if runner.checkpoint() != &previous_checkpoint {
                             if let Err(err) = self
@@ -2693,8 +2993,9 @@ impl ManagedSourceManager {
                                 return;
                             }
                         };
-                        update_subscription_view(runtime_view, Some("running"), None, false).await;
                         let ingested_at_unix = now_unix_secs();
+                        note_subscription_success(runtime_view, ingested_at_unix).await;
+                        update_subscription_view(runtime_view, Some("running"), None, false).await;
                         let events = output
                             .emitted_items
                             .into_iter()
@@ -2718,6 +3019,14 @@ impl ManagedSourceManager {
                             {
                                 self.fail_managed_source(entry, err.to_string()).await;
                                 return;
+                            }
+                            if !events.is_empty() {
+                                note_subscription_events_written(
+                                    runtime_view,
+                                    ingested_at_unix,
+                                    events.len() as u64,
+                                )
+                                .await;
                             }
                         }
                     }
@@ -2903,6 +3212,60 @@ fn managed_source_identity_key(namespace: &str, source_key: &str) -> String {
     format!("{namespace}\u{0}{source_key}")
 }
 
+fn managed_source_checkpoint_kind(spec_json: &Value) -> String {
+    serde_json::from_value::<ManagedSourceSpec>(spec_json.clone())
+        .ok()
+        .and_then(|spec| spec.poll_config)
+        .and_then(|value| {
+            serde_json::from_value::<crate::subscription_poll::PollSubscriptionConfig>(value).ok()
+        })
+        .map(|config| match config.checkpoint_strategy {
+            crate::subscription_poll::PollCheckpointStrategy::CursorOnly => {
+                "cursor_only".to_string()
+            }
+            crate::subscription_poll::PollCheckpointStrategy::ItemKey { .. } => {
+                "item_key".to_string()
+            }
+            crate::subscription_poll::PollCheckpointStrategy::Watermark { .. } => {
+                "watermark".to_string()
+            }
+            crate::subscription_poll::PollCheckpointStrategy::ContentHash { .. } => {
+                "content_hash".to_string()
+            }
+        })
+        .unwrap_or_else(|| "poll".to_string())
+}
+
+fn checkpoint_summary_from_state(
+    kind: String,
+    checkpoint: crate::subscription_poll::PollCheckpointState,
+) -> ManagedSourceCheckpointSummary {
+    ManagedSourceCheckpointSummary {
+        kind,
+        cursor: checkpoint.cursor,
+        watermark: checkpoint.watermark,
+        tie_breaker: checkpoint.tie_breaker,
+        seen_window_len: checkpoint.seen_keys.len(),
+        etag: checkpoint.etag,
+    }
+}
+
+fn enrich_managed_source_view_from_spec(view: &mut ManagedSourceView, spec_json: &Value) {
+    let Ok(spec) = serde_json::from_value::<ManagedSourceSpec>(spec_json.clone()) else {
+        return;
+    };
+    view.mode = Some(spec.mode);
+    view.endpoint = Some(spec.endpoint);
+    view.operation_id = spec.operation_id;
+    view.resource_uri = spec.resource_uri;
+    view.poll_interval_secs = spec
+        .poll_config
+        .and_then(|value| {
+            serde_json::from_value::<crate::subscription_poll::PollSubscriptionConfig>(value).ok()
+        })
+        .map(|config| config.interval_secs);
+}
+
 fn managed_source_streams_db_path(base_dir: &Path) -> PathBuf {
     base_dir.join("managed-source-streams.db")
 }
@@ -3019,13 +3382,14 @@ fn subscription_view_for_managed_source(
         created_at_unix: record.created_at_unix,
         started_at_unix: record.started_at_unix,
         stopped_at_unix: record.stopped_at_unix,
-        last_event_at_unix: None,
+        last_event_at_unix: record.last_event_at_unix,
         last_error: record.last_error.clone(),
         restart_count: 0,
         last_resume_at_unix: None,
         last_resume_error: None,
-        reconnect_count: 0,
-        written_events: 0,
+        reconnect_count: record.reconnect_count,
+        written_events: record.written_events,
+        last_success_at_unix: record.last_success_at_unix,
     }
 }
 
@@ -3099,6 +3463,10 @@ async fn sync_managed_source_state(
                 started_at_unix: snapshot.started_at_unix,
                 stopped_at_unix,
                 last_error: snapshot.last_error.clone(),
+                last_success_at_unix: snapshot.last_success_at_unix,
+                last_event_at_unix: snapshot.last_event_at_unix,
+                reconnect_count: snapshot.reconnect_count,
+                written_events: snapshot.written_events,
             },
         )
         .await?;
@@ -3108,6 +3476,10 @@ async fn sync_managed_source_state(
     state.started_at_unix = snapshot.started_at_unix;
     state.stopped_at_unix = stopped_at_unix;
     state.last_error = snapshot.last_error;
+    state.last_success_at_unix = snapshot.last_success_at_unix;
+    state.last_event_at_unix = snapshot.last_event_at_unix;
+    state.reconnect_count = snapshot.reconnect_count;
+    state.written_events = snapshot.written_events;
     Ok(())
 }
 
@@ -3132,6 +3504,10 @@ async fn managed_source_runtime_state_snapshot(
         started_at_unix: snapshot.started_at_unix,
         stopped_at_unix,
         last_error: snapshot.last_error,
+        last_success_at_unix: snapshot.last_success_at_unix,
+        last_event_at_unix: snapshot.last_event_at_unix,
+        reconnect_count: snapshot.reconnect_count,
+        written_events: snapshot.written_events,
     }
 }
 
@@ -3148,6 +3524,17 @@ fn view_from_record(record: &ManagedSourceRecord) -> ManagedSourceView {
         started_at_unix: record.started_at_unix,
         stopped_at_unix: record.stopped_at_unix,
         last_error: record.last_error.clone(),
+        mode: None,
+        endpoint: None,
+        operation_id: None,
+        resource_uri: None,
+        poll_interval_secs: None,
+        last_success_at_unix: record.last_success_at_unix,
+        last_event_at_unix: record.last_event_at_unix,
+        reconnect_count: record.reconnect_count,
+        written_events: record.written_events,
+        checkpoint: None,
+        stream: None,
     }
 }
 
@@ -3180,6 +3567,7 @@ fn stream_info_view(record: &StreamInfoRecord) -> ManagedStreamInfo {
         created_at_unix: record.created_at_unix,
         earliest_offset: record.earliest_offset,
         latest_offset: record.latest_offset,
+        latest_event_at_unix: record.latest_event_at_unix,
         event_count: record.event_count,
         retention_max_rows: record.retention_max_rows,
         retention_max_age_secs: record.retention_max_age_secs,
@@ -3702,6 +4090,13 @@ impl DaemonRuntime {
             .await
     }
 
+    pub async fn source_doctor(
+        &self,
+        request: &ManagedSourceStatusRequest,
+    ) -> Result<ManagedSourceDoctorResponse> {
+        self.managed_sources.doctor(self, request).await
+    }
+
     pub async fn source_stop(
         &self,
         request: &ManagedSourceStatusRequest,
@@ -4032,9 +4427,23 @@ async fn note_subscription_event_delivered(
     view: &Arc<Mutex<SubscriptionJobView>>,
     timestamp_unix: u64,
 ) {
+    note_subscription_events_written(view, timestamp_unix, 1).await;
+}
+
+async fn note_subscription_events_written(
+    view: &Arc<Mutex<SubscriptionJobView>>,
+    timestamp_unix: u64,
+    count: u64,
+) {
     let mut guard = view.lock().await;
-    guard.written_events = guard.written_events.saturating_add(1);
+    guard.written_events = guard.written_events.saturating_add(count);
+    guard.last_success_at_unix = Some(timestamp_unix);
     guard.last_event_at_unix = Some(timestamp_unix);
+}
+
+async fn note_subscription_success(view: &Arc<Mutex<SubscriptionJobView>>, timestamp_unix: u64) {
+    let mut guard = view.lock().await;
+    guard.last_success_at_unix = Some(timestamp_unix);
 }
 
 #[async_trait::async_trait]
@@ -5920,6 +6329,21 @@ pub async fn source_status_client(
 }
 
 #[cfg(unix)]
+pub async fn source_doctor_client(
+    request: &ManagedSourceStatusRequest,
+) -> Result<ManagedSourceDoctorResponse> {
+    let value = client_call("source.doctor", Some(serde_json::to_value(request)?)).await?;
+    Ok(serde_json::from_value(value)?)
+}
+
+#[cfg(not(unix))]
+pub async fn source_doctor_client(
+    _request: &ManagedSourceStatusRequest,
+) -> Result<ManagedSourceDoctorResponse> {
+    bail!("uxcd daemon is not supported on this platform; run uxc inside WSL")
+}
+
+#[cfg(unix)]
 pub async fn source_list_client() -> Result<Vec<ManagedSourceListEntry>> {
     let value = client_call("source.list", None).await?;
     Ok(serde_json::from_value(value)?)
@@ -6472,6 +6896,53 @@ async fn handle_connection(mut stream: UnixStream, runtime: Arc<DaemonRuntime>) 
                 }
             };
             match runtime.source_status(&status).await {
+                Ok(result) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: Some(serde_json::to_value(result)?),
+                    error: None,
+                },
+                Err(err) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: None,
+                    error: Some(jsonrpc_error_from_anyhow(&err)),
+                },
+            }
+        }
+        "source.doctor" => {
+            let Some(params) = req.params else {
+                let resp = JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "Missing params".to_string(),
+                        data: None,
+                    }),
+                };
+                write_frame(&mut stream, &serde_json::to_value(resp)?).await?;
+                return Ok(());
+            };
+            let status: ManagedSourceStatusRequest = match serde_json::from_value(params) {
+                Ok(value) => value,
+                Err(err) => {
+                    let resp = JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION.to_string(),
+                        id: req.id,
+                        result: None,
+                        error: Some(JsonRpcError {
+                            code: -32602,
+                            message: format!("Invalid params: {err}"),
+                            data: None,
+                        }),
+                    };
+                    write_frame(&mut stream, &serde_json::to_value(resp)?).await?;
+                    return Ok(());
+                }
+            };
+            match runtime.source_doctor(&status).await {
                 Ok(result) => JsonRpcResponse {
                     jsonrpc: JSONRPC_VERSION.to_string(),
                     id: req.id,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3255,7 +3255,7 @@ fn enrich_managed_source_view_from_spec(view: &mut ManagedSourceView, spec_json:
         return;
     };
     view.mode = Some(spec.mode);
-    view.endpoint = Some(spec.endpoint);
+    view.endpoint = Some(redact_endpoint(&spec.endpoint));
     view.operation_id = spec.operation_id;
     view.resource_uri = spec.resource_uri;
     view.poll_interval_secs = spec
@@ -9116,6 +9116,10 @@ mod tests {
             started_at_unix: Some(now),
             stopped_at_unix: None,
             last_error: None,
+            last_success_at_unix: None,
+            last_event_at_unix: None,
+            reconnect_count: 0,
+            written_events: 0,
         }
     }
 
@@ -9211,7 +9215,7 @@ mod tests {
     }
 
     #[test]
-    fn managed_source_store_migrates_v0_schema_to_v1() {
+    fn managed_source_store_migrates_v0_schema_to_v2() {
         let temp = tempdir().unwrap();
         let db_path = managed_source_streams_db_path(temp.path());
         let conn = Connection::open(&db_path).unwrap();
@@ -9260,15 +9264,97 @@ mod tests {
         let version: i64 = conn
             .query_row("pragma user_version", [], |row| row.get(0))
             .unwrap();
-        let has_column: i64 = conn
+        let has_checkpoint_column: i64 = conn
             .query_row(
                 "select count(*) from pragma_table_info('managed_sources') where name = 'poll_checkpoint_json'",
                 [],
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, 1);
-        assert_eq!(has_column, 1);
+        let has_last_success_column: i64 = conn
+            .query_row(
+                "select count(*) from pragma_table_info('managed_sources') where name = 'last_success_at_unix'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let has_last_event_column: i64 = conn
+            .query_row(
+                "select count(*) from pragma_table_info('managed_sources') where name = 'last_event_at_unix'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let has_reconnect_column: i64 = conn
+            .query_row(
+                "select count(*) from pragma_table_info('managed_sources') where name = 'reconnect_count'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let has_written_events_column: i64 = conn
+            .query_row(
+                "select count(*) from pragma_table_info('managed_sources') where name = 'written_events'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, 2);
+        assert_eq!(has_checkpoint_column, 1);
+        assert_eq!(has_last_success_column, 1);
+        assert_eq!(has_last_event_column, 1);
+        assert_eq!(has_reconnect_column, 1);
+        assert_eq!(has_written_events_column, 1);
+    }
+
+    #[test]
+    fn managed_source_view_redacts_endpoint_from_spec() {
+        let mut view = ManagedSourceView {
+            namespace: "test".to_string(),
+            source_key: "redacted".to_string(),
+            spec_key: "spec-redacted".to_string(),
+            run_id: "run-redacted".to_string(),
+            stream_id: managed_stream_id("test", "redacted"),
+            status: "running".to_string(),
+            created_at_unix: 1,
+            updated_at_unix: 1,
+            started_at_unix: Some(1),
+            stopped_at_unix: None,
+            last_error: None,
+            mode: None,
+            endpoint: None,
+            operation_id: None,
+            resource_uri: None,
+            poll_interval_secs: None,
+            last_success_at_unix: None,
+            last_event_at_unix: None,
+            reconnect_count: 0,
+            written_events: 0,
+            checkpoint: None,
+            stream: None,
+        };
+        let mut spec =
+            managed_source_spec("https://user:pass@example.com/events?api_key=secret123&token=abc");
+        spec.mode = SubscriptionMode::Poll;
+        spec.poll_config = Some(json!({
+            "interval_secs": 5,
+            "extract_items_pointer": "/items",
+            "checkpoint_strategy": {
+                "type": "cursor_only"
+            }
+        }));
+
+        enrich_managed_source_view_from_spec(
+            &mut view,
+            &serde_json::to_value(spec).expect("managed source spec should serialize"),
+        );
+
+        assert_eq!(
+            view.endpoint.as_deref(),
+            Some("https://***:***@example.com/events?api_key=***&token=***")
+        );
+        assert_eq!(view.mode, Some(SubscriptionMode::Poll));
+        assert_eq!(view.poll_interval_secs, Some(5));
     }
 
     #[tokio::test]

--- a/src/daemon_client.rs
+++ b/src/daemon_client.rs
@@ -1,11 +1,11 @@
 use crate::auth::injected_env::InjectEnvSpec;
 use crate::daemon::{
     self, DaemonSessionKillRequest, DaemonSessionKillResponse, DaemonSessionView, DaemonStatus,
-    ManagedSourceEnsureRequest, ManagedSourceEnsureResponse, ManagedSourceListEntry,
-    ManagedSourceSpec, ManagedSourceStatusRequest, ManagedSourceStopResponse, ManagedSourceView,
-    ManagedStreamInfo, ManagedStreamReadRequest, ManagedStreamReadResponse,
-    ManagedStreamTrimRequest, ManagedStreamTrimResponse, RuntimeAction, RuntimeInvokeOptions,
-    RuntimeInvokeRequest, RuntimeInvokeResponse,
+    ManagedSourceDoctorResponse, ManagedSourceEnsureRequest, ManagedSourceEnsureResponse,
+    ManagedSourceListEntry, ManagedSourceSpec, ManagedSourceStatusRequest,
+    ManagedSourceStopResponse, ManagedSourceView, ManagedStreamInfo, ManagedStreamReadRequest,
+    ManagedStreamReadResponse, ManagedStreamTrimRequest, ManagedStreamTrimResponse, RuntimeAction,
+    RuntimeInvokeOptions, RuntimeInvokeRequest, RuntimeInvokeResponse,
 };
 use anyhow::Result;
 use serde_json::Value;
@@ -132,6 +132,18 @@ impl DaemonClient {
 
     pub async fn source_list(&self) -> Result<Vec<ManagedSourceListEntry>> {
         daemon::source_list_client().await
+    }
+
+    pub async fn source_doctor(
+        &self,
+        namespace: impl Into<String>,
+        source_key: impl Into<String>,
+    ) -> Result<ManagedSourceDoctorResponse> {
+        daemon::source_doctor_client(&ManagedSourceStatusRequest {
+            namespace: namespace.into(),
+            source_key: source_key.into(),
+        })
+        .await
     }
 
     pub async fn source_stop(

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,6 +357,14 @@ enum SourceCommands {
         #[arg(value_name = "SOURCE_KEY")]
         source_key: String,
     },
+    /// Diagnose a managed source
+    Doctor {
+        #[arg(value_name = "NAMESPACE")]
+        namespace: String,
+
+        #[arg(value_name = "SOURCE_KEY")]
+        source_key: String,
+    },
     /// Stop a managed source
     Stop {
         #[arg(value_name = "NAMESPACE")]
@@ -1471,7 +1479,7 @@ fn infer_help_path_from_tokens(tokens: &[String]) -> Option<Vec<String>> {
         "daemon" => {
             if let Some(level1) = tokens.get(idx).map(|s| s.as_str()) {
                 match level1 {
-                    "start" | "stop" | "status" | "sessions" | "restart" | "_serve" => {
+                    "start" | "stop" | "doctor" | "status" | "sessions" | "restart" | "_serve" => {
                         path.push(level1.to_string());
                     }
                     "session" => {
@@ -1488,7 +1496,7 @@ fn infer_help_path_from_tokens(tokens: &[String]) -> Option<Vec<String>> {
         }
         "source" => {
             if let Some(level1) = tokens.get(idx).map(|s| s.as_str()) {
-                if matches!(level1, "ensure" | "status" | "stop" | "delete") {
+                if matches!(level1, "ensure" | "status" | "doctor" | "stop" | "delete") {
                     path.push(level1.to_string());
                 }
             }
@@ -1607,6 +1615,7 @@ fn static_help_path_from_cli(cli: &Cli) -> Option<Vec<&'static str>> {
             SourceCommands::List => Some(vec!["source", "list"]),
             SourceCommands::Ensure { .. } => Some(vec!["source", "ensure"]),
             SourceCommands::Status { .. } => Some(vec!["source", "status"]),
+            SourceCommands::Doctor { .. } => Some(vec!["source", "doctor"]),
             SourceCommands::Stop { .. } => Some(vec!["source", "stop"]),
             SourceCommands::Delete { .. } => Some(vec!["source", "delete"]),
         },
@@ -2207,11 +2216,12 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
         ["source"] => HelpData {
             path: "uxc source".to_string(),
             about: "Manage daemon-backed source streams".to_string(),
-            usage: "uxc source <list|ensure|status|stop|delete> ...".to_string(),
+            usage: "uxc source <list|ensure|status|doctor|stop|delete> ...".to_string(),
             commands: commands(&[
                 ("list", "List managed sources"),
                 ("ensure", "Ensure a managed source exists and is running"),
                 ("status", "Show a managed source"),
+                ("doctor", "Diagnose a managed source"),
                 ("stop", "Stop a managed source"),
                 ("delete", "Delete a managed source binding"),
             ]),
@@ -2262,9 +2272,19 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
             usage: "uxc source status <namespace> <source_key>".to_string(),
             commands: vec![],
             notes: vec![
-                "Shows the current run, stable stream ID, status, current spec fingerprint, and last persisted checkpoint for the managed source.".to_string(),
+                "Shows the current run, stable stream ID, status, current spec fingerprint, health/progress counters, stream activity, and last persisted checkpoint summary for the managed source.".to_string(),
             ],
             examples: vec!["uxc source status agentinbox github_repo:holon-run/uxc".to_string()],
+        },
+        ["source", "doctor"] => HelpData {
+            path: "uxc source doctor".to_string(),
+            about: "Diagnose a managed source".to_string(),
+            usage: "uxc source doctor <namespace> <source_key>".to_string(),
+            commands: vec![],
+            notes: vec![
+                "Checks supported diagnostics for the current managed source runtime, including runner presence, stream binding, legacy runtime files, checkpoint visibility, and stalled progress heuristics.".to_string(),
+            ],
+            examples: vec!["uxc source doctor agentinbox github_repo:holon-run/uxc".to_string()],
         },
         ["source", "stop"] => HelpData {
             path: "uxc source stop".to_string(),
@@ -5714,6 +5734,19 @@ async fn handle_source_command(command: &SourceCommands, cli: &Cli) -> Result<Ou
                 .await?,
             )?;
             OutputEnvelope::success("source_status", "cli", "uxc", None, data, None)
+        }
+        SourceCommands::Doctor {
+            namespace,
+            source_key,
+        } => {
+            let data = serde_json::to_value(
+                daemon::source_doctor_client(&daemon::ManagedSourceStatusRequest {
+                    namespace: namespace.clone(),
+                    source_key: source_key.clone(),
+                })
+                .await?,
+            )?;
+            OutputEnvelope::success("source_doctor_result", "cli", "uxc", None, data, None)
         }
         SourceCommands::Stop {
             namespace,

--- a/src/managed_source_streams.rs
+++ b/src/managed_source_streams.rs
@@ -8,7 +8,7 @@ use tokio::sync::Mutex;
 
 const DEFAULT_RETENTION_MAX_ROWS: u64 = 10_000;
 const DEFAULT_RETENTION_MAX_AGE_SECS: u64 = 7 * 24 * 60 * 60;
-const MANAGED_SOURCE_SCHEMA_VERSION: i64 = 1;
+const MANAGED_SOURCE_SCHEMA_VERSION: i64 = 2;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManagedSourceRecord {
@@ -24,6 +24,10 @@ pub struct ManagedSourceRecord {
     pub started_at_unix: Option<u64>,
     pub stopped_at_unix: Option<u64>,
     pub last_error: Option<String>,
+    pub last_success_at_unix: Option<u64>,
+    pub last_event_at_unix: Option<u64>,
+    pub reconnect_count: u64,
+    pub written_events: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +63,7 @@ pub struct StreamInfoRecord {
     pub created_at_unix: u64,
     pub earliest_offset: Option<u64>,
     pub latest_offset: Option<u64>,
+    pub latest_event_at_unix: Option<u64>,
     pub event_count: u64,
     pub retention_max_rows: u64,
     pub retention_max_age_secs: u64,
@@ -89,6 +94,10 @@ pub struct SourceRuntimeUpdate {
     pub started_at_unix: Option<u64>,
     pub stopped_at_unix: Option<u64>,
     pub last_error: Option<String>,
+    pub last_success_at_unix: Option<u64>,
+    pub last_event_at_unix: Option<u64>,
+    pub reconnect_count: u64,
+    pub written_events: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -138,6 +147,10 @@ impl ManagedSourceStore {
                 started_at_unix integer,
                 stopped_at_unix integer,
                 last_error text,
+                last_success_at_unix integer,
+                last_event_at_unix integer,
+                reconnect_count integer not null default 0,
+                written_events integer not null default 0,
                 poll_checkpoint_json text,
                 underlying_job_id text,
                 mirrored_after_seq integer not null default 0,
@@ -191,7 +204,11 @@ impl ManagedSourceStore {
                     updated_at_unix,
                     started_at_unix,
                     stopped_at_unix,
-                    last_error
+                    last_error,
+                    last_success_at_unix,
+                    last_event_at_unix,
+                    reconnect_count,
+                    written_events
                 from managed_sources
                 order by namespace, source_key
                 "#,
@@ -290,7 +307,11 @@ impl ManagedSourceStore {
                     updated_at_unix,
                     started_at_unix,
                     stopped_at_unix,
-                    last_error
+                    last_error,
+                    last_success_at_unix,
+                    last_event_at_unix,
+                    reconnect_count,
+                    written_events
                 from managed_sources
                 where namespace = ?1 and source_key = ?2
                 "#,
@@ -340,7 +361,11 @@ impl ManagedSourceStore {
                     updated_at_unix = ?4,
                     started_at_unix = ?5,
                     stopped_at_unix = ?6,
-                    last_error = ?7
+                    last_error = ?7,
+                    last_success_at_unix = ?8,
+                    last_event_at_unix = ?9,
+                    reconnect_count = ?10,
+                    written_events = ?11
                 where namespace = ?1 and source_key = ?2
                 "#,
                 params![
@@ -350,7 +375,11 @@ impl ManagedSourceStore {
                     update.updated_at_unix,
                     update.started_at_unix,
                     update.stopped_at_unix,
-                    update.last_error
+                    update.last_error,
+                    update.last_success_at_unix,
+                    update.last_event_at_unix,
+                    update.reconnect_count,
+                    update.written_events
                 ],
             )?;
             Ok(())
@@ -697,15 +726,20 @@ impl ManagedSourceStore {
             let Some(stream) = stream else {
                 return Ok(None);
             };
-            let (earliest_offset, latest_offset, event_count): (Option<u64>, Option<u64>, u64) =
+            let (earliest_offset, latest_offset, latest_event_at_unix, event_count): (
+                Option<u64>,
+                Option<u64>,
+                Option<u64>,
+                u64,
+            ) =
                 conn.query_row(
                     r#"
-                    select min(offset), max(offset), count(*)
+                    select min(offset), max(offset), max(ingested_at_unix), count(*)
                     from stream_events
                     where stream_id = ?1
                     "#,
                     params![stream.stream_id],
-                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
                 )?;
             Ok(Some(StreamInfoRecord {
                 stream_id: stream.stream_id,
@@ -714,6 +748,7 @@ impl ManagedSourceStore {
                 created_at_unix: stream.created_at_unix,
                 earliest_offset,
                 latest_offset,
+                latest_event_at_unix,
                 event_count,
                 retention_max_rows: stream.retention_max_rows,
                 retention_max_age_secs: stream.retention_max_age_secs,
@@ -753,6 +788,10 @@ fn row_to_managed_source_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<Man
         started_at_unix: row.get(9)?,
         stopped_at_unix: row.get(10)?,
         last_error: row.get(11)?,
+        last_success_at_unix: row.get(12)?,
+        last_event_at_unix: row.get(13)?,
+        reconnect_count: row.get(14)?,
+        written_events: row.get(15)?,
     })
 }
 
@@ -776,9 +815,13 @@ fn upsert_source_tx(
             started_at_unix,
             stopped_at_unix,
             last_error,
+            last_success_at_unix,
+            last_event_at_unix,
+            reconnect_count,
+            written_events,
             poll_checkpoint_json
         )
-        values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
         on conflict(namespace, source_key) do update set
             spec_json = excluded.spec_json,
             spec_key = excluded.spec_key,
@@ -789,6 +832,10 @@ fn upsert_source_tx(
             started_at_unix = excluded.started_at_unix,
             stopped_at_unix = excluded.stopped_at_unix,
             last_error = excluded.last_error,
+            last_success_at_unix = excluded.last_success_at_unix,
+            last_event_at_unix = excluded.last_event_at_unix,
+            reconnect_count = excluded.reconnect_count,
+            written_events = excluded.written_events,
             poll_checkpoint_json = excluded.poll_checkpoint_json
         "#,
         params![
@@ -804,6 +851,10 @@ fn upsert_source_tx(
             record.started_at_unix,
             record.stopped_at_unix,
             record.last_error,
+            record.last_success_at_unix,
+            record.last_event_at_unix,
+            record.reconnect_count,
+            record.written_events,
             Option::<String>::None
         ],
     )?;
@@ -880,8 +931,11 @@ fn migrate_schema(conn: &mut Connection) -> Result<()> {
     let version: i64 = conn.query_row("pragma user_version", [], |row| row.get(0))?;
     if version < 1 {
         migrate_v0_to_v1(conn)?;
-        conn.pragma_update(None, "user_version", MANAGED_SOURCE_SCHEMA_VERSION)?;
     }
+    if version < 2 {
+        migrate_v1_to_v2(conn)?;
+    }
+    conn.pragma_update(None, "user_version", MANAGED_SOURCE_SCHEMA_VERSION)?;
     Ok(())
 }
 
@@ -889,6 +943,34 @@ fn migrate_v0_to_v1(conn: &mut Connection) -> Result<()> {
     if !table_has_column(conn, "managed_sources", "poll_checkpoint_json")? {
         conn.execute(
             "alter table managed_sources add column poll_checkpoint_json text",
+            [],
+        )?;
+    }
+    Ok(())
+}
+
+fn migrate_v1_to_v2(conn: &mut Connection) -> Result<()> {
+    if !table_has_column(conn, "managed_sources", "last_success_at_unix")? {
+        conn.execute(
+            "alter table managed_sources add column last_success_at_unix integer",
+            [],
+        )?;
+    }
+    if !table_has_column(conn, "managed_sources", "last_event_at_unix")? {
+        conn.execute(
+            "alter table managed_sources add column last_event_at_unix integer",
+            [],
+        )?;
+    }
+    if !table_has_column(conn, "managed_sources", "reconnect_count")? {
+        conn.execute(
+            "alter table managed_sources add column reconnect_count integer not null default 0",
+            [],
+        )?;
+    }
+    if !table_has_column(conn, "managed_sources", "written_events")? {
+        conn.execute(
+            "alter table managed_sources add column written_events integer not null default 0",
             [],
         )?;
     }

--- a/tests/cli_help_regression_test.rs
+++ b/tests/cli_help_regression_test.rs
@@ -880,7 +880,7 @@ fn source_help_flag_outputs_subcommand_help_json() {
     assert!(json["data"]["usage"]
         .as_str()
         .unwrap_or_default()
-        .contains("uxc source <list|ensure|status|stop|delete>"));
+        .contains("uxc source <list|ensure|status|doctor|stop|delete>"));
 }
 
 #[test]
@@ -920,6 +920,27 @@ fn source_ensure_help_flag_outputs_subcommand_help_json() {
         .as_str()
         .unwrap_or_default()
         .contains("<namespace> <source_key> <endpoint>"));
+}
+
+#[test]
+#[serial]
+fn source_doctor_help_flag_outputs_subcommand_help_json() {
+    let output = uxc_command()
+        .arg("source")
+        .arg("doctor")
+        .arg("--help")
+        .output()
+        .expect("failed to run uxc source doctor --help");
+    assert!(output.status.success(), "command should succeed");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["kind"], "subcommand_help");
+    assert_eq!(json["data"]["path"], "uxc source doctor");
+    assert_eq!(
+        json["data"]["usage"],
+        "uxc source doctor <namespace> <source_key>"
+    );
 }
 
 #[test]

--- a/tests/source_cli_test.rs
+++ b/tests/source_cli_test.rs
@@ -1,0 +1,188 @@
+mod common;
+
+use serial_test::serial;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use common::{start_test_server, uxc_command_with_home};
+
+fn daemon_stop_best_effort_with_home(home: &Path) {
+    let _ = uxc_command_with_home(home)
+        .arg("daemon")
+        .arg("stop")
+        .output();
+}
+
+fn daemon_runtime_dir(home: &Path) -> PathBuf {
+    home.join("runtime").join("uxc")
+}
+
+fn read_json_output(output: &std::process::Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON")
+}
+
+fn run_source_status(home: &Path, namespace: &str, source_key: &str) -> serde_json::Value {
+    let output = uxc_command_with_home(home)
+        .arg("source")
+        .arg("status")
+        .arg(namespace)
+        .arg(source_key)
+        .output()
+        .expect("uxc source status should run");
+    assert!(
+        output.status.success(),
+        "source status should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    read_json_output(&output)
+}
+
+fn run_source_doctor(home: &Path, namespace: &str, source_key: &str) -> serde_json::Value {
+    let output = uxc_command_with_home(home)
+        .arg("source")
+        .arg("doctor")
+        .arg(namespace)
+        .arg(source_key)
+        .output()
+        .expect("uxc source doctor should run");
+    assert!(
+        output.status.success(),
+        "source doctor should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    read_json_output(&output)
+}
+
+fn wait_for_source_progress(home: &Path, namespace: &str, source_key: &str) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(8);
+    loop {
+        let json = run_source_status(home, namespace, source_key);
+        let data = &json["data"];
+        let has_success = data["last_success_at_unix"].as_u64().is_some();
+        let event_count = data["stream"]["event_count"].as_u64().unwrap_or(0);
+        let has_checkpoint_kind = data["checkpoint"]["kind"].as_str().is_some();
+        if has_success && event_count > 0 && has_checkpoint_kind {
+            return json;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "managed source did not make observable progress in time: {}",
+            serde_json::to_string_pretty(&json).unwrap_or_default()
+        );
+        thread::sleep(Duration::from_millis(200));
+    }
+}
+
+#[test]
+#[serial]
+fn source_status_surfaces_progress_and_checkpoint_for_poll_sources() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+    let server = start_test_server("openapi", "ok");
+
+    let ensure = uxc_command_with_home(temp_home.path())
+        .arg("source")
+        .arg("ensure")
+        .arg("test")
+        .arg("poll-events")
+        .arg(&server.addr)
+        .arg("get:/poll/events")
+        .arg("--mode")
+        .arg("poll")
+        .arg("--poll-config")
+        .arg(
+            r#"{"interval_secs":1,"extract_items_pointer":"/items","request_cursor_arg":"cursor","response_cursor_pointer":"/next_cursor","checkpoint_strategy":{"type":"cursor_only"}}"#,
+        )
+        .output()
+        .expect("uxc source ensure should run");
+    assert!(
+        ensure.status.success(),
+        "source ensure should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&ensure.stdout),
+        String::from_utf8_lossy(&ensure.stderr)
+    );
+
+    let json = wait_for_source_progress(temp_home.path(), "test", "poll-events");
+    let data = &json["data"];
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["kind"], "source_status");
+    assert_eq!(data["namespace"], "test");
+    assert_eq!(data["source_key"], "poll-events");
+    assert_eq!(data["mode"], "poll");
+    assert_eq!(data["endpoint"], format!("http://{}", server.addr));
+    assert_eq!(data["poll_interval_secs"], 1);
+    assert!(data["last_success_at_unix"].as_u64().is_some());
+    assert!(data["last_event_at_unix"].as_u64().is_some());
+    assert!(data["written_events"].as_u64().unwrap_or(0) > 0);
+    assert_eq!(data["reconnect_count"], 0);
+    assert_eq!(data["checkpoint"]["kind"], "cursor_only");
+    assert!(data["checkpoint"]["cursor"].is_string());
+    assert!(data["stream"]["event_count"].as_u64().unwrap_or(0) > 0);
+    assert!(data["stream"]["latest_offset"].as_u64().is_some());
+    assert!(data["stream"]["latest_event_at_unix"].as_u64().is_some());
+
+    daemon_stop_best_effort_with_home(temp_home.path());
+}
+
+#[test]
+#[serial]
+fn source_doctor_warns_on_legacy_cursor_file() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+    let server = start_test_server("openapi", "ok");
+
+    let ensure = uxc_command_with_home(temp_home.path())
+        .arg("source")
+        .arg("ensure")
+        .arg("test")
+        .arg("doctor-cursor")
+        .arg(&server.addr)
+        .arg("get:/poll/events")
+        .arg("--mode")
+        .arg("poll")
+        .arg("--poll-config")
+        .arg(
+            r#"{"interval_secs":1,"extract_items_pointer":"/items","request_cursor_arg":"cursor","response_cursor_pointer":"/next_cursor","checkpoint_strategy":{"type":"cursor_only"}}"#,
+        )
+        .output()
+        .expect("uxc source ensure should run");
+    assert!(ensure.status.success(), "source ensure should succeed");
+
+    let status_json = wait_for_source_progress(temp_home.path(), "test", "doctor-cursor");
+    let run_id = status_json["data"]["run_id"]
+        .as_str()
+        .expect("run_id should be present");
+
+    let healthy = run_source_doctor(temp_home.path(), "test", "doctor-cursor");
+    assert_eq!(healthy["kind"], "source_doctor_result");
+    assert_eq!(healthy["data"]["status"], "healthy");
+    assert_eq!(healthy["data"]["legacy_cursor_file_present"], false);
+
+    let cursor_path = daemon_runtime_dir(temp_home.path())
+        .join("managed-source-cursors")
+        .join(format!("{run_id}.cursor.json"));
+    fs::create_dir_all(
+        cursor_path
+            .parent()
+            .expect("legacy cursor path should have a parent"),
+    )
+    .expect("cursor parent dir should exist");
+    fs::write(&cursor_path, br#"{"after_seq":123}"#).expect("legacy cursor file should be written");
+
+    let warned = run_source_doctor(temp_home.path(), "test", "doctor-cursor");
+    let issue_codes = warned["data"]["issues"]
+        .as_array()
+        .expect("issues should be an array")
+        .iter()
+        .filter_map(|issue| issue.get("code").and_then(serde_json::Value::as_str))
+        .collect::<Vec<_>>();
+    assert_eq!(warned["data"]["status"], "warn");
+    assert_eq!(warned["data"]["legacy_cursor_file_present"], true);
+    assert!(issue_codes.contains(&"legacy_cursor_file_present"));
+
+    daemon_stop_best_effort_with_home(temp_home.path());
+}


### PR DESCRIPTION
## What
- extend `uxc source status` with managed source health/progress fields, stream activity summary, and poll checkpoint summary
- add `uxc source doctor <namespace> <source_key>` for managed source diagnostics
- persist managed source observability counters so status survives daemon/runtime transitions

## Why
- `#382` was narrowed to a phase-1 observability/diagnostics slice for the current managed source runtime
- operators need a supported way to see source health and progress without digging through daemon internals
- we also need a first-class diagnostic surface before taking on stronger scheduling/policy controls

## How
- add persisted runtime counters: `last_success_at_unix`, `last_event_at_unix`, `reconnect_count`, `written_events`
- enrich `ManagedSourceView` from live runtime state, stored stream metadata, and persisted poll checkpoints
- add daemon/client/CLI plumbing for `source.doctor`, with warnings for runner mismatch, missing stream binding, legacy runtime files, missing poll checkpoints, and stalled progress heuristics
- add CLI regression coverage and poll-source E2E coverage for the new status/doctor surfaces

## Testing
- `cargo check`
- `cargo test --test cli_help_regression_test source_help_flag_outputs_subcommand_help_json -- --exact`
- `cargo test --test cli_help_regression_test source_doctor_help_flag_outputs_subcommand_help_json -- --exact`
- `cargo test --test source_cli_test -- --test-threads=1`

Closes #382
