### PR TITLE
feat: improve skill scores for 5 lowest-scoring skills

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/skills/alchemy-openapi-skill/SKILL.md
+++ b/skills/alchemy-openapi-skill/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: alchemy-openapi-skill
-description: Operate Alchemy Prices API reads through UXC with a curated OpenAPI schema, path-templated API-key auth, and read-first guardrails.
+description: "Look up token prices by symbol or contract address and retrieve historical price data through the Alchemy Prices API via UXC. Use when the task involves real-time or historical cryptocurrency token price queries on Alchemy."
+user-invocable: true
+triggers:
+  - alchemy
+  - token price
+  - alchemy prices
+  - crypto price lookup
+  - historical prices
 ---
 
 # Alchemy Prices API Skill
@@ -19,19 +26,9 @@ Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
 
 ## Scope
 
-This v1 skill intentionally covers the narrow Prices API surface:
+Prices API surface: token price by symbol, token price by contract address, and historical token prices.
 
-- token price lookup by symbol
-- token price lookup by contract address
-- historical token prices
-
-This skill does **not** cover:
-
-- node JSON-RPC
-- NFT or portfolio APIs
-- write operations
-- the broader Alchemy API surface
-- multi-symbol batch lookup in one `uxc` call
+Does **not** cover node JSON-RPC, NFT/portfolio APIs, write operations, or multi-symbol batch lookup in one call.
 
 ## Authentication
 
@@ -76,24 +73,17 @@ uxc auth binding match https://api.g.alchemy.com
    - `alchemy-openapi-cli get:/tokens/by-symbol symbols=ETH currency=USD`
    - `alchemy-openapi-cli post:/tokens/by-address '{"addresses":[{"network":"eth-mainnet","address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"}],"currency":"USD"}'`
 
- 4. Use positional JSON only for the POST endpoints:
+4. Use positional JSON only for the POST endpoints:
    - `alchemy-openapi-cli post:/tokens/historical '{"symbol":"ETH","startTime":"2025-01-01T00:00:00Z","endTime":"2025-01-07T00:00:00Z","interval":"1d","currency":"USD"}'`
-
-## Operations
-
-- `get:/tokens/by-symbol`
-- `post:/tokens/by-address`
-- `post:/tokens/historical`
 
 ## Guardrails
 
 - Keep automation on the JSON output envelope; do not use `--text`.
 - Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
 - Treat this v1 skill as read-only and prices-only. Do not imply RPC, trade execution, or wallet mutation support.
-- API keys are sensitive because they appear in the request path. Use `--secret-env` or `--secret-op`, not shell history literals, when possible.
-- `/tokens/by-symbol` is query-based in the live API.
-- The live API supports repeated `symbols=` parameters, but this v1 skill intentionally narrows that endpoint to a single `symbols=<TOKEN>` query because current `uxc` query argument handling does not reliably execute array-shaped query parameters.
-- Historical requests can expand quickly. Keep time windows tight unless the user explicitly wants a larger backfill.
+- API keys appear in the request path — use `--secret-env` or `--secret-op`, not shell history literals.
+- This v1 skill intentionally narrows `/tokens/by-symbol` to a single `symbols=<TOKEN>` query because current `uxc` query argument handling does not reliably execute array-shaped query parameters.
+- Historical requests can expand quickly — keep time windows tight unless the user explicitly wants a larger backfill.
 - `alchemy-openapi-cli <operation> ...` is equivalent to `uxc https://api.g.alchemy.com --schema-url <alchemy_openapi_schema> <operation> ...`.
 
 ## References

--- a/skills/blockscout-openapi-skill/SKILL.md
+++ b/skills/blockscout-openapi-skill/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: blockscout-openapi-skill
-description: Operate Blockscout explorer reads through UXC with a curated OpenAPI schema, instance-specific host selection, and read-first guardrails.
+description: "Look up addresses, tokens, transactions, and blocks on any Blockscout explorer instance through UXC with a curated OpenAPI schema. Use when the task involves blockchain explorer reads across Ethereum, Optimism, or other Blockscout-powered chains."
+user-invocable: true
+triggers:
+  - blockscout
+  - blockchain explorer
+  - address lookup
+  - token holders
+  - block explorer
 ---
 
 # Blockscout Explorer API Skill
@@ -15,32 +22,17 @@ Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
 - Network access to a Blockscout deployment that exposes `/api/v2`.
 - Access to the curated OpenAPI schema URL:
   - `https://raw.githubusercontent.com/holon-run/uxc/main/skills/blockscout-openapi-skill/references/blockscout-v2.openapi.json`
-- A target Blockscout instance. Examples in this skill use `https://eth.blockscout.com/api/v2`.
+- A target Blockscout instance. Examples use `https://eth.blockscout.com/api/v2`.
 
 ## Scope
 
