### PR TITLE
fix: handle hyphenated oauth session ids

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Detect changed files
         id: filter
@@ -82,10 +82,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -104,10 +104,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -137,7 +137,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -170,7 +170,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -198,7 +198,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -211,7 +211,7 @@ jobs:
       - name: Install grpcurl
         run: |
           go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.1
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
@@ -240,7 +240,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -264,7 +264,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -295,7 +295,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -311,7 +311,7 @@ jobs:
         run: cargo build --target ${{ matrix.target }} --release
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: uxc-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/uxc*

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Detect changed files
         id: filter
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -107,14 +107,14 @@ jobs:
         run: cargo llvm-cov report --html --output-dir html --ignore-filename-regex 'test_server/|bin/uxc-test-.*\.rs$'
 
       - name: Upload coverage JSON report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: coverage-json
           path: coverage.json
           retention-days: 30
 
       - name: Upload coverage HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: coverage-html
           path: html/

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -43,7 +43,7 @@ jobs:
         run: npm run docs:build
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: docs-site-cloudflare
           path: dist/cloudflare

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Detect changed files
         id: filter
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -82,10 +82,10 @@ jobs:
       - name: Install grpcurl
         run: |
           go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.1
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "20"
 
@@ -229,7 +229,7 @@ jobs:
           # Host help (operation discovery) with retry
           for attempt in {1..3}; do
             echo "Attempt $attempt/3: Fetching host help..."
-            if OUTPUT=$($UXC grpcb.in:9000 -h 2>&1); then
+            if OUTPUT=$("$UXC" grpcb.in:9000 -h 2>&1); then
               if echo "$OUTPUT" | jq -e '.ok == true and .kind == "host_help" and any(.data.operations[]; .operation_id == "addsvc.Add/Sum")' >/dev/null; then
                 echo "✓ Host help succeeded"
                 break
@@ -255,10 +255,10 @@ jobs:
           # Call operation with retry
           for attempt in {1..3}; do
             echo "Attempt $attempt/3: Calling addsvc.Add/Sum..."
-            if OUTPUT=$($UXC grpcb.in:9000 addsvc.Add/Sum '{"a":1,"b":2}' 2>&1); then
+            if OUTPUT=$("$UXC" grpcb.in:9000 addsvc.Add/Sum '{"a":1,"b":2}' 2>&1); then
               if echo "$OUTPUT" | jq -e '.ok == true and .protocol == "grpc" and .data.v == "3"' >/dev/null; then
                 echo "✓ Call operation succeeded"
-                echo "Result: 1 + 2 = $(echo \"$OUTPUT\" | jq -r '.data.v')"
+                echo "Result: 1 + 2 = $(jq -r '.data.v' <<<"$OUTPUT")"
                 break
               else
                 echo "✗ Call operation returned unexpected output:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload artifact (Unix)
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: pkg-${{ matrix.target }}
           path: ${{ steps.package_unix.outputs.file }}
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: pkg-*
           path: dist
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -166,10 +166,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
@@ -197,12 +197,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           ref: refs/tags/${{ inputs.tag }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
@@ -228,10 +228,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: pkg-*
           path: dist

--- a/.github/workflows/skills-ci.yml
+++ b/.github/workflows/skills-ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Detect changed files
         id: filter
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep

--- a/.github/workflows/skills-publish.yml
+++ b/.github/workflows/skills-publish.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep
@@ -60,10 +60,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "20"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -683,7 +683,7 @@ enum AuthOauthCommands {
         credential_id: String,
 
         /// OAuth session ID
-        #[arg(long)]
+        #[arg(long, allow_hyphen_values = true)]
         session_id: String,
 
         /// Authorization response, callback URL, or plain authorization code

--- a/tests/oauth_cli_test.rs
+++ b/tests/oauth_cli_test.rs
@@ -41,6 +41,15 @@ fn read_session_json(files: &AuthFiles, session_id: &str) -> Value {
     serde_json::from_str(&contents).expect("session file should be valid JSON")
 }
 
+fn rewrite_session_id(files: &AuthFiles, old_session_id: &str, new_session_id: &str) {
+    let old_path = files.session_dir.join(format!("{}.json", old_session_id));
+    let new_path = files.session_dir.join(format!("{}.json", new_session_id));
+    let mut session_json = read_session_json(files, old_session_id);
+    session_json["session_id"] = serde_json::json!(new_session_id);
+    fs::write(&new_path, serde_json::to_vec_pretty(&session_json).unwrap()).unwrap();
+    fs::remove_file(old_path).unwrap();
+}
+
 #[test]
 fn oauth_start_returns_authorization_url_and_session() {
     let files = AuthFiles::new();
@@ -300,7 +309,9 @@ fn oauth_complete_state_mismatch_deletes_session() {
         .output()
         .expect("oauth start should run");
     let start_json = parse_stdout_json(&start);
-    let session_id = start_json["data"]["session_id"].as_str().unwrap();
+    let original_session_id = start_json["data"]["session_id"].as_str().unwrap();
+    let session_id = "-state-mismatch-session";
+    rewrite_session_id(&files, original_session_id, session_id);
 
     let complete = uxc_command(&files)
         .arg("auth")


### PR DESCRIPTION
## What
- Accept OAuth session IDs that start with `-` in `uxc auth oauth complete`.
- Add deterministic regression coverage for a hyphen-leading session ID in the state-mismatch path.
- Upgrade first-party GitHub Actions to Node 24 runtime versions:
  - `actions/checkout@v6.0.2`
  - `actions/setup-node@v6.4.0`
  - `actions/upload-artifact@v7.0.1`
  - `actions/download-artifact@v8.0.1`
- Clean up related workflow shell quoting so `actionlint` is clean.

## Why
The release failure was an intermittent parser edge case: OAuth session IDs are URL-safe random strings and can begin with `-`. When that happened, clap treated the `--session-id` value as another flag and returned `INVALID_ARGUMENT` before the OAuth state-mismatch handler ran.

The workflow action upgrades address the Node.js runtime deprecation warning for older first-party actions.

## How
- Add `allow_hyphen_values = true` to the OAuth complete `--session-id` argument.
- Rewrite the generated test session ID to `-state-mismatch-session` so the regression is no longer probabilistic.
- Pin the official GitHub actions to current Node 24-backed releases.

## Testing
- `for i in $(seq 1 30); do cargo test --test oauth_cli_test oauth_complete_state_mismatch_deletes_session -- --exact || exit 1; done`
- `cargo test --test oauth_cli_test -- --test-threads=1`
- `cargo fmt -- --check`
- `git diff --check`
- `actionlint .github/workflows/*.yml`

Also attempted `cargo test --locked -- --test-threads=1`; OAuth tests passed, but the full local run was blocked by an unrelated stale daemon mismatch (`daemon=0.15.4, cli=0.15.5`) in `daemon_reuse_test`.
