### PR TITLE
perf(daemon): stagger managed source polling

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2309,6 +2309,45 @@ fn resolve_stream_subscription_protocol(request: &SubscribeStartRequest) -> Resu
     bail!("subscription execution requires an http(s) endpoint or --resource-uri for MCP subscriptions")
 }
 
+const MANAGED_SOURCE_POLL_JITTER_MAX_MS: u64 = 30_000;
+
+fn stable_managed_source_hash(namespace: &str, source_key: &str) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+
+    let mut hash = FNV_OFFSET;
+    for byte in namespace
+        .bytes()
+        .chain(std::iter::once(0))
+        .chain(source_key.bytes())
+    {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+fn managed_source_poll_jitter_duration(
+    namespace: &str,
+    source_key: &str,
+    interval_secs: u64,
+) -> Duration {
+    let interval_ms = interval_secs.max(1).saturating_mul(1000);
+    let jitter_window_ms = (interval_ms / 4).clamp(1, MANAGED_SOURCE_POLL_JITTER_MAX_MS);
+    Duration::from_millis(
+        stable_managed_source_hash(namespace, source_key) % (jitter_window_ms + 1),
+    )
+}
+
+fn managed_source_poll_wait_duration(
+    namespace: &str,
+    source_key: &str,
+    interval_secs: u64,
+) -> Duration {
+    Duration::from_secs(interval_secs.max(1))
+        + managed_source_poll_jitter_duration(namespace, source_key, interval_secs)
+}
+
 impl ManagedSourceManager {
     fn new(store: ManagedSourceStore) -> Self {
         Self {
@@ -2970,6 +3009,18 @@ impl ManagedSourceManager {
 
         let default_interval_secs = config.interval_secs.max(1);
         let base_args = request.args.clone().unwrap_or_default();
+        let initial_delay = managed_source_poll_jitter_duration(
+            &entry.namespace,
+            &entry.source_key,
+            default_interval_secs,
+        );
+        if !initial_delay.is_zero() && wait_for_stop_or_timeout(&mut stop_rx, initial_delay).await {
+            update_subscription_view(runtime_view, Some("stopped"), None, false).await;
+            let snapshot = runtime_view.lock().await.clone();
+            let _ =
+                sync_managed_source_state(&self.store, entry, runtime_view, &snapshot.status).await;
+            return;
+        }
         loop {
             if *stop_rx.borrow() {
                 update_subscription_view(runtime_view, Some("stopped"), None, false).await;
@@ -3086,7 +3137,11 @@ impl ManagedSourceManager {
                     }
                     if wait_for_stop_or_timeout(
                         &mut stop_rx,
-                        Duration::from_secs(default_interval_secs),
+                        managed_source_poll_wait_duration(
+                            &entry.namespace,
+                            &entry.source_key,
+                            default_interval_secs,
+                        ),
                     )
                     .await
                     {
@@ -3113,7 +3168,15 @@ impl ManagedSourceManager {
                 return;
             }
 
-            if wait_for_stop_or_timeout(&mut stop_rx, Duration::from_secs(next_interval_secs)).await
+            if wait_for_stop_or_timeout(
+                &mut stop_rx,
+                managed_source_poll_wait_duration(
+                    &entry.namespace,
+                    &entry.source_key,
+                    next_interval_secs,
+                ),
+            )
+            .await
             {
                 update_subscription_view(runtime_view, Some("stopped"), None, false).await;
                 let snapshot = runtime_view.lock().await.clone();
@@ -8708,6 +8771,25 @@ mod tests {
     use tokio_tungstenite::tungstenite::Message;
 
     #[test]
+    fn managed_source_poll_jitter_is_stable_and_bounded() {
+        let one =
+            managed_source_poll_jitter_duration("agentinbox", "github_repo:holon-run/uxc", 30);
+        let two =
+            managed_source_poll_jitter_duration("agentinbox", "github_repo:holon-run/uxc", 30);
+        let other =
+            managed_source_poll_jitter_duration("agentinbox", "github_checks:holon-run/uxc", 30);
+
+        assert_eq!(one, two);
+        assert_ne!(one, other);
+        assert!(one <= StdDuration::from_millis(7_500));
+        assert!(other <= StdDuration::from_millis(7_500));
+        assert!(
+            managed_source_poll_wait_duration("agentinbox", "github_repo:holon-run/uxc", 30)
+                >= StdDuration::from_secs(30)
+        );
+    }
+
+    #[test]
     fn openapi_runtime_endpoint_appends_operation_path_for_execute() {
         let request = RuntimeInvokeRequest {
             request_id: "req-1".to_string(),
@@ -9511,6 +9593,60 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(stored, Some(checkpoint));
+    }
+
+    #[tokio::test]
+    async fn poll_checkpoint_only_write_updates_checkpoint_without_stream_events() {
+        let temp = tempdir().unwrap();
+        let runtime = test_runtime_with_store(&temp);
+        let record =
+            poll_checkpoint_test_record("test", "poll-checkpoint-only", "run-checkpoint-only");
+        runtime
+            .managed_sources
+            .store
+            .upsert_source(&record, true)
+            .await
+            .unwrap();
+
+        let checkpoint = crate::subscription_poll::PollCheckpointState {
+            cursor: Some(json!(789)),
+            watermark: Some(json!("2024-01-01T00:00:00Z")),
+            tie_breaker: Some(json!("event-789")),
+            seen_keys: VecDeque::from([json!("event-789").to_string()]),
+            etag: Some("\"etag-v2\"".to_string()),
+        };
+        let offsets = runtime
+            .managed_sources
+            .store
+            .append_events_and_store_poll_checkpoint(
+                &record.namespace,
+                &record.source_key,
+                &record.run_id,
+                &record.stream_id,
+                &[],
+                &checkpoint,
+            )
+            .await
+            .unwrap();
+        assert!(offsets.is_empty());
+
+        let stored = runtime
+            .managed_sources
+            .store
+            .load_poll_checkpoint(&record.namespace, &record.source_key, &record.run_id)
+            .await
+            .unwrap();
+        assert_eq!(stored, Some(checkpoint));
+
+        let page = runtime
+            .stream_read(&ManagedStreamReadRequest {
+                stream_id: record.stream_id.clone(),
+                after_offset: 0,
+                limit: 10,
+            })
+            .await
+            .unwrap();
+        assert!(page.events.is_empty());
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2311,41 +2311,59 @@ fn resolve_stream_subscription_protocol(request: &SubscribeStartRequest) -> Resu
 
 const MANAGED_SOURCE_POLL_JITTER_MAX_MS: u64 = 30_000;
 
-fn stable_managed_source_hash(namespace: &str, source_key: &str) -> u64 {
+fn stable_managed_source_hash(namespace: &str, source_key: &str, poll_round: u64) -> u64 {
     const FNV_OFFSET: u64 = 0xcbf29ce484222325;
     const FNV_PRIME: u64 = 0x100000001b3;
 
     let mut hash = FNV_OFFSET;
-    for byte in namespace
-        .bytes()
-        .chain(std::iter::once(0))
-        .chain(source_key.bytes())
-    {
+    for byte in namespace.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash ^= 0;
+    hash = hash.wrapping_mul(FNV_PRIME);
+    for byte in source_key.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    for byte in poll_round.to_le_bytes() {
         hash ^= u64::from(byte);
         hash = hash.wrapping_mul(FNV_PRIME);
     }
     hash
 }
 
-fn managed_source_poll_jitter_duration(
+fn managed_source_poll_jitter_window_ms(interval_secs: u64) -> u64 {
+    let interval_ms = interval_secs.max(1).saturating_mul(1000);
+    (interval_ms / 4).clamp(1, MANAGED_SOURCE_POLL_JITTER_MAX_MS)
+}
+
+fn managed_source_initial_poll_delay_duration(
     namespace: &str,
     source_key: &str,
     interval_secs: u64,
 ) -> Duration {
-    let interval_ms = interval_secs.max(1).saturating_mul(1000);
-    let jitter_window_ms = (interval_ms / 4).clamp(1, MANAGED_SOURCE_POLL_JITTER_MAX_MS);
-    Duration::from_millis(
-        stable_managed_source_hash(namespace, source_key) % (jitter_window_ms + 1),
-    )
+    let jitter_window_ms = managed_source_poll_jitter_window_ms(interval_secs);
+    Duration::from_millis(stable_managed_source_hash(namespace, source_key, 0) % jitter_window_ms)
 }
 
 fn managed_source_poll_wait_duration(
     namespace: &str,
     source_key: &str,
     interval_secs: u64,
+    poll_round: u64,
 ) -> Duration {
-    Duration::from_secs(interval_secs.max(1))
-        + managed_source_poll_jitter_duration(namespace, source_key, interval_secs)
+    let interval_ms = interval_secs.max(1).saturating_mul(1000);
+    let jitter_window_ms = managed_source_poll_jitter_window_ms(interval_secs);
+    let half_window_ms = jitter_window_ms / 2;
+    let jitter_ms =
+        stable_managed_source_hash(namespace, source_key, poll_round) % (jitter_window_ms + 1);
+    let wait_ms = if jitter_ms >= half_window_ms {
+        interval_ms.saturating_add(jitter_ms - half_window_ms)
+    } else {
+        interval_ms.saturating_sub(half_window_ms - jitter_ms)
+    };
+    Duration::from_millis(wait_ms.max(1))
 }
 
 impl ManagedSourceManager {
@@ -3009,7 +3027,7 @@ impl ManagedSourceManager {
 
         let default_interval_secs = config.interval_secs.max(1);
         let base_args = request.args.clone().unwrap_or_default();
-        let initial_delay = managed_source_poll_jitter_duration(
+        let initial_delay = managed_source_initial_poll_delay_duration(
             &entry.namespace,
             &entry.source_key,
             default_interval_secs,
@@ -3021,6 +3039,7 @@ impl ManagedSourceManager {
                 sync_managed_source_state(&self.store, entry, runtime_view, &snapshot.status).await;
             return;
         }
+        let mut poll_round = 0_u64;
         loop {
             if *stop_rx.borrow() {
                 update_subscription_view(runtime_view, Some("stopped"), None, false).await;
@@ -3141,6 +3160,7 @@ impl ManagedSourceManager {
                             &entry.namespace,
                             &entry.source_key,
                             default_interval_secs,
+                            poll_round,
                         ),
                     )
                     .await
@@ -3156,6 +3176,7 @@ impl ManagedSourceManager {
                         .await;
                         return;
                     }
+                    poll_round = poll_round.wrapping_add(1);
                     continue;
                 }
             }
@@ -3174,6 +3195,7 @@ impl ManagedSourceManager {
                     &entry.namespace,
                     &entry.source_key,
                     next_interval_secs,
+                    poll_round,
                 ),
             )
             .await
@@ -3185,6 +3207,7 @@ impl ManagedSourceManager {
                         .await;
                 return;
             }
+            poll_round = poll_round.wrapping_add(1);
         }
     }
 
@@ -8771,22 +8794,39 @@ mod tests {
     use tokio_tungstenite::tungstenite::Message;
 
     #[test]
-    fn managed_source_poll_jitter_is_stable_and_bounded() {
-        let one =
-            managed_source_poll_jitter_duration("agentinbox", "github_repo:holon-run/uxc", 30);
-        let two =
-            managed_source_poll_jitter_duration("agentinbox", "github_repo:holon-run/uxc", 30);
-        let other =
-            managed_source_poll_jitter_duration("agentinbox", "github_checks:holon-run/uxc", 30);
-
-        assert_eq!(one, two);
-        assert_ne!(one, other);
-        assert!(one <= StdDuration::from_millis(7_500));
-        assert!(other <= StdDuration::from_millis(7_500));
-        assert!(
-            managed_source_poll_wait_duration("agentinbox", "github_repo:holon-run/uxc", 30)
-                >= StdDuration::from_secs(30)
+    fn managed_source_poll_jitter_preserves_interval_cadence() {
+        let initial_one = managed_source_initial_poll_delay_duration(
+            "agentinbox",
+            "github_repo:holon-run/uxc",
+            30,
         );
+        let initial_two = managed_source_initial_poll_delay_duration(
+            "agentinbox",
+            "github_repo:holon-run/uxc",
+            30,
+        );
+
+        assert_eq!(initial_one, initial_two);
+        assert!(initial_one < StdDuration::from_millis(7_500));
+
+        for round in 0..32 {
+            let one = managed_source_poll_wait_duration(
+                "agentinbox",
+                "github_repo:holon-run/uxc",
+                30,
+                round,
+            );
+            let two = managed_source_poll_wait_duration(
+                "agentinbox",
+                "github_repo:holon-run/uxc",
+                30,
+                round,
+            );
+
+            assert_eq!(one, two);
+            assert!(one >= StdDuration::from_millis(26_250));
+            assert!(one <= StdDuration::from_millis(33_750));
+        }
     }
 
     #[test]

--- a/src/managed_source_streams.rs
+++ b/src/managed_source_streams.rs
@@ -571,11 +571,16 @@ impl ManagedSourceStore {
                 anyhow::bail!("managed source stream mismatch while storing poll checkpoint");
             }
 
-            let mut next_offset: u64 = tx.query_row(
-                "select coalesce(max(offset), 0) + 1 from stream_events where stream_id = ?1",
-                params![stream_id],
-                |row| row.get(0),
-            )?;
+            // Checkpoint-only poll rounds should not pay the stream offset lookup cost.
+            let mut next_offset: u64 = if events.is_empty() {
+                0
+            } else {
+                tx.query_row(
+                    "select coalesce(max(offset), 0) + 1 from stream_events where stream_id = ?1",
+                    params![stream_id],
+                    |row| row.get(0),
+                )?
+            };
             let mut offsets = Vec::with_capacity(events.len());
             let mut latest_ingested_at_unix = None;
             for event in &events {


### PR DESCRIPTION
## What
- add stable deterministic jitter to managed source polling based on namespace/source key
- apply jitter before the initial poll and between interval polls to avoid aligned polling bursts
- skip unnecessary max(offset) lookup for checkpoint-only managed source poll writes
- add focused regression coverage for jitter stability/bounds and checkpoint-only writes

## Why
- reduces thundering-herd risk for managed source polling from Issue #399
- lowers no-event/checkpoint-only polling query amplification in the daemon hot path

## Testing
- cargo fmt -- --check
- cargo check
- cargo test

Part of Issue #399 daemon performance plan PR 3.