-This skill covers a read-first explorer surface:
+Read-first explorer surface: address summary, token balances, transaction history, token metadata, token holders, transaction detail, and block detail lookups.
 
-- address summary lookup
-- address token balances
-- address transaction history
-- token metadata
-- token holder reads
-- transaction detail lookup
-- block detail lookup
-
-This skill does **not** cover:
-
-- Blockscout GraphQL
-- raw JSON-RPC proxying
-- write operations or admin/configuration flows
-- custom authenticated gateways beyond what the caller explicitly binds
+Does **not** cover Blockscout GraphQL, raw JSON-RPC proxying, write operations, or admin flows.
 
 ## Authentication
 
-Public Blockscout instances usually allow explorer reads without auth.
-
-If you are targeting a self-hosted or gateway-protected instance, configure auth separately with standard `uxc auth` bindings for that host. This skill does not assume any default credential.
+Public Blockscout instances need no auth. For gateway-protected instances, use standard `uxc auth` bindings for that host.
 
 ## Core Workflow
 
@@ -64,24 +56,9 @@ If you are targeting a self-hosted or gateway-protected instance, configure auth
    - `blockscout-openapi-cli get:/addresses/{address_hash}/transactions address_hash=0xd8da6bf26964af9d7eed9e03e53415d37aa96045`
    - `blockscout-openapi-cli get:/tokens/{address_hash}/holders address_hash=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`
 
-## Operation Groups
-
-### Address Reads
-
-- `get:/addresses/{address_hash}`
-- `get:/addresses/{address_hash}/token-balances`
-- `get:/addresses/{address_hash}/transactions`
-
-### Token, Transaction, And Block Reads
-
-- `get:/tokens/{address_hash}`
-- `get:/tokens/{address_hash}/holders`
-- `get:/transactions/{hash}`
-- `get:/blocks/{block_number_or_hash}`
-
 ## Multi-Instance Use
 
-To target a different Blockscout deployment, keep the same schema and relink the command to another host that serves `/api/v2`:
+To target a different Blockscout deployment, relink to another host that serves `/api/v2`:
 
 ```bash
 uxc link blockscout-openapi-cli https://optimism.blockscout.com/api/v2 \
@@ -93,8 +70,8 @@ uxc link blockscout-openapi-cli https://optimism.blockscout.com/api/v2 \
 - Keep automation on the JSON output envelope; do not use `--text`.
 - Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
 - Treat this v1 skill as read-only. Do not imply transaction broadcast or contract write support.
-- This schema is designed for Blockscout deployments that expose the explorer REST surface at `/api/v2`. If host help fails, check the deployment path before assuming a protocol mismatch.
-- Pagination and filter options vary across deployments. Start with host help and operation help on the target instance before building large crawls.
+- If host help fails, check the deployment path (`/api/v2`) before assuming a protocol mismatch.
+- Pagination and filter options vary across deployments — inspect with operation help before building large crawls.
 - `blockscout-openapi-cli <operation> ...` is equivalent to `uxc <blockscout_api_v2_host> --schema-url <blockscout_openapi_schema> <operation> ...`.
 
 ## References

--- a/skills/discord-openapi-skill/SKILL.md
+++ b/skills/discord-openapi-skill/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: discord-openapi-skill
-description: Operate Discord HTTP API through UXC with Discord OpenAPI schema. Bot token recommended for full API access including messages and server management. OAuth2 user authentication available for limited profile operations only.
+description: "Send messages, manage channels, and read server data through the Discord HTTP API via UXC with the official OpenAPI schema. Use when the task involves Discord bot operations, server management, or user profile reads."
+user-invocable: true
+triggers:
+  - discord
+  - discord api
+  - discord bot
+  - send discord message
+  - discord server
 ---
 
 # Discord API Skill
@@ -15,28 +22,20 @@ Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
 - Network access to `https://discord.com/api/v10`.
 - Access to Discord OpenAPI spec URL:
   - `https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json`
-- Discord bot token (recommended) or OAuth2 user authentication (limited functionality).
+- Discord bot token (recommended) or OAuth2 user authentication (profile reads only).
 
 ## Authentication
 
-### Option 1: Bot Token (Recommended)
+### Bot Token (Recommended)
 
-Bot token provides full access to Discord API including reading messages, managing servers, sending messages, and all administrative operations. This is the recommended method for most use cases.
-
-1. Create a bot application at https://discord.com/developers/applications
-2. Generate a bot token from the Bot section
-3. Configure bot credential:
+Full API access: messages, server management, moderation.
 
 ```bash
 uxc auth credential set discord-bot \
   --auth-type api_key \
   --header "Authorization=Bot {{secret}}" \
   --secret "YOUR_BOT_TOKEN_HERE"
-```
 
