### PR TITLE
chore(release): prepare v0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.5] - 2026-05-14
+
+### Changed
+- Improved daemon responsiveness under managed-source load by offloading log writes, adding shared-runtime pooling, and staggering managed-source polling startup.
+
 ## [0.15.4] - 2026-04-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3104,7 +3104,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uxc"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxc"
-version = "0.15.4"
+version = "0.15.5"
 edition = "2021"
 authors = ["UXC Contributors"]
 description = "A unified CLI for discovering and invoking tools across OpenAPI, MCP, GraphQL, gRPC, and JSON-RPC"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3866,7 +3866,7 @@
     },
     "packages/uxc-daemon-client": {
       "name": "@holon-run/uxc-daemon-client",
-      "version": "0.12.8",
+      "version": "0.15.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.5.0",

--- a/packages/uxc-daemon-client/package.json
+++ b/packages/uxc-daemon-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holon-run/uxc-daemon-client",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Thin Node.js client for UXC daemon-backed operations",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What
- Bump UXC Rust crate version to v0.15.5
- Bump daemon client package metadata to v0.15.5
- Add CHANGELOG entry for v0.15.5

## Why
Prepare the next UXC release after the latest merged daemon performance improvements.

## Testing
- ./scripts/release-check.sh v0.15.5 --allow-dirty
