### PR TITLE
perf(daemon): improve responsiveness baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,7 +1563,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1927,7 +1927,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1970,9 +1970,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1981,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2208,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2888,7 +2888,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -3028,7 +3028,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls",
  "rustls-pki-types",
  "sha1",

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -77,6 +77,7 @@ const DAEMON_OWNER_TERM_SIGNAL: i32 = 15;
 const STDIO_INIT_LOCK_STALE_SECS: u64 = 30;
 const MCP_IDLE_TTL_DEFAULT_SECS: u64 = 3600;
 const MCP_IDLE_TTL_ENV: &str = "UXC_DAEMON_MCP_IDLE_TTL_SECS";
+const MCP_IDLE_TTL_MAX_SECS: u64 = 24 * 60 * 60;
 const MCP_IDLE_CLEANUP_INTERVAL_MS: u64 = 500;
 // Five seconds is long enough for cooperative stdio servers to notice stdin EOF
 // and release external resources, while still bounding daemon-side eviction stalls.
@@ -878,7 +879,12 @@ fn default_mcp_idle_ttl_secs() -> u64 {
         .ok()
         .and_then(|value| value.trim().parse::<u64>().ok())
         .filter(|ttl| *ttl > 0)
+        .map(|ttl| ttl.min(MCP_IDLE_TTL_MAX_SECS))
         .unwrap_or(MCP_IDLE_TTL_DEFAULT_SECS)
+}
+
+fn instant_cutoff(now: Instant, age_secs: u64) -> Option<Instant> {
+    now.checked_sub(Duration::from_secs(age_secs))
 }
 
 fn resolve_stdio_request_metadata(
@@ -1372,7 +1378,8 @@ impl McpSessionManager {
 
     async fn cleanup_idle(&self) {
         let default_idle_ttl_secs = default_mcp_idle_ttl_secs();
-        let http_cutoff = Instant::now() - Duration::from_secs(default_idle_ttl_secs);
+        let now = Instant::now();
+        let http_cutoff = instant_cutoff(now, default_idle_ttl_secs);
         let stdio_entries: Vec<(String, Arc<Mutex<McpStdioSession>>)> = {
             let map = self.stdio.lock().await;
             map.iter().map(|(k, s)| (k.clone(), s.clone())).collect()
@@ -1387,9 +1394,9 @@ impl McpSessionManager {
                 if guard.idle_ttl_secs == 0 {
                     continue;
                 }
-                let now = Instant::now();
-                let cutoff = now - Duration::from_secs(guard.idle_ttl_secs);
-                if guard.last_used < cutoff {
+                let should_reap = instant_cutoff(Instant::now(), guard.idle_ttl_secs)
+                    .is_some_and(|cutoff| guard.last_used < cutoff);
+                if should_reap {
                     let lifecycle_allows_reap = match (
                         guard.lifecycle_contract_fetch_state,
                         guard
@@ -1444,29 +1451,34 @@ impl McpSessionManager {
             }
         }
 
-        let init_lock_cutoff = Instant::now() - Duration::from_secs(STDIO_INIT_LOCK_STALE_SECS);
-        let mut lock_map = self.stdio_init_locks.lock().await;
-        // Retain locks that are:
-        // 1. Still in use (strong_count > 1 means someone is holding the lock), or
-        // 2. Were touched recently (not stale)
-        // This avoids dropping an init lock during an ongoing initialization,
-        // which could otherwise allow a concurrent cold call to create a duplicate
-        // lock and spawn another MCP process, breaking the singleflight guarantee.
-        lock_map.retain(|_, v| Arc::strong_count(&v.lock) > 1 || v.touched_at >= init_lock_cutoff);
+        let now = Instant::now();
+        if let Some(init_lock_cutoff) = instant_cutoff(now, STDIO_INIT_LOCK_STALE_SECS) {
+            let mut lock_map = self.stdio_init_locks.lock().await;
+            // Retain locks that are:
+            // 1. Still in use (strong_count > 1 means someone is holding the lock), or
+            // 2. Were touched recently (not stale)
+            // This avoids dropping an init lock during an ongoing initialization,
+            // which could otherwise allow a concurrent cold call to create a duplicate
+            // lock and spawn another MCP process, breaking the singleflight guarantee.
+            lock_map
+                .retain(|_, v| Arc::strong_count(&v.lock) > 1 || v.touched_at >= init_lock_cutoff);
 
-        let mut exclusive_lock_map = self.stdio_exclusive_locks.lock().await;
-        exclusive_lock_map
-            .retain(|_, v| Arc::strong_count(&v.lock) > 1 || v.touched_at >= init_lock_cutoff);
+            let mut exclusive_lock_map = self.stdio_exclusive_locks.lock().await;
+            exclusive_lock_map
+                .retain(|_, v| Arc::strong_count(&v.lock) > 1 || v.touched_at >= init_lock_cutoff);
+        }
 
-        let http_entries: Vec<(String, Arc<McpHttpSession>)> = {
-            let map = self.http.lock().await;
-            map.iter().map(|(k, s)| (k.clone(), s.clone())).collect()
-        };
         let mut http_remove = Vec::new();
-        for (key, session) in &http_entries {
-            let last_used = *session.last_used.lock().await;
-            if last_used < http_cutoff {
-                http_remove.push(key.clone());
+        if let Some(http_cutoff) = http_cutoff {
+            let http_entries: Vec<(String, Arc<McpHttpSession>)> = {
+                let map = self.http.lock().await;
+                map.iter().map(|(k, s)| (k.clone(), s.clone())).collect()
+            };
+            for (key, session) in &http_entries {
+                let last_used = *session.last_used.lock().await;
+                if last_used < http_cutoff {
+                    http_remove.push(key.clone());
+                }
             }
         }
         if !http_remove.is_empty() {
@@ -8836,28 +8848,86 @@ mod tests {
         assert!(meta.artifact_path.is_none());
     }
 
+    fn with_mcp_idle_ttl_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+        let previous = std::env::var_os(MCP_IDLE_TTL_ENV);
+        match value {
+            Some(value) => std::env::set_var(MCP_IDLE_TTL_ENV, value),
+            None => std::env::remove_var(MCP_IDLE_TTL_ENV),
+        }
+
+        let result = f();
+
+        match previous {
+            Some(previous) => std::env::set_var(MCP_IDLE_TTL_ENV, previous),
+            None => std::env::remove_var(MCP_IDLE_TTL_ENV),
+        }
+        result
+    }
+
+    #[test]
+    fn default_mcp_idle_ttl_secs_uses_default_without_env() {
+        with_mcp_idle_ttl_env(None, || {
+            assert_eq!(default_mcp_idle_ttl_secs(), MCP_IDLE_TTL_DEFAULT_SECS);
+        });
+    }
+
+    #[test]
+    fn default_mcp_idle_ttl_secs_accepts_positive_env_override() {
+        with_mcp_idle_ttl_env(Some("7200"), || {
+            assert_eq!(default_mcp_idle_ttl_secs(), 7200);
+        });
+    }
+
+    #[test]
+    fn default_mcp_idle_ttl_secs_rejects_invalid_zero_and_clamps_extreme_env_overrides() {
+        with_mcp_idle_ttl_env(Some("not-a-number"), || {
+            assert_eq!(default_mcp_idle_ttl_secs(), MCP_IDLE_TTL_DEFAULT_SECS);
+        });
+        with_mcp_idle_ttl_env(Some("0"), || {
+            assert_eq!(default_mcp_idle_ttl_secs(), MCP_IDLE_TTL_DEFAULT_SECS);
+        });
+        with_mcp_idle_ttl_env(Some("-1"), || {
+            assert_eq!(default_mcp_idle_ttl_secs(), MCP_IDLE_TTL_DEFAULT_SECS);
+        });
+        with_mcp_idle_ttl_env(Some("9999999999999999999"), || {
+            assert_eq!(default_mcp_idle_ttl_secs(), MCP_IDLE_TTL_MAX_SECS);
+        });
+    }
+
+    #[test]
+    fn instant_cutoff_returns_none_for_unrepresentable_age() {
+        let now = Instant::now();
+
+        assert!(instant_cutoff(now, 0).is_some());
+        assert!(instant_cutoff(now, u64::MAX).is_none());
+    }
+
     #[test]
     fn resolve_stdio_request_metadata_resets_ttl_and_link_name_from_current_request() {
-        let resolved = resolve_stdio_request_metadata(
-            &StdioSessionRequestMetadata {
-                idle_ttl_secs: None,
-                link_name: None,
-                link_skill: None,
-                link_skill_doc: None,
-                link_skill_path: None,
-                endpoint: "https://new.example.com",
-                exclusive_keys: &[],
-            },
-            &["/tmp/profile".to_string()],
-        );
+        with_mcp_idle_ttl_env(None, || {
+            let resolved = resolve_stdio_request_metadata(
+                &StdioSessionRequestMetadata {
+                    idle_ttl_secs: None,
+                    link_name: None,
+                    link_skill: None,
+                    link_skill_doc: None,
+                    link_skill_path: None,
+                    endpoint: "https://new.example.com",
+                    exclusive_keys: &[],
+                },
+                &["/tmp/profile".to_string()],
+            );
 
-        assert_eq!(resolved.idle_ttl_secs, default_mcp_idle_ttl_secs());
-        assert_eq!(resolved.link_name, None);
-        assert_eq!(resolved.link_skill, None);
-        assert_eq!(resolved.link_skill_doc, None);
-        assert_eq!(resolved.link_skill_path, None);
-        assert_eq!(resolved.endpoint, "https://new.example.com");
-        assert_eq!(resolved.daemon_exclusive, vec!["/tmp/profile".to_string()]);
+            assert_eq!(resolved.idle_ttl_secs, default_mcp_idle_ttl_secs());
+            assert_eq!(resolved.link_name, None);
+            assert_eq!(resolved.link_skill, None);
+            assert_eq!(resolved.link_skill_doc, None);
+            assert_eq!(resolved.link_skill_path, None);
+            assert_eq!(resolved.endpoint, "https://new.example.com");
+            assert_eq!(resolved.daemon_exclusive, vec!["/tmp/profile".to_string()]);
+        });
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -75,7 +75,8 @@ const STOP_POLL_INTERVAL_MS: u64 = 100;
 const START_LOCK_STALE_SECS: u64 = 30;
 const DAEMON_OWNER_TERM_SIGNAL: i32 = 15;
 const STDIO_INIT_LOCK_STALE_SECS: u64 = 30;
-const MCP_IDLE_TTL_SECS: u64 = 600;
+const MCP_IDLE_TTL_DEFAULT_SECS: u64 = 3600;
+const MCP_IDLE_TTL_ENV: &str = "UXC_DAEMON_MCP_IDLE_TTL_SECS";
 const MCP_IDLE_CLEANUP_INTERVAL_MS: u64 = 500;
 // Five seconds is long enough for cooperative stdio servers to notice stdin EOF
 // and release external resources, while still bounding daemon-side eviction stalls.
@@ -130,6 +131,8 @@ pub struct RuntimeInvokeRequest {
     pub action: RuntimeAction,
     pub operation_id: Option<String>,
     pub args: Option<HashMap<String, Value>>,
+    #[serde(default)]
+    pub suppress_routine_logs: bool,
     pub options: RuntimeInvokeOptions,
 }
 
@@ -870,6 +873,14 @@ struct ResolvedStdioRequestMetadata {
     daemon_exclusive: Vec<String>,
 }
 
+fn default_mcp_idle_ttl_secs() -> u64 {
+    std::env::var(MCP_IDLE_TTL_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|ttl| *ttl > 0)
+        .unwrap_or(MCP_IDLE_TTL_DEFAULT_SECS)
+}
+
 fn resolve_stdio_request_metadata(
     metadata: &StdioSessionRequestMetadata<'_>,
     existing_exclusive_keys: &[String],
@@ -880,7 +891,9 @@ fn resolve_stdio_request_metadata(
         metadata.exclusive_keys.to_vec()
     };
     ResolvedStdioRequestMetadata {
-        idle_ttl_secs: metadata.idle_ttl_secs.unwrap_or(MCP_IDLE_TTL_SECS),
+        idle_ttl_secs: metadata
+            .idle_ttl_secs
+            .unwrap_or_else(default_mcp_idle_ttl_secs),
         link_name: metadata.link_name.map(str::to_string),
         link_skill: metadata.link_skill.map(str::to_string),
         link_skill_doc: metadata.link_skill_doc.map(str::to_string),
@@ -1358,7 +1371,8 @@ impl McpSessionManager {
     }
 
     async fn cleanup_idle(&self) {
-        let http_cutoff = Instant::now() - Duration::from_secs(MCP_IDLE_TTL_SECS);
+        let default_idle_ttl_secs = default_mcp_idle_ttl_secs();
+        let http_cutoff = Instant::now() - Duration::from_secs(default_idle_ttl_secs);
         let stdio_entries: Vec<(String, Arc<Mutex<McpStdioSession>>)> = {
             let map = self.stdio.lock().await;
             map.iter().map(|(k, s)| (k.clone(), s.clone())).collect()
@@ -1604,7 +1618,9 @@ impl McpSessionManager {
             resource_subscriptions: HashMap::new(),
             last_used: Instant::now(),
             last_used_at_unix: created_at_unix,
-            idle_ttl_secs: metadata.idle_ttl_secs.unwrap_or(MCP_IDLE_TTL_SECS),
+            idle_ttl_secs: metadata
+                .idle_ttl_secs
+                .unwrap_or_else(default_mcp_idle_ttl_secs),
             link_name: metadata.link_name.map(str::to_string),
             link_skill: metadata.link_skill.map(str::to_string),
             link_skill_doc: metadata.link_skill_doc.map(str::to_string),
@@ -1634,7 +1650,9 @@ impl McpSessionManager {
                 child_pid,
                 started_at_unix: created_at_unix,
                 last_used_at_unix: created_at_unix,
-                idle_ttl_secs: metadata.idle_ttl_secs.unwrap_or(MCP_IDLE_TTL_SECS),
+                idle_ttl_secs: metadata
+                    .idle_ttl_secs
+                    .unwrap_or_else(default_mcp_idle_ttl_secs),
                 daemon_exclusive: exclusive_keys.clone(),
                 in_flight_requests: 0,
                 reuse_eligible: true,
@@ -3649,6 +3667,14 @@ impl DaemonRuntime {
         }
     }
 
+    async fn flush_logs(&self) {
+        if let Some(ref logger) = self.logger {
+            if let Err(e) = logger.flush().await {
+                tracing::debug!("Failed to flush daemon log: {}", e);
+            }
+        }
+    }
+
     pub async fn invoke(&self, request: RuntimeInvokeRequest) -> Result<RuntimeInvokeResponse> {
         if request
             .options
@@ -3672,15 +3698,18 @@ impl DaemonRuntime {
         }
 
         let start = Instant::now();
+        let log_routine_events = !request.suppress_routine_logs;
 
         // Log runtime invoke start
-        self.log(
-            DaemonLogEntry::new(DaemonEventType::RuntimeInvokeStart)
-                .with_request_id(request.request_id.clone())
-                .with_endpoint(request.endpoint.clone())
-                .with_operation_id(request.operation_id.clone().unwrap_or_default()),
-        )
-        .await;
+        if log_routine_events {
+            self.log(
+                DaemonLogEntry::new(DaemonEventType::RuntimeInvokeStart)
+                    .with_request_id(request.request_id.clone())
+                    .with_endpoint(request.endpoint.clone())
+                    .with_operation_id(request.operation_id.clone().unwrap_or_default()),
+            )
+            .await;
+        }
 
         let cache = self.build_cache(&request.options)?;
         let cache_for_fallback = cache.clone();
@@ -3715,7 +3744,7 @@ impl DaemonRuntime {
             .await?
         {
             let duration_ms = start.elapsed().as_millis() as u64;
-            if reused {
+            if reused && log_routine_events {
                 self.log(
                     DaemonLogEntry::new(DaemonEventType::DaemonSessionReused)
                         .with_request_id(request.request_id.clone())
@@ -3723,15 +3752,17 @@ impl DaemonRuntime {
                 )
                 .await;
             }
-            self.log(
-                DaemonLogEntry::new(DaemonEventType::RuntimeInvokeSuccess)
-                    .with_request_id(request.request_id.clone())
-                    .with_endpoint(request.endpoint.clone())
-                    .with_operation_id(request.operation_id.clone().unwrap_or_default())
-                    .with_protocol("mcp".to_string())
-                    .with_duration_ms(duration_ms),
-            )
-            .await;
+            if log_routine_events {
+                self.log(
+                    DaemonLogEntry::new(DaemonEventType::RuntimeInvokeSuccess)
+                        .with_request_id(request.request_id.clone())
+                        .with_endpoint(request.endpoint.clone())
+                        .with_operation_id(request.operation_id.clone().unwrap_or_default())
+                        .with_protocol("mcp".to_string())
+                        .with_duration_ms(duration_ms),
+                )
+                .await;
+            }
             let mut response_meta = RuntimeMeta {
                 schema_involved: Some(true),
                 daemon_session_reused: Some(reused),
@@ -3828,7 +3859,7 @@ impl DaemonRuntime {
                         .with_protocol(protocol.clone()),
                 )
                 .await;
-            } else {
+            } else if log_routine_events {
                 self.log(
                     DaemonLogEntry::new(DaemonEventType::CacheHit)
                         .with_request_id(request.request_id.clone())
@@ -3865,7 +3896,7 @@ impl DaemonRuntime {
                 .await?;
             meta.daemon_session_reused = Some(reused);
 
-            if reused {
+            if reused && log_routine_events {
                 self.log(
                     DaemonLogEntry::new(DaemonEventType::DaemonSessionReused)
                         .with_request_id(request.request_id.clone())
@@ -3983,15 +4014,17 @@ impl DaemonRuntime {
                     &mut meta,
                     request.options.artifact_compaction.unwrap_or(true),
                 )?;
-                self.log(
-                    DaemonLogEntry::new(DaemonEventType::RuntimeInvokeSuccess)
-                        .with_request_id(request.request_id.clone())
-                        .with_endpoint(request.endpoint.clone())
-                        .with_operation_id(request.operation_id.clone().unwrap_or_default())
-                        .with_protocol(protocol.clone())
-                        .with_duration_ms(duration_ms),
-                )
-                .await;
+                if log_routine_events {
+                    self.log(
+                        DaemonLogEntry::new(DaemonEventType::RuntimeInvokeSuccess)
+                            .with_request_id(request.request_id.clone())
+                            .with_endpoint(request.endpoint.clone())
+                            .with_operation_id(request.operation_id.clone().unwrap_or_default())
+                            .with_protocol(protocol.clone())
+                            .with_duration_ms(duration_ms),
+                    )
+                    .await;
+                }
 
                 Ok(RuntimeInvokeResponse {
                     protocol,
@@ -5901,6 +5934,7 @@ async fn fetch_managed_source_poll(
             action: RuntimeAction::Execute,
             operation_id: request.operation_id.clone(),
             args: Some(args),
+            suppress_routine_logs: true,
             options,
         })
         .await?;
@@ -6637,6 +6671,7 @@ pub async fn run_daemon_server() -> Result<()> {
     runtime
         .log(DaemonLogEntry::new(DaemonEventType::DaemonStop))
         .await;
+    runtime.flush_logs().await;
 
     owner_lock.clear_metadata();
     let _ = fs::remove_file(&socket);
@@ -8661,6 +8696,7 @@ mod tests {
             action: RuntimeAction::Execute,
             operation_id: Some("get:/api/v3/account".to_string()),
             args: None,
+            suppress_routine_logs: false,
             options: RuntimeInvokeOptions {
                 auth: None,
                 inject_env: Vec::new(),
@@ -8815,7 +8851,7 @@ mod tests {
             &["/tmp/profile".to_string()],
         );
 
-        assert_eq!(resolved.idle_ttl_secs, MCP_IDLE_TTL_SECS);
+        assert_eq!(resolved.idle_ttl_secs, default_mcp_idle_ttl_secs());
         assert_eq!(resolved.link_name, None);
         assert_eq!(resolved.link_skill, None);
         assert_eq!(resolved.link_skill_doc, None);
@@ -8865,6 +8901,7 @@ mod tests {
             action: RuntimeAction::OperationHelp,
             operation_id: Some("post:/api/v3/order".to_string()),
             args: None,
+            suppress_routine_logs: false,
             options: RuntimeInvokeOptions {
                 auth: None,
                 inject_env: Vec::new(),
@@ -8919,6 +8956,7 @@ mod tests {
             action: RuntimeAction::Execute,
             operation_id: Some("post:/pet".to_string()),
             args: None,
+            suppress_routine_logs: false,
             options: RuntimeInvokeOptions {
                 auth: None,
                 inject_env: Vec::new(),
@@ -8954,6 +8992,7 @@ mod tests {
             action: RuntimeAction::Execute,
             operation_id: Some("get:/health".to_string()),
             args: None,
+            suppress_routine_logs: false,
             options: RuntimeInvokeOptions {
                 auth: None,
                 inject_env: Vec::new(),

--- a/src/daemon_client.rs
+++ b/src/daemon_client.rs
@@ -99,6 +99,7 @@ impl DaemonClient {
             action: RuntimeAction::Execute,
             operation_id: Some(operation.into()),
             args: payload,
+            suppress_routine_logs: false,
             options: options.into(),
         };
         daemon::runtime_invoke_client(&request).await

--- a/src/daemon_log.rs
+++ b/src/daemon_log.rs
@@ -16,10 +16,13 @@ use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
+use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 const DEFAULT_MAX_LOG_BYTES: u64 = 10 * 1024 * 1024; // 10 MiB
 const DEFAULT_LOG_BACKUPS: usize = 3;
+const LOG_FLUSH_BYTES: usize = 64 * 1024;
+const LOG_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Daemon log event types for troubleshooting
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -163,6 +166,8 @@ pub struct DaemonLogger {
 
 struct LoggerInner {
     file: Option<File>,
+    pending_bytes: usize,
+    last_flush: Instant,
 }
 
 impl DaemonLogger {
@@ -188,7 +193,11 @@ impl DaemonLogger {
             log_file,
             max_bytes,
             backups,
-            inner: Arc::new(Mutex::new(LoggerInner { file: Some(file) })),
+            inner: Arc::new(Mutex::new(LoggerInner {
+                file: Some(file),
+                pending_bytes: 0,
+                last_flush: Instant::now(),
+            })),
         })
     }
 
@@ -203,18 +212,30 @@ impl DaemonLogger {
 
         if let Some(file) = &mut inner.file {
             writeln!(file, "{}", line).context("Failed to write log entry")?;
-            file.flush().context("Failed to flush log entry")?;
+            inner.pending_bytes = inner.pending_bytes.saturating_add(line.len() + 1);
+        }
+        if inner.pending_bytes >= LOG_FLUSH_BYTES
+            || inner.last_flush.elapsed() >= LOG_FLUSH_INTERVAL
+        {
+            flush_locked(&mut inner)?;
         }
 
         // Keep write + rotate in one critical section to avoid races and stale fds.
         // Close the active fd before rotate so Windows rename can succeed.
         if should_rotate(&self.log_file, self.max_bytes)? {
+            flush_locked(&mut inner)?;
             inner.file.take();
             rotate_log_if_needed(&self.log_file, self.backups)?;
             inner.file = Some(open_log_file(&self.log_file)?);
         }
 
         Ok(())
+    }
+
+    /// Flush any buffered log entries to disk.
+    pub async fn flush(&self) -> Result<()> {
+        let mut inner = self.inner.lock().await;
+        flush_locked(&mut inner)
     }
 
     /// Get the log file path
@@ -227,6 +248,18 @@ impl DaemonLogger {
     pub fn is_enabled(&self) -> bool {
         true // Logging is always enabled when logger is created
     }
+}
+
+fn flush_locked(inner: &mut LoggerInner) -> Result<()> {
+    if inner.pending_bytes == 0 {
+        return Ok(());
+    }
+    if let Some(file) = &mut inner.file {
+        file.flush().context("Failed to flush log entries")?;
+    }
+    inner.pending_bytes = 0;
+    inner.last_flush = Instant::now();
+    Ok(())
 }
 
 /// Rotate log file
@@ -503,5 +536,20 @@ mod tests {
         assert_eq!(parsed["type"], "runtime_invoke_start");
         assert_eq!(parsed["request_id"], "req-123");
         assert!(parsed["endpoint"].as_str().unwrap().contains("***"));
+    }
+
+    #[tokio::test]
+    async fn test_logger_flush_writes_buffered_entries() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let logger = DaemonLogger::new(temp_dir.path()).unwrap();
+
+        logger
+            .log(&DaemonLogEntry::new(DaemonEventType::DaemonStart))
+            .await
+            .unwrap();
+        logger.flush().await.unwrap();
+
+        let contents = std::fs::read_to_string(logger.log_file_path()).unwrap();
+        assert!(contents.contains("\"type\":\"daemon_start\""));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1904,6 +1904,7 @@ async fn execute_endpoint_via_daemon(
         action,
         operation_id,
         args: args_map,
+        suppress_routine_logs: false,
         options: daemon::RuntimeInvokeOptions {
             auth: cli.auth.clone(),
             inject_env: collect_inject_env_specs(cli)?,


### PR DESCRIPTION
## What
- Increase daemon MCP default idle TTL and allow overriding it via UXC_DAEMON_MCP_IDLE_TTL_SECS.
- Suppress routine runtime/cache/session log entries for managed source polling while preserving anomalies.
- Batch daemon log flushing and flush on rotation/shutdown.

## Why
Managed source polling and per-entry log flushing introduced avoidable daemon churn; short default MCP session TTL also reduced reuse for normal workflows.

## Testing
- cargo fmt
- cargo check
- cargo clippy -- -D warnings
- cargo test --lib test_logger_flush_writes_buffered_entries
- cargo test --lib resolve_stdio_request_metadata_resets_ttl_and_link_name_from_current_request
- cargo test