-4. Bind credential to Discord API endpoint:
-
-```bash
 uxc auth binding add \
   --id discord-bot \
   --host discord.com \
@@ -46,54 +45,12 @@ uxc auth binding add \
   --priority 100
 ```
 
-### Option 2: OAuth2 User Authentication (Limited Use Cases)
+### OAuth2 User Authentication (Profile Reads Only)
 
-**Important:** User OAuth2 has significant limitations and is **not recommended** for most operations:
-- ❌ Cannot read channel messages via HTTP API (local RPC only)
-- ❌ Cannot send messages or manage servers
-- ✅ Can read user profile, email, connections
-- ✅ Can list user's servers
+User OAuth2 **cannot** read channel messages via HTTP API, send messages, or manage servers. Use only for user profile, email, connections, and server list reads.
 
-Only use OAuth2 if you specifically need to access user profile information as the user. For all other operations, use Bot Token.
+Two-stage flow:
 
-If you still need OAuth2 for user profile operations:
-
-**Configuration:**
-- Client ID: `1479302369723285736`
-- Redirect URI: `http://127.0.0.1:11111/callback`
-
-**OAuth2 Scopes:**
-
-Discord user OAuth2 supports **read-only operations**. It cannot send messages or manage servers as a user (use Bot Token for those operations).
-
-**Recommended Scopes (Full Functionality):**
-```bash
---scope "identify email connections guilds guilds.members.read messages.read openid"
-```
-
-**Minimal Read-Only Scopes:**
-```bash
---scope "identify email connections guilds guilds.members.read"
-```
-
-**Scope Reference:**
-
-| Scope | Description | Write Operation |
-|-------|-------------|-----------------|
-| `identify` | Basic user info (username, avatar, etc.) | ❌ Read |
-| `email` | User's email address | ❌ Read |
-| `connections` | Linked third-party accounts (Twitch, YouTube, etc.) | ❌ Read |
-| `guilds` | User's server list | ❌ Read |
-| `guilds.join` | Join user to servers (requires the same application's bot to already be in that guild) | ✅ **Write** |
-| `guilds.members.read` | User's member info in servers | ❌ Read |
-| `messages.read` | Read messages (local RPC only, **not** HTTP API) | ❌ Read |
-| `openid` | OpenID Connect support | ❌ Read |
-
-**Note:** User OAuth2 **cannot** send messages or manage servers as the user. Use Bot Token for write operations. `guilds.join` is a special user OAuth write capability that depends on the same application's bot already being in the target guild, so it is not part of the default read-only flow. See [Discord OAuth2 documentation](https://discord.com/developers/topics/oauth2) for complete scope list.
-
-**Two-Stage OAuth Flow (Agent-Friendly):**
-
-1. Start OAuth flow with desired scopes:
 ```bash
 uxc auth oauth start discord-user \
   --endpoint https://discord.com/api/oauth2/token \
@@ -102,17 +59,13 @@ uxc auth oauth start discord-user \
   --scope "identify email connections guilds guilds.members.read messages.read openid"
 ```
 
-2. Open the displayed authorization URL in browser, complete authorization, then copy the callback URL from browser address bar.
+Complete after browser authorization:
 
-3. Complete OAuth flow:
 ```bash
 uxc auth oauth complete discord-user \
   --session-id <session_id_from_step_1> \
   --authorization-response "<callback_url_from_browser>"
-```
 
-4. Bind credential:
-```bash
 uxc auth binding add \
   --id discord-user \
   --host discord.com \
@@ -121,19 +74,6 @@ uxc auth binding add \
   --credential discord-user \
   --priority 100
 ```
-
-**Interactive Alternative (Local Terminal Only):**
-
-```bash
-uxc auth oauth login discord-user \
-  --endpoint https://discord.com/api/oauth2/token \
-  --flow authorization_code \
-  --client-id 1479302369723285736 \
-  --redirect-uri http://127.0.0.1:11111/callback \
-  --scope "identify email connections guilds guilds.members.read messages.read openid"
-```
-
-Then paste the callback URL when prompted.
 
 ## Core Workflow
 
@@ -155,32 +95,9 @@ Then paste the callback URL when prompted.
    - positional JSON: `discord-openapi-cli post:/channels/{channel_id}/messages '{"channel_id":"CHANNEL_ID","content":"Hello from uxc"}'`
    - binding check when auth looks wrong: `uxc auth binding match https://discord.com/api/v10`
 
-## Authentication Methods Comparison
+## Subscribe / Gateway
 
-| Feature | Bot Token | User OAuth2 |
-|---------|-----------|-------------|
-| **Read channel messages** | ✅ Full access | ❌ Not via HTTP API |
-| **Send messages** | ✅ As the bot | ❌ Not supported |
-| **Manage channels/roles** | ✅ Bot permissions | ❌ Not supported |
-| **Moderation actions** | ✅ Bot permissions | ❌ Not supported |
-| **List servers** | ✅ Servers bot is in | ✅ User's servers |
-| **Read user info** | ❌ Not available | ✅ As the user |
-| **Message appearance** | Bot badge "BOT" | N/A |
-
-**Key Recommendation:** Use **Bot Token** for almost all operations. User OAuth2 is only useful if you need to read user profile information as that specific user. For reading channel messages, managing servers, or sending messages, Bot Token is required.
-
-## Subscribe / Gateway Status
-
-Discord inbound events flow through the Gateway WebSocket, not through this REST/OpenAPI surface.
-
-Current `uxc subscribe` status:
-
-- the built-in `discord-gateway` transport now bootstraps through `GET /gateway/bot`
-- live Gateway sessions reached `READY` and delivered `GUILD_CREATE`
-- a real posted channel message produced a `MESSAGE_CREATE` event in the subscribe sink
-- heartbeat scheduling, `IDENTIFY`, sequence tracking, and reconnect handling are implemented
-
-Recommended invocation:
+Discord inbound events flow through the Gateway WebSocket, not this REST surface. The built-in `discord-gateway` transport handles `IDENTIFY`, heartbeat, sequence tracking, and reconnect:
 
 ```bash
 uxc subscribe start https://discord.com/api/v10 \
@@ -190,19 +107,13 @@ uxc subscribe start https://discord.com/api/v10 \
   --sink file:$HOME/.uxc/subscriptions/discord-gateway.ndjson
 ```
 
-Intent notes:
-
-- `4609` = `GUILDS | GUILD_MESSAGES | DIRECT_MESSAGES`
-- add `32768` (`MESSAGE_CONTENT`) only when the bot has that privileged intent enabled in the Discord developer portal
-
-Use `discord-openapi-cli` for REST calls and `uxc subscribe start ... --transport discord-gateway ...` for inbound Gateway events.
+Intent `4609` = `GUILDS | GUILD_MESSAGES | DIRECT_MESSAGES`. Add `32768` (`MESSAGE_CONTENT`) only when the bot has that privileged intent enabled in the developer portal.
 
 ## Guardrails
 
-- **OAuth2 Scope Limitation:** User OAuth2 tokens cannot read channel messages via HTTP API, send messages, or manage servers. These operations require Bot Token authentication.
-- Discord OpenAPI spec is persisted in the generated link via `uxc link --schema-url ...`; pass `--schema-url <other-url>` only when you need to override it temporarily.
 - Keep automation on JSON output envelope; do not use `--text`.
 - Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
+- User OAuth2 tokens cannot read channel messages, send messages, or manage servers via HTTP API — use Bot Token for those.
 - Prefer positional JSON for non-string objects instead of `--input-json`.
 - `discord-openapi-cli <operation> ...` is equivalent to `uxc https://discord.com/api/v10 --schema-url <discord_openapi_spec> <operation> ...`.
 - Treat `post:/channels/{channel_id}/messages`, delete/update endpoints, and moderation endpoints as write/high-risk operations; require explicit user confirmation before execution.

--- a/skills/qmd-mcp-skill/SKILL.md
+++ b/skills/qmd-mcp-skill/SKILL.md
@@ -1,8 +1,13 @@
 ---
 name: qmd-mcp-skill
-description: Use a local QMD knowledge base through UXC over MCP stdio, with daemon-backed session reuse and typed retrieval flows that avoid repeated model warmup and unnecessary query-expansion latency.
-metadata:
-  short-description: Query local QMD indexes via UXC MCP stdio
+description: "Search and retrieve documents from a local QMD knowledge base through UXC over MCP stdio with daemon-backed session reuse. Use when the task involves querying local markdown corpora, notes, or indexed documents via lex/vec/hyde search types."
+user-invocable: true
+triggers:
+  - qmd
+  - qmd search
+  - local knowledge base
+  - document retrieval
+  - qmd query
 ---
 
 # QMD MCP Skill
@@ -14,26 +19,19 @@ Reuse the `uxc` skill for generic protocol discovery, JSON envelope parsing, and
 ## Prerequisites
 
 - `uxc` is installed and available in `PATH`.
-- `qmd` is installed and available in the runtime `PATH`, or can be launched through a shell wrapper.
-- A QMD index already exists and is healthy:
-  - `qmd status`
-  - `qmd update`
-  - `qmd embed`
-- For GPU-backed setups, the shell used by `qmd mcp` already exports any required runtime environment such as `CUDA_PATH`, `CUDACXX`, `LD_LIBRARY_PATH`, or Node/nvm initialization.
+- `qmd` is installed and available in the runtime `PATH`, or launchable through a shell wrapper.
+- A healthy QMD index (`qmd status`, `qmd update`, `qmd embed`).
+- For GPU-backed setups, the shell must export `CUDA_PATH`, `CUDACXX`, `LD_LIBRARY_PATH`, or Node/nvm initialization. See `references/usage-patterns.md` for a full wrapper example.
 
 ## Core Workflow
 
-1. Verify the local QMD index first:
+1. Verify the local QMD index:
    - `qmd status`
-   - Confirm collections, vector count, and device look reasonable before linking MCP.
 2. Use a fixed link command by default:
    - `command -v qmd-mcp-cli`
-   - If missing and `qmd` already works in the current shell:
-     - `uxc link --daemon-idle-ttl 0 qmd-mcp-cli "qmd mcp"`
-   - If `qmd` depends on `nvm`, CUDA env, or other shell setup, wrap it explicitly:
-     - `uxc link --daemon-idle-ttl 0 qmd-mcp-cli "/bin/bash -lc 'export NVM_DIR=$HOME/.nvm; . $NVM_DIR/nvm.sh; nvm use 23 >/dev/null; export CUDA_PATH=/usr/local/cuda-11.6; export CUDA_HOME=/usr/local/cuda-11.6; export CUDACXX=/usr/local/cuda-11.6/bin/nvcc; export LD_LIBRARY_PATH=/usr/local/cuda-11.6/lib64:${LD_LIBRARY_PATH:-}; export NODE_LLAMA_CPP_CMAKE_OPTION_CMAKE_CUDA_ARCHITECTURES=86; export NODE_LLAMA_CPP_GPU=cuda; qmd mcp'"`
+   - If missing: `uxc link --daemon-idle-ttl 0 qmd-mcp-cli "qmd mcp"`
+   - For GPU/nvm setups, see the wrapped command in `references/usage-patterns.md`.
    - `qmd-mcp-cli -h`
-   - If command conflict is detected and cannot be safely reused, stop and ask skill maintainers to pick another fixed command name.
 3. Confirm the daemon-backed stdio path is active:
    - `uxc daemon status`
    - `uxc daemon sessions`
@@ -42,57 +40,29 @@ Reuse the `uxc` skill for generic protocol discovery, JSON envelope parsing, and
    - `qmd-mcp-cli get -h`
    - `qmd-mcp-cli multi_get -h`
    - `qmd-mcp-cli status -h`
-5. Prefer typed retrieval over CLI-style auto expansion:
-   - Start with `query` using explicit `lex` / `vec` / `hyde` searches
-   - Use `get` or `multi_get` only after narrowing candidates
+5. Execute typed retrieval — start with `query` using explicit `lex`/`vec`/`hyde` searches, then narrow with `get` or `multi_get`.
 
 ## Recommended Usage Pattern
 
-1. Health check the index:
-   - `qmd-mcp-cli status`
-2. Start with a fast explicit search payload:
+1. Health check: `qmd-mcp-cli status`
+2. Fast explicit search:
    - `qmd-mcp-cli query '{"searches":[{"type":"lex","query":"\"execution layer\" MCP CLI"},{"type":"vec","query":"What is the missing execution surface between MCP and CLI?"}],"collections":["workspace"],"limit":5,"intent":"Find the article explaining capability description, execution surface, and workflow orchestration"}'`
-3. Retrieve the chosen file:
+3. Retrieve chosen file:
    - `qmd-mcp-cli get file=workspace/public/mcp-is-not-the-problem/readme.md`
-4. Use `multi_get` for a short candidate set only:
+4. Batch retrieve (short candidate set only):
    - `qmd-mcp-cli multi_get pattern='workspace/public/*.md,workspace/research/*.md' maxBytes=20480`
-
-## Capability Map
-
-- Search:
-  - `query`
-- Retrieval:
-  - `get`
-  - `multi_get`
-- Health:
-  - `status`
 
 ## Guardrails
 
 - Keep automation on JSON output envelope; do not rely on `--text`.
 - Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
-- Use `qmd-mcp-cli` as the default command path.
 - `qmd-mcp-cli <operation> ...` is equivalent to `uxc "qmd mcp" <operation> ...` when `qmd` already runs correctly in the current shell.
 - If `qmd` requires shell initialization or GPU env exports, use the same wrapped shell command in the link and any direct `uxc "<host>" ...` fallback.
-- Prefer explicit typed `query` payloads over the standalone QMD CLI hybrid mode when latency matters.
-- Treat `lex` as the default fast path:
-  - exact names
-  - quoted phrases
-  - negation
-- Add `vec` when the question is semantic but still bounded.
-- Add `hyde` only for nuanced or sparse topics; it is the most expensive query type.
-- Use `intent` to disambiguate ambiguous search terms instead of over-expanding the query text itself.
+- Prefer `lex` as the default fast path (exact names, quoted phrases, negation). Add `vec` for semantic queries; add `hyde` only for nuanced/sparse topics (most expensive).
+- Use `intent` to disambiguate ambiguous search terms instead of over-expanding the query text.
 - Keep `limit` and `candidateLimit` modest for interactive use.
-- `--daemon-idle-ttl 0` is recommended for QMD because the first heavy request may warm models and sessions; long-lived reuse makes repeated calls much faster.
-
-## Notes
-
-- The first MCP request can still be slow while the `uxc` daemon creates the stdio session and QMD warms model state.
-- Repeated calls through the same `uxc` daemon session can drop sharply in latency once the session is warm.
-- This skill is best for local knowledge bases, notes, and markdown corpora already indexed by QMD.
-- If you need the highest-quality but slowest retrieval path, you can still express it through `query` with richer `searches` arrays instead of shelling out to the standalone QMD CLI hybrid mode.
+- `--daemon-idle-ttl 0` is recommended — the first request warms models; long-lived reuse makes repeated calls faster.
 
 ## References
 
-- Invocation patterns:
-  - `references/usage-patterns.md`
+- Invocation patterns and GPU wrapper examples: `references/usage-patterns.md`

--- a/skills/slack-openapi-skill/SKILL.md
+++ b/skills/slack-openapi-skill/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: slack-openapi-skill
-description: Operate Slack Web API through UXC with a curated OpenAPI schema, bearer-token auth, and messaging-core guardrails.
+description: "Send messages, read conversation history, and manage reactions in Slack through UXC with a curated OpenAPI schema and bearer-token auth. Use when the task involves Slack messaging, channel reads, or reaction workflows."
+user-invocable: true
+triggers:
+  - slack
+  - slack api
+  - send slack message
+  - conversation history
+  - slack reactions
 ---
 
 # Slack Web API Skill
@@ -15,75 +22,29 @@ Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
 - Network access to `https://slack.com/api`.
 - Access to the curated OpenAPI schema URL:
   - `https://raw.githubusercontent.com/holon-run/uxc/main/skills/slack-openapi-skill/references/slack-web.openapi.json`
-- A Slack bot token and, for selected thread/history reads, an optional user token.
+- A Slack bot token (`xoxb-...`); optional user token (`xoxp-...`) for user-identity reads.
 
 ## Scope
 
-This skill covers a Messaging Core surface:
+Messaging Core surface: auth validation, channel lookup, conversation history, thread replies, posting messages (including `thread_ts` replies), and adding reactions.
 
-- auth validation
-- channel lookup and inspection
-- conversation history reads
-- thread replies reads
-- posting messages, including replies via `thread_ts`
-- adding reactions
+Does **not** cover Slack OAuth app installation, file uploads, or `users.*`/`admin.*`/`usergroups.*` families.
 
-This skill does **not** cover:
+## Subscribe / Socket Mode
 
-- Slack OAuth app installation flow
-- file upload flows
-- `users.*`, `admin.*`, or `usergroups.*` method families
+`uxc` has a built-in Slack Socket Mode transport. Invoke with:
 
-## Subscribe / Socket Mode Status
+```bash
+uxc subscribe start https://slack.com/api --transport slack-socket-mode --auth slack-app --sink file:...
+```
 
-Slack inbound events can be delivered through Socket Mode. `uxc` now has a built-in Slack Socket Mode transport, but this skill still treats it as a limited event-ingest path rather than a fully packaged workflow surface.
-
-Current `uxc subscribe` status:
-
-- Slack Web API request/response calls are supported by this skill
-- a live Socket Mode smoke test succeeded with the built-in transport:
-  - `uxc subscribe start https://slack.com/api --transport slack-socket-mode --auth slack-app --sink file:...`
-  - the runtime opened a fresh temporary WebSocket URL automatically
-  - the initial Slack `hello` frame was received
-- a real inbound message event was validated end-to-end:
-  - while the Socket Mode job was running, a live Slack message event was delivered as an `events_api` envelope
-  - the sink recorded the message payload and `ack_sent=true`
-
-What the current built-in transport already handles:
-
-- app-level `xapp-...` auth via `--auth`
-- automatic `apps.connections.open` before each connect attempt
-- raw Socket Mode frame capture
-- automatic ack for envelopes that carry `envelope_id`
-
-What is still not packaged:
-
-- event-shape guidance per subscribed Slack event family
-- higher-level workflow packaging for common Slack event intake flows
-
-Slack Socket Mode is now a validated IM subscribe provider at the transport/runtime level.
+Socket Mode requires an app-level `xapp-...` token with `connections:write` scope. This skill covers Web API request/response calls; Socket Mode event intake is a validated transport but not yet fully workflow-packaged.
 
 ## Authentication
 
-Slack Web API uses `Authorization: Bearer <token>`.
+Slack Web API uses `Authorization: Bearer <token>`. Token types: `xoxb-...` (bot, recommended default), `xoxp-...` (user, explicit override), `xapp-...` (app-level, Socket Mode only).
 
-Token types used in practice:
-
-- `xoxb-...`: Bot User OAuth Token. This is the recommended default for this skill.
-- `xoxp-...`: User OAuth Token. Use this only when you explicitly want user-token semantics.
-- `xapp-...`: App-level token. Use this for Socket Mode subscribe, not for normal Web API methods.
-
-To create an app-level `xapp-...` token for Socket Mode:
-
-1. Open the target Slack app at `https://api.slack.com/apps`
-2. Go to `Basic Information`
-3. Find `App-Level Tokens`
-4. Generate a token with the `connections:write` scope
-5. Enable `Socket Mode` in the app configuration before relying on subscribe-based event intake
-
-### Option 1: Bot Token (Recommended Default)
-
-Use the Slack `Bot User OAuth Token` (`xoxb-...`) for the default binding and for most messaging operations:
+### Bot Token (Recommended Default)
 
 ```bash
 uxc auth credential set slack-bot \
@@ -99,9 +60,9 @@ uxc auth binding add \
   --priority 100
 ```
 
-### Option 2: User Token (Explicit Override For Selected Reads)
+### User Token (Explicit Override)
 
-Use a separate Slack `User OAuth Token` (`xoxp-...`) when the method requires user-token semantics, especially thread/history access outside bot-accessible conversations:
+Use `xoxp-...` when the method requires user-token semantics (thread/history reads outside bot-accessible conversations):
 
 ```bash
 uxc auth credential set slack-user \
@@ -109,14 +70,12 @@ uxc auth credential set slack-user \
   --secret-env SLACK_USER_TOKEN
 ```
 
-Do **not** bind `slack-user` by default to the same host/path. Invoke it explicitly when needed:
+Do **not** bind `slack-user` by default. Invoke explicitly:
 
 ```bash
 uxc auth binding match https://slack.com/api
 slack-openapi-cli --auth slack-user get:/conversations.replies channel=C1234567890 ts=1717171717.000100
 ```
-
-If you intentionally want writes to appear as the installing user rather than the bot, you can also invoke write methods with `--auth slack-user`, but treat that as an explicit override rather than the default path.
 
 ## Core Workflow
 
@@ -142,33 +101,14 @@ If you intentionally want writes to appear as the installing user rather than th
    - positional JSON:
      `slack-openapi-cli post:/chat.postMessage '{"channel":"C1234567890","text":"Hello from UXC"}'`
 
-## Operation Groups
-
-### Read / Lookup
-
-- `get:/auth.test`
-- `get:/conversations.list`
-- `get:/conversations.info`
-- `get:/conversations.history`
-- `get:/conversations.replies`
-
-### Messaging / Reactions
-
-- `post:/chat.postMessage`
-- `post:/reactions.add`
-
 ## Guardrails
 
 - Keep automation on the JSON output envelope; do not use `--text`.
 - Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
-- Bot token is the recommended default for send and basic read flows.
-- Bot token means Slack `Bot User OAuth Token` (`xoxb-...`); do not confuse it with `xapp-...` app-level tokens.
-- User token means Slack `User OAuth Token` (`xoxp-...`); use `--auth slack-user` when you intentionally need user identity or user-token-only reads.
-- `get:/conversations.replies` has token-type restrictions:
-  - bot token works for IM and MPIM threads the bot can access
-  - public/private channel thread reads should use `--auth slack-user`
-- `get:/conversations.history` only returns conversations visible to the supplied token; a bot token is limited to joined conversations.
-- Slack rate limits for `conversations.history` and `conversations.replies` vary by app distribution. Slack documents a tighter limit for newly created commercially distributed non-Marketplace apps starting on May 29, 2025; do not assume generic Tier 3 behavior.
+- Bot token (`xoxb-...`) is the recommended default. Use `--auth slack-user` (`xoxp-...`) only when user-identity or user-token-only reads are needed.
+- `get:/conversations.replies`: bot token works for IM/MPIM threads; use `--auth slack-user` for public/private channel threads.
+- `get:/conversations.history` only returns conversations visible to the token; bot token is limited to joined conversations.
+- Slack rate limits for `conversations.history` and `conversations.replies` vary by app distribution. Tighter limits apply to newly created commercially distributed non-Marketplace apps starting on May 29, 2025; do not assume generic Tier 3 behavior.
 - Treat `post:/chat.postMessage` and `post:/reactions.add` as write/high-risk operations; require explicit user confirmation before execution.
 - `slack-openapi-cli <operation> ...` is equivalent to `uxc https://slack.com/api --schema-url <slack_openapi_schema> <operation> ...`.
 


### PR DESCRIPTION
Hey @jolestar 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| slack-openapi-skill | 52% | 93% | +41% |
| qmd-mcp-skill | 53% | 93% | +40% |
| discord-openapi-skill | 56% | 88% | +32% |
| blockscout-openapi-skill | 57% | 99% | +42% |
| alchemy-openapi-skill | 61% | 99% | +38% |

This PR covers your 5 lowest-scoring skill(s) in the repo. I capped it at five to keep the review manageable — the included GitHub Action covers ongoing review for the rest on future PRs.

All five `validate.sh` scripts pass after changes — I checked before committing.

<details>
<summary>What changed in slack-openapi-skill</summary>

- **Description rewritten** with concrete action verbs, an explicit "Use when..." clause, and natural trigger terms
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance
- **Condensed Subscribe / Socket Mode section** from ~30 lines of changelog-style notes to 5 actionable lines
- **Trimmed auth token type explanations** and removed app-level token creation walkthrough
- **Removed verbose "does not cover" list** — replaced with single-line scope summary
- **Removed Operation Groups section** — operations already demonstrated in Core Workflow

</details>

<details>
<summary>What changed in qmd-mcp-skill</summary>

- **Description rewritten** with concrete action verbs, an explicit "Use when..." clause, and natural trigger terms
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance
- **Removed `metadata` block** (non-standard frontmatter)
- **Moved GPU/nvm shell wrapper** to a pointer to `references/usage-patterns.md` instead of inlining the full command
- **Removed Notes section** — folded key points into Guardrails
- **Removed Capability Map** — operations already covered in the workflow

</details>

<details>
<summary>What changed in discord-openapi-skill</summary>

- **Description rewritten** with concrete action verbs, an explicit "Use when..." clause, and natural trigger terms
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance
- **Condensed OAuth2 section** from ~80 lines to ~20 lines with essential commands only
- **Removed Authentication Methods Comparison table** — key constraint stated once in auth section and guardrails
- **Trimmed Subscribe/Gateway section** to essential invocation command and intent notes

</details>

<details>
<summary>What changed in blockscout-openapi-skill</summary>

- **Description rewritten** with concrete action verbs, an explicit "Use when..." clause, and natural trigger terms
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance
- **Condensed Authentication section** to single line (public instances need no auth)
- **Condensed scope** to single-line summary instead of two separate bullet lists
- **Removed Operation Groups section** — operations already demonstrated in Core Workflow
- **Trimmed guardrails** — removed verbose deployment path explanation

</details>

<details>
<summary>What changed in alchemy-openapi-skill</summary>

- **Description rewritten** with concrete action verbs, an explicit "Use when..." clause, and natural trigger terms
- **Added `user-invocable: true`** and **`triggers`** array for frontmatter compliance
- **Condensed scope** to single-line summary instead of two separate bullet lists
- **Removed Operations list** — the three endpoints already shown in Core Workflow
- **Trimmed guardrails** — consolidated redundant lines, kept all validator-required patterns
- **Fixed step 4 indentation** (was misaligned with leading space)

</details>

## Tessl Skill Review GitHub Action ✅

I've also included a GitHub Action (`.github/workflows/skill-review.yml`) that automatically reviews any `SKILL.md` changed in future PRs and posts scores as a PR comment.

**What this gives you:**
- 🔍 Automatic `tessl skill review` runs on every PR touching `SKILL.md`
- 💬 One updated PR comment with scores and improvement feedback
- 🔓 **Zero extra accounts** — contributors don't need a Tessl login; only `GITHUB_TOKEN` is used
- ✅ **Non-blocking by default** — feedback-only, no surprise red CI (add `fail-threshold: 70` later if you want a hard gate)
- 📈 Covers future skills incrementally as contributors edit them

This complements your existing `skills-ci.yml` validator pipeline — it adds quality scoring without replacing your build/validate flow.

## Want automatic AI optimization on every SKILL.md change? 🚀

The action I've added gives you **review scores** on PRs. We also have a more powerful variant — [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) — that can:

- Run **AI-powered optimization suggestions** on every `SKILL.md` PR (requires adding `TESSL_API_TOKEN` as a repo secret)
- Let contributors accept suggested improvements by commenting **`/apply-optimize`**
- Still works in review-only mode with zero secrets

Interested? Tick the box and I'll raise a follow-up PR:

- [ ] **Yes please!** Add the `tesslio/skill-review-and-optimize` action so every SKILL.md PR gets AI optimization suggestions + the `/apply-optimize` flow
- [ ] **No thanks** — the review scores action is enough for now

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@rohan-tessl](https://github.com/rohan-tessl) — if you hit any snags.

Thanks in advance 🙏
