### PR TITLE
fix: refresh feishu openapi schema

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ For public product docs, use the docs site:
 
 - [`operations/release.md`](./operations/release.md): release workflow and publishing checklist
 - [`operations/skills.md`](./operations/skills.md): skills publish and maintenance log
+- [`operations/feishu-openapi-schema-maintenance.md`](./operations/feishu-openapi-schema-maintenance.md): Feishu/Lark schema generation and update plan
 - [`decisions/matrix-auth.md`](./decisions/matrix-auth.md): issue-specific Matrix auth decision note for #274
 - [`decisions/daemon-session-lifecycle.md`](./decisions/daemon-session-lifecycle.md): daemon session lifecycle contract note for #337
 - [`decisions/artifact-contract.md`](./decisions/artifact-contract.md): artifact contract note for #338

--- a/docs/operations/feishu-openapi-schema-maintenance.md
+++ b/docs/operations/feishu-openapi-schema-maintenance.md
@@ -95,7 +95,16 @@ services incrementally.
 Use `larksuite/cli` as an implementation reference for endpoints missing from
 the registry metadata.
 
-Useful local sources:
+Useful sources in this repository:
+
+- `skills/feishu-openapi-skill/scripts/generate_openapi.py`: metadata to
+  OpenAPI converter
+- `skills/feishu-openapi-skill/references/feishu-openapi.overlay.json`:
+  curated overlay for missing endpoints and UXC guardrails
+- `skills/feishu-openapi-skill/scripts/validate.sh`: schema validation checks
+
+Useful external reference sources in `larksuite/cli`
+(`https://github.com/larksuite/cli`, paths relative to that repository):
 
 - `scripts/fetch_meta.py`: official metadata fetch shape
 - `internal/registry/remote.go`: Feishu/Lark metadata endpoint and cache rules

--- a/docs/operations/feishu-openapi-schema-maintenance.md
+++ b/docs/operations/feishu-openapi-schema-maintenance.md
@@ -1,0 +1,164 @@
+# Feishu / Lark OpenAPI Schema Maintenance
+
+This note tracks how UXC should maintain the Feishu/Lark OpenAPI JSON used by
+`skills/feishu-openapi-skill`.
+
+## Problem
+
+The current skill schema is a small curated OpenAPI document:
+
+- `skills/feishu-openapi-skill/references/feishu-im.openapi.json`
+- current focus: IM messages, chats, uploads, and basic contact lookup
+
+This is useful for stable agent workflows, but it is not a complete Feishu/Lark
+Open Platform surface. Issue #407 exposed the gap for bot self-identity:
+
+- required endpoint: `GET /open-apis/bot/v3/info`
+- use case: AgentInbox resolves the configured app bot `open_id` without
+  shipping its own tiny provider schema
+
+## Source Of Truth
+
+Feishu/Lark does not currently expose a public standard OpenAPI 3 JSON document
+through the same endpoint used by the official CLI.
+
+The official `larksuite/cli` registry fetches a custom metadata protocol:
+
+```text
+https://open.feishu.cn/api/tools/open/api_definition?protocol=meta&client_version=<version>
+https://open.larksuite.com/api/tools/open/api_definition?protocol=meta&client_version=<version>
+```
+
+The same endpoint rejects `protocol=openapi`, `protocol=swagger`, and
+`protocol=json`, so UXC should treat `protocol=meta` as an upstream metadata
+source, not as an OpenAPI document.
+
+The metadata still carries enough structure to generate OpenAPI operations:
+
+- `servicePath`
+- `resources.<resource>.methods.<method>.httpMethod`
+- `path`
+- `parameters`
+- `requestBody`
+- `responseBody`
+- `scopes`
+- `accessTokens`
+- `docUrl`
+
+However, this metadata is not full coverage by itself. Some common IM endpoints
+are implemented by `larksuite/cli` as shortcuts rather than registry methods,
+including send/list/reply message workflows.
+
+## Maintenance Strategy
+
+Maintain the Feishu/Lark schema through three layers, in this order.
+
+### 1. Generate From Official Metadata
+
+Build a converter that fetches `api_definition?protocol=meta` and writes an
+OpenAPI 3 document.
+
+Current generator:
+
+```bash
+python3 skills/feishu-openapi-skill/scripts/generate_openapi.py
+```
+
+The generator writes:
+
+- `skills/feishu-openapi-skill/references/feishu-im.openapi.json`
+
+It applies this curated overlay after metadata conversion:
+
+- `skills/feishu-openapi-skill/references/feishu-openapi.overlay.json`
+
+The converter should:
+
+- support Feishu and Lark hosts
+- cache the fetched upstream metadata with its `version`
+- map `servicePath + method.path` into OpenAPI paths
+- preserve method identity in `operationId`
+- map `parameters` into path/query/header parameters
+- map `requestBody` and `responseBody` into JSON schemas
+- map file fields into `multipart/form-data`
+- preserve Feishu/Lark-specific metadata with extensions such as
+  `x-feishu-scopes`, `x-feishu-access-tokens`, `x-feishu-doc-url`, and
+  `x-feishu-source`
+- emit deterministic JSON so diffs are reviewable
+
+Initial generator scope is the skill's current surface plus the bot identity
+service needed by #407. After the converter is stable, broaden the selected
+services incrementally.
+
+### 2. Patch From CLI And Skill Knowledge
+
+Use `larksuite/cli` as an implementation reference for endpoints missing from
+the registry metadata.
+
+Useful local sources:
+
+- `scripts/fetch_meta.py`: official metadata fetch shape
+- `internal/registry/remote.go`: Feishu/Lark metadata endpoint and cache rules
+- `cmd/schema/schema.go`: method metadata interpretation
+- `shortcuts/im/*`: hand-written IM endpoints and guardrails
+- `skills/lark-openapi-explorer`: documented fallback to Feishu/Lark docs
+
+Manual patches should be explicit, small, and source-attributed. Prefer a
+structured overlay file over ad hoc edits to generated JSON.
+
+### 3. Fill Gaps From Official `llms.txt`
+
+For endpoints that are neither in `protocol=meta` nor clearly represented in
+CLI shortcuts, use the official documentation index:
+
+```text
+https://open.feishu.cn/llms.txt
+https://open.larksuite.com/llms.txt
+```
+
+The extraction flow should be:
+
+1. find the relevant module from `llms.txt`
+2. load the module `llms-*.txt`
+3. load the API markdown document
+4. extract method, path, parameters, request body, response body, permissions,
+   and notes
+5. add the endpoint through the same structured overlay path used for CLI gaps
+
+## Periodic Update Task
+
+Run this maintenance task on a regular cadence, and also whenever AgentInbox or
+another provider integration reports a missing Feishu/Lark endpoint.
+
+Recommended cadence: weekly while Feishu integration is active, otherwise before
+each UXC release.
+
+Checklist:
+
+1. Fetch fresh Feishu and Lark `protocol=meta` payloads.
+2. Regenerate the OpenAPI JSON.
+3. Apply CLI/skill/`llms.txt` overlays.
+4. Compare generated output with the committed schema.
+5. Review added/removed operations and permission changes.
+6. Run `bash skills/feishu-openapi-skill/scripts/validate.sh`.
+7. Smoke at least one read operation and any newly added operation that can be
+   safely called with test credentials.
+8. Update this note or the overlay comments when upstream behavior changes.
+
+## First Closure Target: Issue #407
+
+The first implementation pass should close #407 by making this UXC operation
+available through the official Feishu/Lark schema path:
+
+```text
+GET /open-apis/bot/v3/info
+```
+
+Acceptance for that pass:
+
+- UXC can resolve the configured bot identity with existing bootstrap-managed
+  app credentials.
+- The schema exposes at least `bot.open_id` and `bot.app_name`.
+- `skills/feishu-openapi-skill/SKILL.md` documents the operation.
+- AgentInbox can remove its temporary mini schema for bot identity discovery.
+- A small validation or smoke test covers the endpoint shape.

--- a/skills/feishu-openapi-skill/SKILL.md
+++ b/skills/feishu-openapi-skill/SKILL.md
@@ -22,6 +22,7 @@ Reuse the `uxc` skill for shared execution, auth, and error-handling guidance.
 
 This skill covers an IM-focused request/response surface:
 
+- bot identity lookup
 - chat lookup
 - chat member lookup
 - image and file upload for IM sends
@@ -162,6 +163,7 @@ uxc auth binding match https://open.feishu.cn/open-apis
    - `feishu-openapi-cli -h`
 
 2. Inspect operation schema first:
+   - `feishu-openapi-cli get:/bot/v3/info -h`
    - `feishu-openapi-cli get:/im/v1/chats -h`
    - `feishu-openapi-cli post:/im/v1/images -h`
    - `feishu-openapi-cli post:/im/v1/files -h`
@@ -169,6 +171,7 @@ uxc auth binding match https://open.feishu.cn/open-apis
    - `feishu-openapi-cli get:/im/v1/messages -h`
 
 3. Prefer read/setup validation before writes:
+   - `feishu-openapi-cli get:/bot/v3/info`
    - `feishu-openapi-cli get:/im/v1/chats page_size=20`
    - `feishu-openapi-cli get:/im/v1/chats/{chat_id} chat_id=oc_xxx`
    - `feishu-openapi-cli get:/contact/v3/users/{user_id} user_id=ou_xxx user_id_type=open_id`
@@ -186,6 +189,10 @@ uxc auth binding match https://open.feishu.cn/open-apis
    - send a bot-visible message, then inspect the sink for `header.event_type = "im.message.receive_v1"`
 
 ## Operation Groups
+
+### Bot Identity
+
+- `get:/bot/v3/info`
 
 ### Chat Reads
 
@@ -215,6 +222,7 @@ uxc auth binding match https://open.feishu.cn/open-apis
 - Keep automation on the JSON output envelope; do not use `--text`.
 - Parse stable fields first: `ok`, `kind`, `protocol`, `data`, `error`.
 - Prefer `uxc auth bootstrap` over manual token management. Manual `tenant_access_token` setup is still supported as a fallback.
+- `get:/bot/v3/info` requires a tenant token for an app with bot capability enabled, but does not require additional API scopes.
 - `feishu-long-connection` requires the app credential fields `app_id` and `app_secret`; a plain bearer-only credential is not enough for event intake.
 - `post:/im/v1/images` and `post:/im/v1/files` use `multipart/form-data`. File fields must be local path strings; help output marks them as multipart file fields.
 - `post:/im/v1/messages` requires the `receive_id_type` query parameter and the body `content` field is a JSON-encoded string, not a nested JSON object.

--- a/skills/feishu-openapi-skill/references/feishu-im.openapi.json
+++ b/skills/feishu-openapi-skill/references/feishu-im.openapi.json
@@ -3847,6 +3847,11 @@
       }
     }
   },
+  "security": [
+    {
+      "FeishuBearerAuth": []
+    }
+  ],
   "servers": [
     {
       "url": "https://open.feishu.cn/open-apis"

--- a/skills/feishu-openapi-skill/references/feishu-im.openapi.json
+++ b/skills/feishu-openapi-skill/references/feishu-im.openapi.json
@@ -1,9 +1,3851 @@
 {
-  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "BatchGetUserIdRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "emails": {
+            "description": "Email addresses to resolve",
+            "items": {
+              "format": "email",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "include_resigned": {
+            "description": "Whether to include resigned users in the lookup",
+            "type": "boolean"
+          },
+          "mobiles": {
+            "description": "Mobile numbers to resolve",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "BotInfo": {
+        "properties": {
+          "activate_status": {
+            "description": "Current app activation status in the tenant.",
+            "type": "integer"
+          },
+          "app_name": {
+            "description": "App bot display name.",
+            "type": "string"
+          },
+          "avatar_url": {
+            "description": "App bot avatar URL.",
+            "type": "string"
+          },
+          "ip_white_list": {
+            "description": "Configured IP allow list for the app.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "open_id": {
+            "description": "Bot open_id for the configured app.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "app_name",
+          "open_id"
+        ],
+        "type": "object"
+      },
+      "BotInfoResponse": {
+        "properties": {
+          "bot": {
+            "$ref": "#/components/schemas/BotInfo"
+          },
+          "code": {
+            "description": "Feishu/Lark API status code. 0 means success.",
+            "type": "integer"
+          },
+          "msg": {
+            "description": "Feishu/Lark API status message.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "msg",
+          "bot"
+        ],
+        "type": "object"
+      },
+      "CreateMessageRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "description": "Stringified JSON payload expected by Feishu, for example {\"text\":\"hello\"}",
+            "type": "string"
+          },
+          "msg_type": {
+            "description": "Message content type",
+            "enum": [
+              "text",
+              "post",
+              "image",
+              "interactive",
+              "share_chat",
+              "share_user",
+              "audio",
+              "media",
+              "file",
+              "sticker"
+            ],
+            "type": "string"
+          },
+          "receive_id": {
+            "description": "Target identifier whose type is defined by receive_id_type",
+            "type": "string"
+          },
+          "uuid": {
+            "description": "Optional client-generated idempotency token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "receive_id",
+          "msg_type",
+          "content"
+        ],
+        "type": "object"
+      },
+      "ReplyMessageRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "description": "Stringified JSON payload expected by Feishu, for example {\"text\":\"reply\"}",
+            "type": "string"
+          },
+          "msg_type": {
+            "description": "Message content type. Defaults vary by API behavior; set it explicitly.",
+            "enum": [
+              "text",
+              "post",
+              "image",
+              "interactive",
+              "share_chat",
+              "share_user",
+              "audio",
+              "media",
+              "file",
+              "sticker"
+            ],
+            "type": "string"
+          },
+          "uuid": {
+            "description": "Optional client-generated idempotency token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "UploadFileRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "duration": {
+            "description": "Optional duration in milliseconds for audio or video uploads",
+            "type": "integer"
+          },
+          "file": {
+            "description": "Local file path to upload",
+            "format": "binary",
+            "type": "string"
+          },
+          "file_name": {
+            "description": "Original filename shown in Feishu",
+            "type": "string"
+          },
+          "file_type": {
+            "description": "File upload type. Use stream for general file uploads.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_type",
+          "file_name",
+          "file"
+        ],
+        "type": "object"
+      },
+      "UploadImageRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "image": {
+            "description": "Local image file path to upload",
+            "format": "binary",
+            "type": "string"
+          },
+          "image_type": {
+            "description": "Image upload purpose. Use message for IM sends.",
+            "enum": [
+              "message"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "image_type",
+          "image"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "FeishuBearerAuth": {
+        "bearerFormat": "tenant_access_token",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
   "info": {
+    "description": "Curated Feishu / Lark IM, bot identity, and contact surface for UXC messaging workflows.",
     "title": "Feishu / Lark IM API (Curated)",
-    "version": "1.0.0",
-    "description": "Curated Feishu / Lark IM and contact surface for UXC messaging workflows."
+    "version": "1.0.0"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/bot/v3/info": {
+      "get": {
+        "description": "Returns the configured Feishu/Lark app bot identity, including bot.open_id and bot.app_name. Requires tenant_access_token but no additional API scope.",
+        "operationId": "botGetInfo",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotInfoResponse"
+                }
+              }
+            },
+            "description": "Bot identity response"
+          }
+        },
+        "summary": "Get bot identity information for the configured app",
+        "x-feishu-access-tokens": [
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/client-docs/bot-v3/obtain-bot-info.md",
+        "x-feishu-scopes": [],
+        "x-feishu-source": "llms.txt:bot-v3/obtain-bot-info"
+      }
+    },
+    "/contact/v3/users/batch_get_id": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchGetUserIdRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Batch user ID lookup response"
+          }
+        },
+        "summary": "Resolve user IDs from email or mobile values"
+      }
+    },
+    "/contact/v3/users/{user_id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "User identifier",
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Identifier type used for the path parameter",
+            "in": "query",
+            "name": "user_id_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "open_id",
+                "union_id",
+                "user_id"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Preferred department ID type in the response",
+            "in": "query",
+            "name": "department_id_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "department_id",
+                "open_department_id"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User profile response"
+          }
+        },
+        "summary": "Get one user profile"
+      }
+    },
+    "/im/v1/chats": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Number of chats to return",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination token from a previous response",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort order for the chat list",
+            "in": "query",
+            "name": "sort_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ByCreateTimeAsc",
+                "ByCreateTimeDesc",
+                "ByActiveTimeAsc",
+                "ByActiveTimeDesc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chat list response"
+          }
+        },
+        "summary": "List chats visible to the app"
+      },
+      "post": {
+        "description": "创建群。Identity: `bot` only (`tenant_access_token`).",
+        "operationId": "imChatsCreate",
+        "parameters": [
+          {
+            "description": "如果在请求体的 ==owner_id== 字段指定了某个用户为群主，可以选择是否同时设置创建此群的机器人为管理员，此标志位用于标记是否设置创建群的机器人为管理员。",
+            "in": "query",
+            "name": "set_bot_manager",
+            "required": false,
+            "schema": {
+              "description": "如果在请求体的 ==owner_id== 字段指定了某个用户为群主，可以选择是否同时设置创建此群的机器人为管理员，此标志位用于标记是否设置创建群的机器人为管理员。",
+              "example": "false",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "此次调用中使用的用户ID的类型",
+            "in": "query",
+            "name": "user_id_type",
+            "required": false,
+            "schema": {
+              "description": "此次调用中使用的用户ID的类型",
+              "enum": [
+                "user_id",
+                "union_id",
+                "open_id"
+              ],
+              "example": "open_id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "由开发者生成的唯一字符串序列，用于创建群组请求去重；持有相同 uuid + owner_id（若有） 的请求 10 小时内只可成功创建 1 个群聊。不传值表示不进行请求去重，每一次请求成功后都会创建一个群聊。",
+            "in": "query",
+            "name": "uuid",
+            "required": false,
+            "schema": {
+              "description": "由开发者生成的唯一字符串序列，用于创建群组请求去重；持有相同 uuid + owner_id（若有） 的请求 10 小时内只可成功创建 1 个群聊。不传值表示不进行请求去重，每一次请求成功后都会创建一个群聊。",
+              "example": "b13g2t38-1jd2-458b-8djf-dtbca5104204",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "avatar": {
+                    "description": "群头像对应的 Image Key;;- 可通过[上传图片](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/image/create)获取（注意：上传图片的 ==image_type== 需要指定为 ==avatar==）;- 不传值则使用系统默认头像",
+                    "example": "default-avatar_44ae0ca3-e140-494b-956f-78091e348435",
+                    "type": "string"
+                  },
+                  "bot_id_list": {
+                    "description": "创建群时邀请的群机器人，不填则不邀请机器人。可参考[如何获取应用的 App ID？](https://open.feishu.cn/document/uAjLw4CM/ugTN1YjL4UTN24CO1UjN/trouble-shooting/how-to-obtain-app-id)来获取应用的 App ID; ;**注意：**;- 操作此接口的机器人会自动入群，无需重复填写;- 拉机器人入群请使用 `app_id`;- 最多同时邀请 5 个机器人，且邀请后群组中机器人数量不能超过 15 个",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "chat_mode": {
+                    "description": "群模式;;**可选值有**：;- `group`：群组",
+                    "example": "group",
+                    "type": "string"
+                  },
+                  "chat_tags": {
+                    "description": "群标签",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "chat_type": {
+                    "description": "群类型;;**可选值有**：;- `private`：私有群;- `public`：公开群",
+                    "example": "private",
+                    "type": "string"
+                  },
+                  "description": {
+                    "description": "群描述，建议不超过 100 字符;;**默认值**：空",
+                    "example": "测试群描述",
+                    "type": "string"
+                  },
+                  "edit_permission": {
+                    "description": "谁可以编辑群信息;;**默认值**：all_members",
+                    "enum": [
+                      "only_owner",
+                      "all_members"
+                    ],
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "external": {
+                    "description": "是否是外部群",
+                    "example": "false",
+                    "type": "boolean"
+                  },
+                  "group_message_type": {
+                    "description": "群消息形式",
+                    "enum": [
+                      "chat",
+                      "thread"
+                    ],
+                    "example": "chat",
+                    "type": "string"
+                  },
+                  "hide_member_count_setting": {
+                    "description": "隐藏群成员人数设置;;**默认值**：all_members",
+                    "enum": [
+                      "all_members",
+                      "only_owner"
+                    ],
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "i18n_names": {
+                    "description": "群国际化名称",
+                    "properties": {
+                      "en_us": {
+                        "description": "英文名",
+                        "example": "group chat",
+                        "type": "string"
+                      },
+                      "ja_jp": {
+                        "description": "日文名",
+                        "example": "グループチャット",
+                        "type": "string"
+                      },
+                      "zh_cn": {
+                        "description": "中文名",
+                        "example": "群聊",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "join_message_visibility": {
+                    "description": "成员入群提示消息的可见性;;**可选值有**：;- `only_owner`：仅群主和管理员可见;- `all_members`：所有成员可见;- `not_anyone`：任何人均不可见",
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "description": "群标签",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "leave_message_visibility": {
+                    "description": "成员退群提示消息的可见性;;**可选值有**：;- `only_owner`：仅群主和管理员可见;- `all_members`：所有成员可见;- `not_anyone`：任何人均不可见",
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "membership_approval": {
+                    "description": "加群是否需要审批;;**可选值有**：;- `no_approval_required`：无需审批;- `approval_required`：需要审批",
+                    "example": "no_approval_required",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "群名称;; **注意：** ;- 建议群名称不超过 60 字符;- 公开群名称的长度不得少于 2 个字符;- 私有群若未填写群名称，群名称默认设置为 `(无主题)`",
+                    "example": "测试群名称",
+                    "type": "string"
+                  },
+                  "owner_id": {
+                    "description": "创建群时指定的群主，不填时指定建群的机器人为群主。群主 ID 类型在查询参数 ==user_id_type== 中指定；推荐使用 OpenID，获取方式可参考文档[如何获取 Open ID？](https://open.feishu.cn/document/uAjLw4CM/ugTN1YjL4UTN24CO1UjN/trouble-shooting/how-to-obtain-openid);;**注意**：开启对外共享能力的机器人在创建外部群时，机器人不能为群主，必须指定某一用户作为群主。此外，添加外部用户进群时，外部用户必须和群主已成为飞书好友。",
+                    "example": "ou_7d8a6e6df7621556ce0d21922b676706ccs",
+                    "type": "string"
+                  },
+                  "pin_manage_setting": {
+                    "description": "谁可以管理置顶",
+                    "enum": [
+                      "only_owner",
+                      "all_members"
+                    ],
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "restricted_mode_setting": {
+                    "description": "保密模式设置;;**注意**：保密模式适用于企业旗舰版。适用版本与功能介绍参见[会话保密模式](https://www.feishu.cn/hc/zh-CN/articles/418691056559)。",
+                    "properties": {
+                      "download_has_permission_setting": {
+                        "description": "允许下载消息中图片、视频和文件;;**默认值**：all_members",
+                        "enum": [
+                          "all_members",
+                          "not_anyone"
+                        ],
+                        "example": "all_members",
+                        "type": "string"
+                      },
+                      "message_has_permission_setting": {
+                        "description": "允许复制和转发消息;;**默认值**：all_members",
+                        "enum": [
+                          "all_members",
+                          "not_anyone"
+                        ],
+                        "example": "all_members",
+                        "type": "string"
+                      },
+                      "screenshot_has_permission_setting": {
+                        "description": "允许截屏录屏;;**默认值**：all_members",
+                        "enum": [
+                          "all_members",
+                          "not_anyone"
+                        ],
+                        "example": "all_members",
+                        "type": "string"
+                      },
+                      "status": {
+                        "description": "保密模式是否开启;;**可选值有**：;;- true：开启。设置为 ture 时，`screenshot_has_permission_setting`、`download_has_permission_setting`、`message_has_permission_setting` 不能全为 `all_members`。;- false：不开启。设置为 false 时，`screenshot_has_permission_setting`、`download_has_permission_setting`、`message_has_permission_setting` 不能存在 `not_anyone`。;;;**默认值**：false",
+                        "example": "false",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "toolkit_ids": {
+                    "description": "群快捷组件列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "urgent_setting": {
+                    "description": "谁可以加急;;**默认值**：all_members",
+                    "enum": [
+                      "only_owner",
+                      "all_members"
+                    ],
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "user_id_list": {
+                    "description": "创建群时邀请的群成员，不填则不邀请成员。ID 类型在查询参数 ==user_id_type== 中指定；推荐使用 OpenID，获取方式可参考文档[如何获取 Open ID？](https://open.feishu.cn/document/uAjLw4CM/ugTN1YjL4UTN24CO1UjN/trouble-shooting/how-to-obtain-openid);;**注意**：;- 最多同时邀请 50 个用户;- 为便于在客户端查看效果，建议调试接口时加入开发者自身 ID;- 如果需要邀请外部用户，则外部用户必须和群主已成为飞书好友;- 如何获取外部用户的 open_id，参考[获取外部用户的 open_id](https://open.feishu.cn/document/uAjLw4CM/ukzMukzMukzM/develop-robots/add-bot-to-external-group#c38b1d97)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "video_conference_setting": {
+                    "description": "谁可以发起视频会议;;**默认值**：all_members",
+                    "enum": [
+                      "only_owner",
+                      "all_members"
+                    ],
+                    "example": "all_members",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "add_member_permission": {
+                      "description": "谁可以邀请用户或机器人入群;;**可选值有**：;- `only_owner`：仅群主和管理员;- `all_members`：所有成员",
+                      "example": "all members",
+                      "type": "string"
+                    },
+                    "at_all_permission": {
+                      "description": "谁可以 at 所有人;;**可选值有**：;- `only_owner`：仅群主和管理员;- `all_members`：所有成员",
+                      "example": "all members",
+                      "type": "string"
+                    },
+                    "avatar": {
+                      "description": "群头像 URL",
+                      "example": "https://p3-lark-file.byteimg.com/img/lark-avatar-staging/default-avatar_44ae0ca3-e140-494b-956f-78091e348435~100x100.jpg",
+                      "type": "string"
+                    },
+                    "chat_id": {
+                      "description": "群 ID。建议保存该 ID，后续[向群发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)、[更新群信息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/update)以及[将用户或机器人拉入群聊](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat-members/create)等群组相关的操作均需使用该 ID。",
+                      "example": "oc_a0553eda9014c201e6969b478895c230",
+                      "type": "string"
+                    },
+                    "chat_mode": {
+                      "description": "群模式;;**可选值有**：;- `group`：群组",
+                      "example": "group",
+                      "type": "string"
+                    },
+                    "chat_tag": {
+                      "description": "群标签，如有多个，则按照下列顺序返回第一个;;**可选值有**：;- `inner`：内部群;- `tenant`：公司群;- `department`：部门群;- `edu`：教育群;- `meeting`：会议群;- `customer_service`：客服群",
+                      "example": "inner",
+                      "type": "string"
+                    },
+                    "chat_type": {
+                      "description": "群类型;;**可选值有**：;- `private`：私有群;- `public`：公开群",
+                      "example": "private",
+                      "type": "string"
+                    },
+                    "description": {
+                      "description": "群描述",
+                      "example": "测试群描述",
+                      "type": "string"
+                    },
+                    "edit_permission": {
+                      "description": "群编辑权限;;**可选值有**：;- `only_owner`：仅群主和管理员;- `all_members`：所有成员",
+                      "example": "all members",
+                      "type": "string"
+                    },
+                    "external": {
+                      "description": "是否是外部群",
+                      "example": "false",
+                      "type": "boolean"
+                    },
+                    "group_message_type": {
+                      "description": "群消息形式;;**可选值有**：;- `chat`：对话消息;- `thread`：话题消息",
+                      "example": "chat",
+                      "type": "string"
+                    },
+                    "hide_member_count_setting": {
+                      "description": "隐藏群成员人数设置",
+                      "enum": [
+                        "all_members",
+                        "only_owner"
+                      ],
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "i18n_names": {
+                      "description": "群国际化名称",
+                      "properties": {
+                        "en_us": {
+                          "description": "英文名",
+                          "example": "group chat",
+                          "type": "string"
+                        },
+                        "ja_jp": {
+                          "description": "日文名",
+                          "example": "グループチャット",
+                          "type": "string"
+                        },
+                        "zh_cn": {
+                          "description": "中文名",
+                          "example": "群聊",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "join_message_visibility": {
+                      "description": "入群消息可见性;;**可选值有**：;- `only_owner`：仅群主和管理员可见;- `all_members`：所有成员可见;- `not_anyone`：任何人均不可见",
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "description": "群标签",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "leave_message_visibility": {
+                      "description": "出群消息可见性;;**可选值有**：;- `only_owner`：仅群主和管理员可见;- `all_members`：所有成员可见;- `not_anyone`：任何人均不可见",
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "membership_approval": {
+                      "description": "加群审批;;**可选值有**：;- `no_approval_required`：无需审批;- `approval_required`：需要审批",
+                      "example": "no_approval_required",
+                      "type": "string"
+                    },
+                    "moderation_permission": {
+                      "description": "发言权限;;**可选值有**：;- `only_owner`：仅群主和管理员;- `all_members`：所有成员;- `moderator_list`：指定群成员",
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "群名称",
+                      "example": "测试群名称",
+                      "type": "string"
+                    },
+                    "owner_id": {
+                      "description": "群主 ID，ID 类型与查询参数中的 ==user_id_type== 对应；不同 ID 的说明参见 [用户相关的 ID 概念](https://open.feishu.cn/document/home/user-identity-introduction/introduction)。;;**注意**：当群主是机器人时，该字段不返回",
+                      "example": "ou_7d8a6e6df7621556ce0d21922b676706ccs",
+                      "type": "string"
+                    },
+                    "owner_id_type": {
+                      "description": "群主 ID 类型，与查询参数中的 ==user_id_type== 取值相同。;;**注意**：当群主是机器人时，该字段不返回",
+                      "example": "open_id",
+                      "type": "string"
+                    },
+                    "pin_manage_setting": {
+                      "description": "谁可以管理置顶",
+                      "enum": [
+                        "only_owner",
+                        "all_members"
+                      ],
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "restricted_mode_setting": {
+                      "description": "保密模式设置;;**注意**：仅企业旗舰版支持设置保密模式。保密模式的适用版本与功能介绍，参见[会话保密模式](https://www.feishu.cn/hc/zh-CN/articles/418691056559)。",
+                      "properties": {
+                        "download_has_permission_setting": {
+                          "description": "允许下载消息中图片、视频和文件",
+                          "enum": [
+                            "all_members",
+                            "not_anyone"
+                          ],
+                          "example": "all_members",
+                          "type": "string"
+                        },
+                        "message_has_permission_setting": {
+                          "description": "允许复制和转发消息",
+                          "enum": [
+                            "all_members",
+                            "not_anyone"
+                          ],
+                          "example": "all_members",
+                          "type": "string"
+                        },
+                        "screenshot_has_permission_setting": {
+                          "description": "允许截屏录屏",
+                          "enum": [
+                            "all_members",
+                            "not_anyone"
+                          ],
+                          "example": "all_members",
+                          "type": "string"
+                        },
+                        "status": {
+                          "description": "保密模式是否开启",
+                          "example": "false",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "share_card_permission": {
+                      "description": "群分享权限;;**可选值有**：;- `allowed`：允许;- `not_allowed`：不允许",
+                      "example": "allowed",
+                      "type": "string"
+                    },
+                    "tenant_key": {
+                      "description": "租户在飞书上的唯一标识，用来换取对应的 tenant_access_token，也可以用作租户在应用里面的唯一标识",
+                      "example": "736588c9260f175e",
+                      "type": "string"
+                    },
+                    "toolkit_ids": {
+                      "description": "群快捷组件列表",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "urgent_setting": {
+                      "description": "谁可以加急",
+                      "enum": [
+                        "only_owner",
+                        "all_members"
+                      ],
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "video_conference_setting": {
+                      "description": "谁可以发起视频会议",
+                      "enum": [
+                        "only_owner",
+                        "all_members"
+                      ],
+                      "example": "all_members",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "创建群。Identity: `bot` only (`tenant_access_token`).",
+        "x-feishu-access-tokens": [
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/create",
+        "x-feishu-scopes": [
+          "im:chat",
+          "im:chat:create",
+          "im:chat:create_by_user"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/chats/{chat_id}": {
+      "get": {
+        "description": "获取群信息。Identity: supports `user` and `bot`; the caller must be in the target chat to get full details, and must belong to the same tenant for internal chats.",
+        "operationId": "imChatsGet",
+        "parameters": [
+          {
+            "description": "Feishu chat identifier",
+            "in": "path",
+            "name": "chat_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "add_member_permission": {
+                      "description": "谁可以添加群成员，群成员包括用户或机器人;;**可选值有**：;- `only_owner`：仅群主和管理员;- `all_members`：所有成员;;**注意**：单聊不返回该字段",
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "at_all_permission": {
+                      "description": "谁可以 at 所有人;;**可选值有**：;- `only_owner`：仅群主和管理员;- `all_members`：所有成员;;**注意**：单聊不返回该字段",
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "avatar": {
+                      "description": "群头像 URL",
+                      "example": "https://p3-lark-file.byteimg.com/img/lark-avatar-staging/default-avatar_44ae0ca3-e140-494b-956f-78091e348435~100x100.jpg",
+                      "type": "string"
+                    },
+                    "bot_count": {
+                      "description": "群内机器人的数量",
+                      "example": "3",
+                      "type": "string"
+                    },
+                    "bot_manager_id_list": {
+                      "description": "机器人管理员 ID 列表，ID 类型为应用的 App ID。",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "chat_mode": {
+                      "description": "群模式;;**可选值有**：;- `group`：群组;- `topic`: 话题;- `p2p`: 单聊",
+                      "example": "group",
+                      "type": "string"
+                    },
+                    "chat_status": {
+                      "description": "群状态",
+                      "enum": [
+                        "normal",
+                        "dissolved",
+                        "dissolved_save"
+                      ],
+                      "example": "normal",
+                      "type": "string"
+                    },
+                    "chat_tag": {
+                      "description": "群标签。如有多个，则按照下列顺序返回第一个标签。;;**可选值有**：;- `inner`：内部群;- `tenant`：公司群;- `department`：部门群;- `edu`：教育群;- `meeting`：会议群;- `customer_service`：客服群;;**注意**：单聊不返回该字段",
+                      "example": "inner",
+                      "type": "string"
+                    },
+                    "chat_type": {
+                      "description": "群类型;;**可选值有**：;- `private`：私有群;- `public`：公开群;;**注意**：单聊不返回该字段",
+                      "example": "private",
+                      "type": "string"
+                    },
+                    "description": {
+                      "description": "群描述",
+                      "example": "测试群描述",
+                      "type": "string"
+                    },
+                    "edit_permission": {
+                      "description": "谁可以编辑群;;**可选值有**：;- `only_owner`：仅群主和管理员;- `all_members`：所有成员",
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "external": {
+                      "description": "是否是外部群",
+                      "example": "false",
+                      "type": "boolean"
+                    },
+                    "group_message_type": {
+                      "description": "群消息模式;;**可选值有**：;- `chat`：会话消息;- ` thread`：话题消息;;**注意**：仅普通对话群组返回该字段，话题群和单聊不返回值。",
+                      "example": "chat",
+                      "type": "string"
+                    },
+                    "hide_member_count_setting": {
+                      "description": "隐藏群成员人数设置",
+                      "enum": [
+                        "all_members",
+                        "only_owner"
+                      ],
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "i18n_names": {
+                      "description": "群国际化名称",
+                      "properties": {
+                        "en_us": {
+                          "description": "英文名",
+                          "example": "group chat",
+                          "type": "string"
+                        },
+                        "ja_jp": {
+                          "description": "日文名",
+                          "example": "グループチャット",
+                          "type": "string"
+                        },
+                        "zh_cn": {
+                          "description": "中文名",
+                          "example": "群聊",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "join_message_visibility": {
+                      "description": "入群提示消息的可见性;;**可选值有**：;- `only_owner`：仅群主和管理员可见;- `all_members`：所有成员可见;- `not_anyone`：任何人均不可见;;**注意**：单聊不返回该字段",
+                      "example": "only_owner",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "description": "群标签",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "leave_message_visibility": {
+                      "description": "出群提示消息的可见性;;**可选值有**：;- `only_owner`：仅群主和管理员可见;- `all_members`：所有成员可见;- `not_anyone`：任何人均不可见;;**注意**：单聊不返回该字段",
+                      "example": "only_owner",
+                      "type": "string"
+                    },
+                    "membership_approval": {
+                      "description": "加群是否需要审批;;**可选值有**：;- `no_approval_required`：无需审批;- `approval_required`：需要审批;;**注意**：单聊不返回该字段",
+                      "example": "no_approval_required",
+                      "type": "string"
+                    },
+                    "moderation_permission": {
+                      "description": "群发言权限;;**可选值有**：;- `only_owner`：仅群主和管理员;- `all_members`：所有成员;- `moderator_list`：指定群成员",
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "群名称。没有设置群名称时，不会返回该参数。",
+                      "example": "测试群名称",
+                      "type": "string"
+                    },
+                    "owner_id": {
+                      "description": "群主的用户 ID，ID 类型与查询参数中的 user_id_type 对应。;;**注意**：;- 当群主是机器人时不返回该字段;- 单聊不返回该字段",
+                      "example": "4d7a3c6g",
+                      "type": "string"
+                    },
+                    "owner_id_type": {
+                      "description": "群主的用户 ID 类型，与查询参数中的 user_id_type 相同。取值为 `open_id`、`user_id`、`union_id` 其中之一，不同 ID 的说明参见 [用户相关的 ID 概念](https://open.feishu.cn/document/home/user-identity-introduction/introduction)。;;**注意**：;- 当群主是机器人时不返回该字段;- 单聊不返回该字段",
+                      "example": "user_id",
+                      "type": "string"
+                    },
+                    "pin_manage_setting": {
+                      "description": "谁可以管理置顶",
+                      "enum": [
+                        "only_owner",
+                        "all_members"
+                      ],
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "restricted_mode_setting": {
+                      "description": "保密模式设置",
+                      "properties": {
+                        "download_has_permission_setting": {
+                          "description": "允许下载消息中图片、视频和文件",
+                          "enum": [
+                            "all_members",
+                            "not_anyone"
+                          ],
+                          "example": "all_members",
+                          "type": "string"
+                        },
+                        "message_has_permission_setting": {
+                          "description": "允许复制和转发消息",
+                          "enum": [
+                            "all_members",
+                            "not_anyone"
+                          ],
+                          "example": "all_members",
+                          "type": "string"
+                        },
+                        "screenshot_has_permission_setting": {
+                          "description": "允许截屏录屏",
+                          "enum": [
+                            "all_members",
+                            "not_anyone"
+                          ],
+                          "example": "all_members",
+                          "type": "string"
+                        },
+                        "status": {
+                          "description": "保密模式是否开启",
+                          "example": "false",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "share_card_permission": {
+                      "description": "是否允许分享群;;**可选值有**：;- `allowed`：允许;- `not_allowed`：不允许;;**注意**：单聊不返回该字段",
+                      "example": "allowed",
+                      "type": "string"
+                    },
+                    "tenant_key": {
+                      "description": "租户 Key，为租户在飞书上的唯一标识，用来换取对应的tenant_access_token，也可以用作租户在应用中的唯一标识。",
+                      "example": "736588c9260f175e",
+                      "type": "string"
+                    },
+                    "toolkit_ids": {
+                      "description": "群快捷组件列表",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "urgent_setting": {
+                      "description": "谁可以加急",
+                      "enum": [
+                        "only_owner",
+                        "all_members"
+                      ],
+                      "example": "all_members",
+                      "type": "string"
+                    },
+                    "user_count": {
+                      "description": "群内用户的数量",
+                      "example": "1",
+                      "type": "string"
+                    },
+                    "user_manager_id_list": {
+                      "description": "用户管理员 ID 列表，ID 类型与查询参数 user_id_type 一致。",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "video_conference_setting": {
+                      "description": "谁可以发起视频会议",
+                      "enum": [
+                        "only_owner",
+                        "all_members"
+                      ],
+                      "example": "all_members",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Chat detail response"
+          }
+        },
+        "summary": "Get details for one chat",
+        "x-feishu-access-tokens": [
+          "user",
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/get",
+        "x-feishu-scopes": [
+          "im:chat:readonly",
+          "im:chat",
+          "im:chat:read"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      },
+      "put": {
+        "description": "更新群信息。Identity: supports `user` and `bot`.",
+        "operationId": "imChatsUpdate",
+        "parameters": [
+          {
+            "description": "群 ID。获取方式：;;- [创建群](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/create)，从返回结果中获取该群的 chat_id。;- 调用[获取用户或机器人所在的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/list)接口，可以查询用户或机器人所在群的 chat_id。;- 调用[搜索对用户或机器人可见的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/search)，可搜索用户或机器人所在的群、对用户或机器人公开的群的 chat_id。;;**注意**：仅支持群模式为 `group` 的群组 ID。你可以调用[获取群信息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/get)接口，在返回结果中查看 `chat_mode` 参数取值是否为 `group`。",
+            "in": "path",
+            "name": "chat_id",
+            "required": true,
+            "schema": {
+              "description": "群 ID。获取方式：;;- [创建群](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/create)，从返回结果中获取该群的 chat_id。;- 调用[获取用户或机器人所在的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/list)接口，可以查询用户或机器人所在群的 chat_id。;- 调用[搜索对用户或机器人可见的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/search)，可搜索用户或机器人所在的群、对用户或机器人公开的群的 chat_id。;;**注意**：仅支持群模式为 `group` 的群组 ID。你可以调用[获取群信息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/get)接口，在返回结果中查看 `chat_mode` 参数取值是否为 `group`。",
+              "example": "oc_a0553eda9014c201e6969b478895c230",
+              "type": "string"
+            }
+          },
+          {
+            "description": "此次调用中使用的用户ID的类型",
+            "in": "query",
+            "name": "user_id_type",
+            "required": false,
+            "schema": {
+              "description": "此次调用中使用的用户ID的类型",
+              "enum": [
+                "user_id",
+                "union_id",
+                "open_id"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "add_member_permission": {
+                    "description": "谁可以添加群成员，群成员包括用户或机器人;;**可选值有**：;- `only_owner`：仅群主和管理员;- `all_members`：所有成员;;**注意**：`add_member_permission` 和 `share_card_permission` 两个参数必须同步配置。;;- 如果 `add_member_permission` 值为 `only_owner`，则 `share_card_permission` 只能设置为 `not_allowed`。;- 如果 `add_member_permission` 值为`all_members`，则 `share_card_permission` 只能设置为 `allowed`。;;",
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "at_all_permission": {
+                    "description": "谁可以 at 所有人;;**可选值有**：;- `only_owner`：仅群主和管理员;- `all_members`：所有成员",
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "avatar": {
+                    "description": "群头像对应的 Image Key，可通过[上传图片](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/image/create)获取（注意：上传图片的 ==image_type== 需要指定为 ==avatar==）",
+                    "example": "default-avatar_44ae0ca3-e140-494b-956f-78091e348435",
+                    "type": "string"
+                  },
+                  "chat_type": {
+                    "description": "群类型;;**可选值有**：;- `private`：私有群;- `public`：公开群",
+                    "example": "private",
+                    "type": "string"
+                  },
+                  "description": {
+                    "description": "群描述，建议不超过 100 字符",
+                    "example": "测试群描述",
+                    "type": "string"
+                  },
+                  "edit_permission": {
+                    "description": "谁可以编辑群信息;;**可选值有**：;- `only_owner`：仅群主和管理员;- `all_members`：所有成员",
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "group_message_type": {
+                    "description": "群消息形式",
+                    "enum": [
+                      "chat",
+                      "thread"
+                    ],
+                    "example": "chat",
+                    "type": "string"
+                  },
+                  "hide_member_count_setting": {
+                    "description": "隐藏群成员人数设置",
+                    "enum": [
+                      "all_members",
+                      "only_owner"
+                    ],
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "i18n_names": {
+                    "description": "群国际化名称",
+                    "properties": {
+                      "en_us": {
+                        "description": "英文名",
+                        "example": "group chat",
+                        "type": "string"
+                      },
+                      "ja_jp": {
+                        "description": "日文名",
+                        "example": "グループチャット",
+                        "type": "string"
+                      },
+                      "zh_cn": {
+                        "description": "中文名",
+                        "example": "群聊",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "join_message_visibility": {
+                    "description": "成员入群提示消息的可见性;;**可选值有**：;- `only_owner`：仅群主和管理员可见;- `all_members`：所有成员可见;- `not_anyone`：任何人均不可见",
+                    "example": "only_owner",
+                    "type": "string"
+                  },
+                  "labels": {
+                    "description": "群标签",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "leave_message_visibility": {
+                    "description": "成员退群提示消息的可见性;;**可选值有**：;- `only_owner`：仅群主和管理员可见;- `all_members`：所有成员可见;- `not_anyone`：任何人均不可见",
+                    "example": "only_owner",
+                    "type": "string"
+                  },
+                  "membership_approval": {
+                    "description": "加群是否需要审批;;**可选值有**：;- `no_approval_required`：无需审批;- `approval_required`：需要审批",
+                    "example": "no_approval_required",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "群名称;;**注意：** ;- 建议群名称不超过 60 字符;- 公开群名称的长度不得少于 2 个字符",
+                    "example": "群聊",
+                    "type": "string"
+                  },
+                  "owner_id": {
+                    "description": "新群主的用户 ID，不转让群主时无需填写。ID 类型与查询参数 user_id_type 取值一致，ID 类型推荐使用 OpenID，获取方式可参考文档[如何获取 Open ID？](https://open.feishu.cn/document/uAjLw4CM/ugTN1YjL4UTN24CO1UjN/trouble-shooting/how-to-obtain-openid)。",
+                    "example": "4d7a3c6g",
+                    "type": "string"
+                  },
+                  "pin_manage_setting": {
+                    "description": "谁可以管理置顶",
+                    "enum": [
+                      "only_owner",
+                      "all_members"
+                    ],
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "restricted_mode_setting": {
+                    "description": "保密模式设置;;**注意**：保密模式适用于企业旗舰版。适用版本与功能介绍参见[会话保密模式](https://www.feishu.cn/hc/zh-CN/articles/418691056559)。",
+                    "properties": {
+                      "download_has_permission_setting": {
+                        "description": "允许下载消息中图片、视频和文件",
+                        "enum": [
+                          "all_members",
+                          "not_anyone"
+                        ],
+                        "example": "all_members",
+                        "type": "string"
+                      },
+                      "message_has_permission_setting": {
+                        "description": "允许复制和转发消息",
+                        "enum": [
+                          "all_members",
+                          "not_anyone"
+                        ],
+                        "example": "all_members",
+                        "type": "string"
+                      },
+                      "screenshot_has_permission_setting": {
+                        "description": "允许截屏录屏",
+                        "enum": [
+                          "all_members",
+                          "not_anyone"
+                        ],
+                        "example": "all_members",
+                        "type": "string"
+                      },
+                      "status": {
+                        "description": "保密模式是否开启;;**可选值有**：;;- true：开启。设置为 ture 时，`screenshot_has_permission_setting`、`download_has_permission_setting`、`message_has_permission_setting` 不能全为 `all_members`。;- false：不开启。设置为 false 时，`screenshot_has_permission_setting`、`download_has_permission_setting`、`message_has_permission_setting` 不能存在 `not_anyone`。",
+                        "example": "false",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "share_card_permission": {
+                    "description": "是否允许分享群;;**可选值有**：;- `allowed`：允许;- `not_allowed`：不允许;;**注意**：`add_member_permission` 和 `share_card_permission` 两个参数必须同步配置。;;- 如果 `add_member_permission` 值为 `only_owner`，则 `share_card_permission` 只能设置为 `not_allowed`。;- 如果 `add_member_permission` 值为`all_members`，则 `share_card_permission` 只能设置为 `allowed`。",
+                    "example": "allowed",
+                    "type": "string"
+                  },
+                  "toolkit_ids": {
+                    "description": "群快捷组件列表",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "urgent_setting": {
+                    "description": "谁可以加急",
+                    "enum": [
+                      "only_owner",
+                      "all_members"
+                    ],
+                    "example": "all_members",
+                    "type": "string"
+                  },
+                  "video_conference_setting": {
+                    "description": "谁可以发起视频会议",
+                    "enum": [
+                      "only_owner",
+                      "all_members"
+                    ],
+                    "example": "all_members",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "更新群信息。Identity: supports `user` and `bot`.",
+        "x-feishu-access-tokens": [
+          "tenant",
+          "user"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/update",
+        "x-feishu-scopes": [
+          "im:chat",
+          "im:chat:update"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/chats/{chat_id}/link": {
+      "post": {
+        "description": "获取群分享链接。Identity: supports `user` and `bot`; the caller must be in the target chat, must be an owner or admin when chat sharing is restricted to owners/admins, and must belong to the same tenant for internal chats.",
+        "operationId": "imChatsLink",
+        "parameters": [
+          {
+            "description": "群 ID。获取方式：;;- [创建群](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/create)，从返回结果中获取该群的 chat_id。;- 调用[获取用户或机器人所在的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/list)接口，可以查询用户或机器人所在群的 chat_id。;- 调用[搜索对用户或机器人可见的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/search)，可搜索用户或机器人所在的群、对用户或机器人公开的群的 chat_id。;;**注意**：单聊、密聊、团队群不支持分享群链接",
+            "in": "path",
+            "name": "chat_id",
+            "required": true,
+            "schema": {
+              "description": "群 ID。获取方式：;;- [创建群](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/create)，从返回结果中获取该群的 chat_id。;- 调用[获取用户或机器人所在的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/list)接口，可以查询用户或机器人所在群的 chat_id。;- 调用[搜索对用户或机器人可见的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/search)，可搜索用户或机器人所在的群、对用户或机器人公开的群的 chat_id。;;**注意**：单聊、密聊、团队群不支持分享群链接",
+              "example": "oc_a0553eda9014c201e6969b478895c230",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "validity_period": {
+                    "description": "群分享链接有效时长",
+                    "enum": [
+                      "week",
+                      "year",
+                      "permanently"
+                    ],
+                    "example": "week",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "expire_time": {
+                      "description": "分享链接的过期时间，秒级时间戳",
+                      "example": "1609296809",
+                      "type": "string"
+                    },
+                    "is_permanent": {
+                      "description": "分享链接是否永久有效",
+                      "example": "false",
+                      "type": "boolean"
+                    },
+                    "share_link": {
+                      "description": "群分享链接",
+                      "example": "https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=3nf8789-4rfx-427d-a6bf-ed1d2df348aabd",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "获取群分享链接。Identity: supports `user` and `bot`; the caller must be in the target chat, must be an owner or admin when chat sharing is restricted to owners/admins, and must belong to the same tenant for internal chats.",
+        "x-feishu-access-tokens": [
+          "tenant",
+          "user"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/link",
+        "x-feishu-scopes": [
+          "im:chat:readonly",
+          "im:chat",
+          "im:chat:read"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/chats/{chat_id}/members": {
+      "delete": {
+        "description": "将用户或机器人移出群聊。Identity: supports `user` and `bot`; only group owner, admin, or creator bot can remove others; max 50 users or 5 bots per request.",
+        "operationId": "imChatMembersDelete",
+        "parameters": [
+          {
+            "description": "群 ID。获取方式：;;- [创建群](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/create)，从返回结果中获取该群的 chat_id。;- 调用[获取用户或机器人所在的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/list)接口，可以查询用户或机器人所在群的 chat_id。;- 调用[搜索对用户或机器人可见的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/search)，可搜索用户或机器人所在的群、对用户或机器人公开的群的 chat_id。;;**注意**：仅支持群模式为 **群组（group）**、**话题（topic）** 的群组 ID。你可以调用[获取群信息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/get)接口，在返回结果中查看 `chat_mode` 参数取值是否为 `group`、`topic`。",
+            "in": "path",
+            "name": "chat_id",
+            "required": true,
+            "schema": {
+              "description": "群 ID。获取方式：;;- [创建群](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/create)，从返回结果中获取该群的 chat_id。;- 调用[获取用户或机器人所在的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/list)接口，可以查询用户或机器人所在群的 chat_id。;- 调用[搜索对用户或机器人可见的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/search)，可搜索用户或机器人所在的群、对用户或机器人公开的群的 chat_id。;;**注意**：仅支持群模式为 **群组（group）**、**话题（topic）** 的群组 ID。你可以调用[获取群信息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/get)接口，在返回结果中查看 `chat_mode` 参数取值是否为 `group`、`topic`。",
+              "example": "oc_a0553eda9014c201e6969b478895c230",
+              "type": "string"
+            }
+          },
+          {
+            "description": "用户 ID 类型",
+            "in": "query",
+            "name": "member_id_type",
+            "required": false,
+            "schema": {
+              "description": "用户 ID 类型",
+              "enum": [
+                "user_id",
+                "union_id",
+                "open_id",
+                "app_id"
+              ],
+              "example": "open_id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id_list": {
+                    "description": "成员 ID 列表。ID 类型与查询参数 member_id_type 的取值一致。;;- 移除群内的用户时推荐使用 OpenID，获取方式可参考文档[如何获取 Open ID？](https://open.feishu.cn/document/uAjLw4CM/ugTN1YjL4UTN24CO1UjN/trouble-shooting/how-to-obtain-openid)。;- 移除群内的机器人时需填写应用的 App ID，请参考[如何获取应用的 App ID？](https://open.feishu.cn/document/uAjLw4CM/ugTN1YjL4UTN24CO1UjN/trouble-shooting/how-to-obtain-app-id)。;;**注意**：;- 成员列表不可为空。;- 每次请求，最多移除 50 个用户或者 5 个机器人。",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "invalid_id_list": {
+                      "description": "无效成员列表。",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "将用户或机器人移出群聊。Identity: supports `user` and `bot`; only group owner, admin, or creator bot can remove others; max 50 users or 5 bots per request.",
+        "x-feishu-access-tokens": [
+          "user",
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat-members/delete",
+        "x-feishu-scopes": [
+          "im:chat",
+          "im:chat.members:write_only"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      },
+      "get": {
+        "description": "获取群成员列表。Identity: supports `user` and `bot`; the caller must be in the target chat and must belong to the same tenant for internal chats.",
+        "operationId": "imChatMembersGet",
+        "parameters": [
+          {
+            "description": "Feishu chat identifier",
+            "in": "path",
+            "name": "chat_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Identifier type for returned members",
+            "in": "query",
+            "name": "member_id_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "open_id",
+                "union_id",
+                "user_id"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of members to return",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination token from a previous response",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "description": "是否还有更多项",
+                      "example": "true",
+                      "type": "boolean"
+                    },
+                    "items": {
+                      "description": "成员列表",
+                      "items": {
+                        "properties": {
+                          "member_id": {
+                            "description": "成员的用户ID，ID 值与查询参数中的 member_id_type 对应。;;不同 ID 的说明参见 [用户相关的 ID 概念](https://open.feishu.cn/document/home/user-identity-introduction/introduction)",
+                            "example": "4d7a3c6g",
+                            "type": "string"
+                          },
+                          "member_id_type": {
+                            "description": "成员的用户 ID 类型，与查询参数中的 member_id_type 相同。取值为：`open_id`、`user_id`、`union_id`其中之一。",
+                            "example": "user_id",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "名字",
+                            "example": "张三",
+                            "type": "string"
+                          },
+                          "tenant_key": {
+                            "description": "租户Key，为租户在飞书上的唯一标识，用来换取对应的tenant_access_token，也可以用作租户在应用中的唯一标识",
+                            "example": "736588c9260f175d",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "member_total": {
+                      "description": "成员总数",
+                      "example": "2",
+                      "type": "integer"
+                    },
+                    "page_token": {
+                      "description": "分页标记，当 has_more 为 true 时，会同时返回新的 page_token，否则不返回 page_token",
+                      "example": "0",
+                      "type": "string"
+                    },
+                    "security_conf_limit": {
+                      "description": "安全配置支持的最大查询群成员数量",
+                      "example": "100",
+                      "type": "integer"
+                    },
+                    "trigger_security_conf_limit": {
+                      "description": "是否触发了安全配置",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Chat member list response"
+          }
+        },
+        "summary": "List members of a chat",
+        "x-feishu-access-tokens": [
+          "user",
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat-members/get",
+        "x-feishu-scopes": [
+          "im:chat:readonly",
+          "im:chat",
+          "im:chat.group_info:readonly",
+          "im:chat.members:read"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      },
+      "post": {
+        "description": "将用户或机器人拉入群聊。Identity: supports `user` and `bot`; the caller must be in the target chat; for `bot` calls, added users must be within the app's availability; for internal chats the operator must belong to the same tenant; if only owners/admins can add members, the caller must be an owner/admin, or a chat-creator bot with `im:chat:operate_as_owner`.",
+        "operationId": "imChatMembersCreate",
+        "parameters": [
+          {
+            "description": "群 ID。获取方式：;;- [创建群](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/create)，从返回结果中获取该群的 chat_id。;- 调用[获取用户或机器人所在的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/list)接口，可以查询用户或机器人所在群的 chat_id。;- 调用[搜索对用户或机器人可见的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/search)，可搜索用户或机器人所在的群、对用户或机器人公开的群的 chat_id。;;**注意**：仅支持群模式为 **群组（group）**、**话题（topic）** 的群组 ID。你可以调用[获取群信息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/get)接口，在返回结果中查看 `chat_mode` 参数取值是否为 `group`、`topic`。",
+            "in": "path",
+            "name": "chat_id",
+            "required": true,
+            "schema": {
+              "description": "群 ID。获取方式：;;- [创建群](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/create)，从返回结果中获取该群的 chat_id。;- 调用[获取用户或机器人所在的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/list)接口，可以查询用户或机器人所在群的 chat_id。;- 调用[搜索对用户或机器人可见的群列表](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/search)，可搜索用户或机器人所在的群、对用户或机器人公开的群的 chat_id。;;**注意**：仅支持群模式为 **群组（group）**、**话题（topic）** 的群组 ID。你可以调用[获取群信息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/get)接口，在返回结果中查看 `chat_mode` 参数取值是否为 `group`、`topic`。",
+              "example": "oc_a0553eda9014c201e6969b478895c230",
+              "type": "string"
+            }
+          },
+          {
+            "description": "用户 ID 类型",
+            "in": "query",
+            "name": "member_id_type",
+            "required": false,
+            "schema": {
+              "description": "用户 ID 类型",
+              "enum": [
+                "user_id",
+                "union_id",
+                "open_id",
+                "app_id"
+              ],
+              "example": "open_id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "出现不可用ID后的处理方式 0/1/2;;**默认值**：`0`",
+            "in": "query",
+            "name": "succeed_type",
+            "required": false,
+            "schema": {
+              "description": "出现不可用ID后的处理方式 0/1/2;;**默认值**：`0`",
+              "enum": [
+                "0",
+                "1",
+                "2"
+              ],
+              "example": "0",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "id_list": {
+                    "description": "成员 ID 列表。;;- 邀请用户进群时推荐使用 OpenID，获取方式可参考文档[如何获取 Open ID？](https://open.feishu.cn/document/uAjLw4CM/ugTN1YjL4UTN24CO1UjN/trouble-shooting/how-to-obtain-openid);;- 邀请机器人进群时需填写应用的 App ID，请参考[如何获取应用的 App ID？](https://open.feishu.cn/document/uAjLw4CM/ugTN1YjL4UTN24CO1UjN/trouble-shooting/how-to-obtain-app-id);;**注意**：;- 成员列表不可为空;- 列表中填写的成员 ID 类型应与 ==member_id_type== 参数中选择的类型相对应;- 每次请求最多拉 50 个用户且不超过群人数上限。对于已认证企业的飞书的群人数默认上限：普通群 5000 人，会议群 3000 人，话题群 5000 人。若租户管理员配置了群人数上限，则群人数上限为该人数上限;- 最多同时邀请 5 个机器人，且邀请后群组中机器人数量不能超过 15 个",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "invalid_id_list": {
+                      "description": "无效成员列表;;**注意**：;- 当`success_type` 取值为 `0`时，`invalid_id_list`只包含已离职的用户ID;- 当`success_type` 取值为 `1`时，`invalid_id_list`中包含已离职的、不可见的、应用未激活的 ID",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "not_existed_id_list": {
+                      "description": "ID 不存在的成员列表",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "pending_approval_id_list": {
+                      "description": "等待群主或管理员审批的成员 ID 列表",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "将用户或机器人拉入群聊。Identity: supports `user` and `bot`; the caller must be in the target chat; for `bot` calls, added users must be within the app's availability; for internal chats the operator must belong to the same tenant; if only owners/admins can add members, the caller must be an owner/admin, or a chat-creator bot with `im:chat:operate_as_owner`.",
+        "x-feishu-access-tokens": [
+          "user",
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat-members/create",
+        "x-feishu-scopes": [
+          "im:chat",
+          "im:chat.members:write_only"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/chats/{chat_id}/members/bots": {
+      "get": {
+        "description": "获取群内机器人列表。Identity: supports `user` and `bot`; the caller must be in the target chat and must belong to the same tenant for internal chats.",
+        "operationId": "imChatMembersBots",
+        "parameters": [
+          {
+            "description": "群ID",
+            "in": "path",
+            "name": "chat_id",
+            "required": true,
+            "schema": {
+              "description": "群ID",
+              "example": "oc_a0553eda9014c201e6969b478895c230",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "items": {
+                      "description": "机器人列表",
+                      "items": {
+                        "properties": {
+                          "bot_id": {
+                            "description": "机器人的 open_id",
+                            "example": "ou_a0553eda9014c201e6969b478895c230",
+                            "type": "string"
+                          },
+                          "bot_name": {
+                            "description": "机器人名称",
+                            "example": "值班机器人",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "获取群内机器人列表。Identity: supports `user` and `bot`; the caller must be in the target chat and must belong to the same tenant for internal chats.",
+        "x-feishu-access-tokens": [
+          "user",
+          "tenant"
+        ],
+        "x-feishu-scopes": [
+          "im:chat:readonly",
+          "im:chat",
+          "im:chat.group_info:readonly",
+          "im:chat.members:read"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/files": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadFileRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "File upload response"
+          }
+        },
+        "summary": "Upload a file and receive a file_key"
+      }
+    },
+    "/im/v1/images": {
+      "post": {
+        "description": "上传图片。Identity: `bot` only (`tenant_access_token`).",
+        "operationId": "imImagesCreate",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadImageRequest",
+                "properties": {
+                  "image": {
+                    "description": "图片内容。传值方式可以参考请求体示例。;;**注意**：;;- 上传的图片大小不能超过 10 MB，也不能上传大小为 0 的图片。;- 分辨率限制：;\t- GIF 图片分辨率不能超过 2000 x 2000，其他图片分辨率不能超过 12000 x 12000。;\t- 用于设置头像的图片分辨率不能超过 4096 x 4096。",
+                    "example": "二进制文件",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "image_type": {
+                    "description": "图片类型",
+                    "enum": [
+                      "message",
+                      "avatar"
+                    ],
+                    "example": "message",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "image",
+                  "image_type"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "image_key": {
+                      "description": "图片的 Key",
+                      "example": "img_8d5181ca-0aed-40f0-b0d1-b1452132afbg",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Image upload response"
+          }
+        },
+        "summary": "Upload an image and receive an image_key",
+        "x-feishu-access-tokens": [
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/image/create",
+        "x-feishu-scopes": [
+          "im:resource:upload",
+          "im:resource"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/messages": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Container type used for the lookup",
+            "in": "query",
+            "name": "container_id_type",
+            "required": true,
+            "schema": {
+              "enum": [
+                "chat"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Chat identifier whose history should be returned",
+            "in": "query",
+            "name": "container_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort order for the message history",
+            "in": "query",
+            "name": "sort_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ByCreateTimeAsc",
+                "ByCreateTimeDesc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of messages to return",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "maximum": 50,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination token from a previous response",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive start time filter, typically epoch milliseconds as a string",
+            "in": "query",
+            "name": "start_time",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive end time filter, typically epoch milliseconds as a string",
+            "in": "query",
+            "name": "end_time",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Message history response"
+          }
+        },
+        "summary": "List historical messages for a container"
+      },
+      "post": {
+        "parameters": [
+          {
+            "description": "Identifier type for the receive_id field",
+            "in": "query",
+            "name": "receive_id_type",
+            "required": true,
+            "schema": {
+              "enum": [
+                "open_id",
+                "user_id",
+                "union_id",
+                "chat_id",
+                "email"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Send message response"
+          }
+        },
+        "summary": "Send a message to a user, chat, or thread target"
+      }
+    },
+    "/im/v1/messages/merge_forward": {
+      "post": {
+        "description": "合并转发消息。Identity: `bot` only (`tenant_access_token`).",
+        "operationId": "imMessagesMergeForward",
+        "parameters": [
+          {
+            "description": "消息接收者 ID 类型。",
+            "in": "query",
+            "name": "receive_id_type",
+            "required": true,
+            "schema": {
+              "description": "消息接收者 ID 类型。",
+              "enum": [
+                "open_id",
+                "user_id",
+                "union_id",
+                "email",
+                "chat_id",
+                "thread_id"
+              ],
+              "example": "open_id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "自定义设置的唯一字符串序列，用于在合并转发消息时请求去重。持有相同 uuid 的请求，在 1 小时内向同一目标的合并转发只可成功一次。",
+            "in": "query",
+            "name": "uuid",
+            "required": false,
+            "schema": {
+              "description": "自定义设置的唯一字符串序列，用于在合并转发消息时请求去重。持有相同 uuid 的请求，在 1 小时内向同一目标的合并转发只可成功一次。",
+              "example": "b13g2t38-1jd2-458b-8djf-dtbca5104204",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "message_id_list": {
+                    "description": "待转发的消息 ID 列表，列表内的消息必须来自同一个会话。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "receive_id": {
+                    "description": "消息接收者 ID，ID 类型与 `receive_id_type` 的值一致。",
+                    "example": "oc_a0553eda9014c201e6969b478895c230",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message_id_list",
+                  "receive_id"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "invalid_message_id_list": {
+                      "description": "无效的消息 ID 列表，如不存在的消息、已被撤回的消息、当前操作者不可见的历史消息、接口不支持的消息类型等。",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "message": {
+                      "description": "合并转发生成的新消息。",
+                      "example": "--",
+                      "properties": {
+                        "body": {
+                          "description": "通过 `body` 内的 `content` 参数，返回所发送的消息内容。 ",
+                          "example": "json结构",
+                          "properties": {
+                            "content": {
+                              "description": "消息内容，JSON 结构序列化后的字符串，合并转发生成的新消息的消息内容为固定值==Merged and Forwarded Message==，其中的子消息可以使用[获取指定消息的内容](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/get)接口获取。",
+                              "example": "Merged and Forwarded Message",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "content"
+                          ],
+                          "type": "object"
+                        },
+                        "chat_id": {
+                          "description": "消息所属的群 ID。你可以调用[获取群信息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/get)接口，根据群 ID 获取群详情。",
+                          "example": "oc_5ad11d72b830411d72b836c20",
+                          "type": "string"
+                        },
+                        "create_time": {
+                          "description": "消息生成的时间戳。单位：毫秒",
+                          "example": "1615380573411",
+                          "type": "string"
+                        },
+                        "deleted": {
+                          "description": "消息是否被撤回。返回 false 表示未被撤回。",
+                          "example": "false",
+                          "type": "boolean"
+                        },
+                        "mentions": {
+                          "description": "发送的消息内，被 @ 的用户或机器人列表。",
+                          "items": {
+                            "properties": {
+                              "id": {
+                                "description": "被 @ 的用户或者机器人的 open_id。",
+                                "example": "ou_155184d1e73cbfb8973e5a9e698e74f2",
+                                "type": "string"
+                              },
+                              "id_type": {
+                                "description": "被 @ 的用户或机器人 ID 类型，目前仅支持 `open_id` ([什么是 Open ID](https://open.feishu.cn/document/home/user-identity-introduction/open-id))。",
+                                "example": "open_id",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "被 @ 的用户或机器人序号。例如，第 3 个被 @ 到的成员，取值为 `@_user_3`。",
+                                "example": "@_user_1",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "被 @ 的用户或机器人的姓名。",
+                                "example": "Tom",
+                                "type": "string"
+                              },
+                              "tenant_key": {
+                                "description": "租户唯一标识。该标识用来识别被 @ 用户或机器人的租户，也可以用来获取租户访问凭证（tenant_access_token）。",
+                                "example": "736588c9260f175e",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "id_type",
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "message_app_link": {
+                          "description": "消息跳转链接",
+                          "example": "https://xxxx/client/thread/open?chatid=xxx&threadid=xxx&thread_position=xxx",
+                          "type": "string"
+                        },
+                        "message_id": {
+                          "description": "消息 ID。合并转发后由系统自动生成的消息唯一标识。后续对消息的管理维护操作均需要使用该 ID。",
+                          "example": "om_dc13264520392913993dd051dba21dcf",
+                          "type": "string"
+                        },
+                        "msg_type": {
+                          "description": "消息类型，取值 merge_forward 表示合并转发消息。了解消息类型定义，参考[接收消息内容](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/im-v1/message/events/message_content)。",
+                          "example": "merge_forward",
+                          "type": "string"
+                        },
+                        "parent_id": {
+                          "description": "父消息 ID，仅在回复消息场景会有返回值。了解 parent_id 可参见[消息管理概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/intro)。",
+                          "example": "om_d4be107c616aed9c1da8ed8068570a9f",
+                          "type": "string"
+                        },
+                        "root_id": {
+                          "description": "根消息 ID，仅在回复消息场景会有返回值。了解 root_id 可参见[消息管理概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/intro)。",
+                          "example": "om_40eb06e7b84dc71c03e009ad3c754195",
+                          "type": "string"
+                        },
+                        "sender": {
+                          "description": "消息的发送者信息。",
+                          "example": "object",
+                          "properties": {
+                            "id": {
+                              "description": "发送者的 ID。",
+                              "example": "cli_9f427eec54ae901b",
+                              "type": "string"
+                            },
+                            "id_type": {
+                              "description": "发送者的 ID 类型。;;**可能值有：**;- `open_id`：表示发送者为用户，且返回的 ID 是用户的 open_id。;- `app_id`：表示发送者为应用，切返回的 ID 是应用的 app_id。",
+                              "example": "app_id",
+                              "type": "string"
+                            },
+                            "sender_name": {
+                              "description": "该字段标识发送者的名称",
+                              "type": "string"
+                            },
+                            "sender_type": {
+                              "description": "发送者类型。;;**可能值有：**;- `user`: 用户;- `app`: 应用;- `anonymous`: 匿名;- `unknown`: 未知",
+                              "example": "app",
+                              "type": "string"
+                            },
+                            "tenant_key": {
+                              "description": "租户唯一标识。该标识用来识别租户，也可以用来获取租户访问凭证（tenant_access_token）。",
+                              "example": "736588c9260f175e",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "id_type",
+                            "sender_type"
+                          ],
+                          "type": "object"
+                        },
+                        "thread_id": {
+                          "description": "消息所属的话题 ID（不返回说明该消息非话题消息），了解话题可参见[话题概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/thread-introduction)。",
+                          "example": "omt_d4be107c616a",
+                          "type": "string"
+                        },
+                        "update_time": {
+                          "description": "消息更新的时间戳。单位：毫秒",
+                          "example": "1615380573411",
+                          "type": "string"
+                        },
+                        "updated": {
+                          "description": "消息是否被更新。返回 false 表示未被更新。",
+                          "example": "false",
+                          "type": "boolean"
+                        },
+                        "upper_message_id": {
+                          "description": "合并转发消息中，上一层级的消息 ID。了解 upper_message_id 可参见[消息管理概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/intro)。",
+                          "example": "om_40eb06e7b84dc71c03e009ad3c754195",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "合并转发消息。Identity: `bot` only (`tenant_access_token`).",
+        "x-feishu-access-tokens": [
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/api-explorer?from=op_doc_tab&apiName=merge_forward&project=im&resource=message&version=v1",
+        "x-feishu-scopes": [
+          "im:message:send_as_bot",
+          "im:message"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/messages/reactions/batch_query": {
+      "post": {
+        "description": "批量获取消息表情。Identity: supports `user` and `bot`.[Must-read](references/lark-im-reactions.md)",
+        "operationId": "imReactionsBatchQuery",
+        "parameters": [
+          {
+            "description": "用户 ID 类型，控制接口返回值中表情添加者的ID",
+            "in": "query",
+            "name": "user_id_type",
+            "required": false,
+            "schema": {
+              "description": "用户 ID 类型，控制接口返回值中表情添加者的ID",
+              "enum": [
+                "user_id",
+                "union_id",
+                "open_id"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "page_size_per_message": {
+                    "description": "每个消息最多返回多少个表情",
+                    "example": "10",
+                    "type": "integer"
+                  },
+                  "queries": {
+                    "description": "要查询的消息",
+                    "items": {
+                      "properties": {
+                        "message_id": {
+                          "description": "消息ID",
+                          "example": "om_8964d1b4*********2b31383276113",
+                          "type": "string"
+                        },
+                        "page_token": {
+                          "description": "分页标记，第一次请求不填，表示从头开始遍历；分页查询结果还有更多项时会同时返回新的 page_token，下次遍历可采用该 page_token 获取查询结果。",
+                          "example": "YhljsPiGfUgnVAg9urvRFd-BvSqRL20",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "reaction_type": {
+                    "description": "表情类型",
+                    "example": "LAUGH",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "queries"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "fail_msg_reaction_details": {
+                      "description": "未成功获取的消息",
+                      "items": {
+                        "properties": {
+                          "fail_reason": {
+                            "description": "获取表情失败的原因",
+                            "enum": [
+                              "invalid",
+                              "invalid_page_token",
+                              "no_permission"
+                            ],
+                            "type": "string"
+                          },
+                          "message_id": {
+                            "description": "消息id",
+                            "example": "om_8964d1b4*********2b31383276113",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "success_msg_reaction_counts": {
+                      "description": "成功获取到的表情数量统计",
+                      "items": {
+                        "properties": {
+                          "message_id": {
+                            "description": "消息ID",
+                            "example": "om_8964d1b4*********2b31383276113",
+                            "type": "string"
+                          },
+                          "reaction_count": {
+                            "description": "消息上不同表情的数量",
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "description": "表情数量",
+                                  "example": "20",
+                                  "type": "string"
+                                },
+                                "reaction_type": {
+                                  "description": "表情类型",
+                                  "example": "LAUGH",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "success_msg_reaction_details": {
+                      "description": "成功获取到的表情列表",
+                      "items": {
+                        "properties": {
+                          "has_more": {
+                            "description": "是否还有更多项",
+                            "type": "boolean"
+                          },
+                          "message_id": {
+                            "description": "消息id",
+                            "example": "om_a8f2294b************a1a38afaac9d",
+                            "type": "string"
+                          },
+                          "message_reaction_items": {
+                            "description": "表情实体",
+                            "items": {
+                              "properties": {
+                                "action_time": {
+                                  "description": "表情添加时间",
+                                  "example": "1626086391570",
+                                  "type": "string"
+                                },
+                                "emoji_type": {
+                                  "description": "表情类型",
+                                  "example": "SMILE",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "操作者信息",
+                                  "type": "object"
+                                },
+                                "reaction_id": {
+                                  "description": "表情ID",
+                                  "example": "ZCaCIjUBVVWSrm5L-3ZTw****",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "page_token": {
+                            "description": "分页标记，当 has_more 为 true 时，会同时返回新的 page_token，否则不返回 page_token",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "批量获取消息表情。Identity: supports `user` and `bot`.[Must-read](references/lark-im-reactions.md)",
+        "x-feishu-access-tokens": [
+          "user",
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/api-explorer?from=op_doc_tab&apiName=batch_query&project=im&resource=message.reaction&version=v1",
+        "x-feishu-scopes": [
+          "im:message:readonly",
+          "im:message.reactions:read"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/messages/{message_id}": {
+      "delete": {
+        "description": "撤回消息。Identity: supports `user` and `bot`; for `bot` calls, the bot must be in the chat to revoke group messages; to revoke another user's group message, the bot must be the owner, an admin, or the creator; for user P2P recalls, the target user must be within the bot's availability.",
+        "operationId": "imMessagesDelete",
+        "parameters": [
+          {
+            "description": "待撤回的消息 ID。;;ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "待撤回的消息 ID。;;ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+              "example": "om_dc13264520392913993dd051dba21dcf",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "撤回消息。Identity: supports `user` and `bot`; for `bot` calls, the bot must be in the chat to revoke group messages; to revoke another user's group message, the bot must be the owner, an admin, or the creator; for user P2P recalls, the target user must be within the bot's availability.",
+        "x-feishu-access-tokens": [
+          "tenant",
+          "user"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/delete",
+        "x-feishu-scopes": [
+          "im:message:recall",
+          "im:message",
+          "im:message:send_as_bot"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      },
+      "get": {
+        "parameters": [
+          {
+            "description": "Feishu message identifier",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Message detail response"
+          }
+        },
+        "summary": "Get one message by ID"
+      }
+    },
+    "/im/v1/messages/{message_id}/forward": {
+      "post": {
+        "description": "转发消息。Identity: supports `user` and `bot`.",
+        "operationId": "imMessagesForward",
+        "parameters": [
+          {
+            "description": "待转发的消息 ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "待转发的消息 ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+              "example": "om_dc13264520392913993dd051dba21dcf",
+              "type": "string"
+            }
+          },
+          {
+            "description": "消息接收者 ID 类型。",
+            "in": "query",
+            "name": "receive_id_type",
+            "required": true,
+            "schema": {
+              "description": "消息接收者 ID 类型。",
+              "enum": [
+                "open_id",
+                "user_id",
+                "union_id",
+                "email",
+                "chat_id",
+                "thread_id"
+              ],
+              "example": "open_id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "自定义设置的唯一字符串序列，用于在转发消息时请求去重。持有相同 uuid 的请求，在 1 小时内向同一目标的转发只可成功一次。",
+            "in": "query",
+            "name": "uuid",
+            "required": false,
+            "schema": {
+              "description": "自定义设置的唯一字符串序列，用于在转发消息时请求去重。持有相同 uuid 的请求，在 1 小时内向同一目标的转发只可成功一次。",
+              "example": "b13g2t38-1jd2-458b-8djf-dtbca5104204",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "receive_id": {
+                    "description": "消息接收者 ID，ID 类型与 `receive_id_type` 的值一致。",
+                    "example": "ou_a0553eda9014c201e6969b478895c230",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "receive_id"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "body": {
+                      "description": "通过 `body` 内的 `content` 参数，返回所发送的消息内容。 ",
+                      "example": "json结构",
+                      "properties": {
+                        "content": {
+                          "description": "消息内容，JSON 结构序列化后的字符串，不同消息类型（`msg_type`）对应不同内容。",
+                          "example": "{\\\"text\\\":\\\"@_user_1 test content\\\"}",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "content"
+                      ],
+                      "type": "object"
+                    },
+                    "chat_id": {
+                      "description": "消息所属的群 ID。你可以调用[获取群信息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/get)接口，根据群 ID 获取群详情。",
+                      "example": "oc_5ad11d72b830411d72b836c20",
+                      "type": "string"
+                    },
+                    "create_time": {
+                      "description": "消息生成的时间戳。单位：毫秒",
+                      "example": "1615380573411",
+                      "type": "string"
+                    },
+                    "deleted": {
+                      "description": "消息是否被撤回。返回 false 表示未被撤回。",
+                      "example": "false",
+                      "type": "boolean"
+                    },
+                    "mentions": {
+                      "description": "发送的消息内，被 @ 的用户或机器人列表。",
+                      "items": {
+                        "properties": {
+                          "id": {
+                            "description": "被 @ 的用户或者机器人的 open_id。",
+                            "example": "ou_155184d1e73cbfb8973e5a9e698e74f2",
+                            "type": "string"
+                          },
+                          "id_type": {
+                            "description": "被 @ 的用户或机器人 ID 类型，目前仅支持 `open_id` ([什么是 Open ID](https://open.feishu.cn/document/home/user-identity-introduction/open-id))。",
+                            "example": "open_id",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "被 @ 的用户或机器人序号。例如，第 3 个被 @ 到的成员，取值为 `@_user_3`。",
+                            "example": "@_user_1",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "被 @ 的用户或机器人的姓名。",
+                            "example": "Tom",
+                            "type": "string"
+                          },
+                          "tenant_key": {
+                            "description": "租户唯一标识。该标识用来识别被 @ 用户或机器人的租户，也可以用来获取租户访问凭证（tenant_access_token）。",
+                            "example": "736588c9260f175e",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "id_type",
+                          "key",
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "message_app_link": {
+                      "description": "消息跳转链接",
+                      "example": "https://xxxx/client/thread/open?chatid=xxx&threadid=xxx&thread_position=xxx",
+                      "type": "string"
+                    },
+                    "message_id": {
+                      "description": "消息 ID。消息转发后，由系统自动生成的消息唯一标识。后续对消息的管理维护操作均需要使用该 ID。",
+                      "example": "om_dc13264520392913993dd051dba21dcf",
+                      "type": "string"
+                    },
+                    "msg_type": {
+                      "description": "消息类型。包括 text、post、image、file、audio、media、sticker、interactive、share_chat、share_user 等。各类型定义参考[接收消息内容](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/im-v1/message/events/message_content)。",
+                      "example": "text",
+                      "type": "string"
+                    },
+                    "parent_id": {
+                      "description": "父消息 ID，仅在回复消息场景会有返回值。了解 parent_id 可参见[消息管理概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/intro)。",
+                      "example": "om_d4be107c616aed9c1da8ed8068570a9f",
+                      "type": "string"
+                    },
+                    "root_id": {
+                      "description": "根消息 ID，仅在回复消息场景会有返回值。了解 root_id 可参见[消息管理概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/intro)。",
+                      "example": "om_40eb06e7b84dc71c03e009ad3c754195",
+                      "type": "string"
+                    },
+                    "sender": {
+                      "description": "消息的发送者信息。",
+                      "example": "object",
+                      "properties": {
+                        "id": {
+                          "description": "发送者的 ID。",
+                          "example": "cli_9f427eec54ae901b",
+                          "type": "string"
+                        },
+                        "id_type": {
+                          "description": "发送者的 ID 类型。;;**可能值有：**;- `open_id`：表示发送者为用户，且返回的 ID 是用户的 open_id。;- `app_id`：表示发送者为应用，切返回的 ID 是应用的 app_id。",
+                          "example": "app_id",
+                          "type": "string"
+                        },
+                        "sender_name": {
+                          "description": "该字段标识发送者的名称",
+                          "type": "string"
+                        },
+                        "sender_type": {
+                          "description": "发送者类型。;;**可能值有：**;- `user`: 用户;- `app`: 应用;- `anonymous`: 匿名;- `unknown`: 未知",
+                          "example": "app",
+                          "type": "string"
+                        },
+                        "tenant_key": {
+                          "description": "租户唯一标识。该标识用来识别租户，也可以用来获取租户访问凭证（tenant_access_token）。",
+                          "example": "736588c9260f175e",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "id_type",
+                        "sender_type"
+                      ],
+                      "type": "object"
+                    },
+                    "thread_id": {
+                      "description": "消息所属的话题 ID（不返回说明该消息非话题消息），了解话题可参见[话题概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/thread-introduction)。",
+                      "example": "omt_d4be107c616a",
+                      "type": "string"
+                    },
+                    "update_time": {
+                      "description": "消息更新的时间戳。单位：毫秒",
+                      "example": "1615380573411",
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "消息是否被更新。返回 false 表示未被更新。",
+                      "example": "false",
+                      "type": "boolean"
+                    },
+                    "upper_message_id": {
+                      "description": "合并转发消息中，上一层级的消息 ID，仅在合并转发场景会有返回值。了解 upper_message_id 可参见[消息管理概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/intro)。",
+                      "example": "om_40eb06e7b84dc71c03e009ad3c754195",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "转发消息。Identity: supports `user` and `bot`.",
+        "x-feishu-access-tokens": [
+          "user",
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/api-explorer?from=op_doc_tab&apiName=forward&project=im&resource=message&version=v1",
+        "x-feishu-scopes": [
+          "im:message:send_as_bot",
+          "im:message"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/messages/{message_id}/reactions": {
+      "get": {
+        "description": "获取消息表情回复。Identity: supports `user` and `bot`; the caller must be in the conversation that contains the message.[Must-read](references/lark-im-reactions.md)",
+        "operationId": "imReactionsList",
+        "parameters": [
+          {
+            "description": "待查询的消息ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "待查询的消息ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+              "example": "om_8964d1b4*********2b31383276113",
+              "type": "string"
+            }
+          },
+          {
+            "description": "分页大小，用于限制一次请求返回的数据条目数。;;**默认值**：20",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "description": "分页大小，用于限制一次请求返回的数据条目数。;;**默认值**：20",
+              "example": "10",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "分页标记，第一次请求不填，表示从头开始遍历；分页查询结果还有更多项时，会同时返回新的 page_token，下次遍历可采用该 page_token 获取查询结果",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "description": "分页标记，第一次请求不填，表示从头开始遍历；分页查询结果还有更多项时，会同时返回新的 page_token，下次遍历可采用该 page_token 获取查询结果",
+              "example": "YhljsPiGfUgnVAg9urvRFd-BvSqRL20wMZNAWfa9xXkud6UKCybPuUgQ1vM26dj6",
+              "type": "string"
+            }
+          },
+          {
+            "description": "待查询的表情类型，支持的枚举值参考[表情文案说明](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce)中的 emoji_type 值。;;**注意**：该参数为可选参数，不传入该参数时将查询消息内所有的表情回复。",
+            "in": "query",
+            "name": "reaction_type",
+            "required": false,
+            "schema": {
+              "description": "待查询的表情类型，支持的枚举值参考[表情文案说明](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce)中的 emoji_type 值。;;**注意**：该参数为可选参数，不传入该参数时将查询消息内所有的表情回复。",
+              "example": "LAUGH",
+              "type": "string"
+            }
+          },
+          {
+            "description": "当操作人为用户时返回用户ID的类型",
+            "in": "query",
+            "name": "user_id_type",
+            "required": false,
+            "schema": {
+              "description": "当操作人为用户时返回用户ID的类型",
+              "enum": [
+                "open_id",
+                "union_id",
+                "user_id"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "description": "是否还有更多项",
+                      "example": "true",
+                      "type": "boolean"
+                    },
+                    "items": {
+                      "description": "表情回复列表。",
+                      "items": {
+                        "properties": {
+                          "action_time": {
+                            "description": "添加消息表情回复的时间。Unix 时间戳，单位：ms",
+                            "example": "1663054162546",
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "添加表情回复的操作人",
+                            "properties": {
+                              "operator_id": {
+                                "description": "操作人 ID，具体的取值与 `operator_type` 相关：;      ;- 当 `operator_type` 取值 `app` 时返回机器人的应用 ID（app_id）。;- 当 `operator_type` 取值 `user` 时返回用户的 ID（ID 类型与查询参数 `user_id_type` 的取值一致）。",
+                                "example": "ou_ff0b7ba35fb********67dfc8b885136",
+                                "type": "string"
+                              },
+                              "operator_type": {
+                                "description": "操作人身份。",
+                                "enum": [
+                                  "app",
+                                  "user"
+                                ],
+                                "example": "app/user",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "operator_id",
+                              "operator_type"
+                            ],
+                            "type": "object"
+                          },
+                          "reaction_id": {
+                            "description": "表情回复 ID。",
+                            "example": "ZCaCIjUBVVWSrm5L-3ZTw*************sNa8dHVplEzzSfJVUVLMLcS_",
+                            "type": "string"
+                          },
+                          "reaction_type": {
+                            "description": "表情类型",
+                            "properties": {
+                              "emoji_type": {
+                                "description": "emoji 类型。emoji_type 值对应的表情参考[表情文案说明](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce)。",
+                                "example": "SMILE",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "emoji_type"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page_token": {
+                      "description": "分页标记，当 has_more 为 true 时，会同时返回新的 page_token，否则不返回 page_token",
+                      "example": "YhljsPiGfUgnVAg9urvRFd-BvSqRL****",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "has_more",
+                    "items",
+                    "page_token"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "获取消息表情回复。Identity: supports `user` and `bot`; the caller must be in the conversation that contains the message.[Must-read](references/lark-im-reactions.md)",
+        "x-feishu-access-tokens": [
+          "user",
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/list",
+        "x-feishu-scopes": [
+          "im:message:readonly",
+          "im:message.reactions:read"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      },
+      "post": {
+        "description": "添加消息表情回复。Identity: supports `user` and `bot`; the caller must be in the conversation that contains the message.[Must-read](references/lark-im-reactions.md)",
+        "operationId": "imReactionsCreate",
+        "parameters": [
+          {
+            "description": "待添加表情回复的消息 ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "待添加表情回复的消息 ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+              "example": "om_a8f2294b************a1a38afaac9d",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "reaction_type": {
+                    "description": "表情回复的资源类型。",
+                    "properties": {
+                      "emoji_type": {
+                        "description": "emoji 类型。支持的表情与对应的 emoji_type 值参见[表情文案说明](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce)。;",
+                        "example": "SMILE",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "emoji_type"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "reaction_type"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "action_time": {
+                      "description": "添加消息表情回复的时间。Unix 时间戳，单位：ms",
+                      "example": "1663054162546",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "添加消息表情回复的操作人。",
+                      "properties": {
+                        "operator_id": {
+                          "description": "操作人 ID，具体的取值与 `operator_type` 相关：;      ;- 当 `operator_type` 取值 `app` 时返回机器人的应用 ID（app_id）。;- 当 `operator_type` 取值 `user` 时返回用户的 open_id。",
+                          "example": "ou_ff0b7ba35fb********67dfc8b885136",
+                          "type": "string"
+                        },
+                        "operator_type": {
+                          "description": "操作人身份。",
+                          "enum": [
+                            "app",
+                            "user"
+                          ],
+                          "example": "app/user",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "operator_id",
+                        "operator_type"
+                      ],
+                      "type": "object"
+                    },
+                    "reaction_id": {
+                      "description": "表情回复 ID。为消息添加表情回复后，会获得该表情回复的唯一标识 ID，后续使用该 ID 可以[删除消息表情回复](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/delete)。",
+                      "example": "ZCaCIjUBVVWSrm5L-3ZTw*************sNa8dHVplEzzSfJVUVLMLcS_",
+                      "type": "string"
+                    },
+                    "reaction_type": {
+                      "description": "表情类型",
+                      "properties": {
+                        "emoji_type": {
+                          "description": "emoji 类型。emoji_type 值对应的表情参考[表情文案说明](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce)。",
+                          "example": "SMILE",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "emoji_type"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "添加消息表情回复。Identity: supports `user` and `bot`; the caller must be in the conversation that contains the message.[Must-read](references/lark-im-reactions.md)",
+        "x-feishu-access-tokens": [
+          "user",
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/create",
+        "x-feishu-scopes": [
+          "im:message",
+          "im:message.reactions:write_only"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/messages/{message_id}/reactions/{reaction_id}": {
+      "delete": {
+        "description": "删除消息表情回复。Identity: supports `user` and `bot`; the caller must be in the conversation that contains the message, and can only delete reactions added by itself.[Must-read](references/lark-im-reactions.md)",
+        "operationId": "imReactionsDelete",
+        "parameters": [
+          {
+            "description": "待删除表情回复的消息 ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "待删除表情回复的消息 ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+              "example": "om_8964d1b4*********2b31383276113",
+              "type": "string"
+            }
+          },
+          {
+            "description": "待删除的表情回复 ID，该 ID 获取方式：;;- 调用[添加消息表情回复](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/create)接口添加表情回复后，在返回结果中获取。;;- 调用[获取消息表情回复](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/list)接口，获取某一表情回复的 ID。",
+            "in": "path",
+            "name": "reaction_id",
+            "required": true,
+            "schema": {
+              "description": "待删除的表情回复 ID，该 ID 获取方式：;;- 调用[添加消息表情回复](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/create)接口添加表情回复后，在返回结果中获取。;;- 调用[获取消息表情回复](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/list)接口，获取某一表情回复的 ID。",
+              "example": "ZCaCIjUBVVWSrm5L-3ZTw*************sNa8dHVplEzzSfJVUVLMLcS_",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "action_time": {
+                      "description": "添加消息表情回复的时间。Unix 时间戳，单位：ms",
+                      "example": "1626086391570",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "添加表情回复的操作人。",
+                      "properties": {
+                        "operator_id": {
+                          "description": "操作人 ID，具体的取值与 `operator_type` 相关：;      ;- 当 `operator_type` 取值 `app` 时返回机器人的应用 ID（app_id）。;- 当 `operator_type` 取值 `user` 时返回用户的 open_id。",
+                          "example": "ou_ff0b7ba35fb********67dfc8b885136",
+                          "type": "string"
+                        },
+                        "operator_type": {
+                          "description": "操作人身份。",
+                          "enum": [
+                            "app",
+                            "user"
+                          ],
+                          "example": "app/user",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "operator_id",
+                        "operator_type"
+                      ],
+                      "type": "object"
+                    },
+                    "reaction_id": {
+                      "description": "表情回复 ID。",
+                      "example": "ZCaCIjUBVVWSrm5L-3ZTw*************sNa8dHVplEzzSfJVUVLMLcS_",
+                      "type": "string"
+                    },
+                    "reaction_type": {
+                      "description": "表情类型",
+                      "properties": {
+                        "emoji_type": {
+                          "description": "emoji 类型。emoji_type 值对应的表情参考[表情文案说明](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce)。",
+                          "example": "SMILE",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "emoji_type"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "删除消息表情回复。Identity: supports `user` and `bot`; the caller must be in the conversation that contains the message, and can only delete reactions added by itself.[Must-read](references/lark-im-reactions.md)",
+        "x-feishu-access-tokens": [
+          "user",
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/delete",
+        "x-feishu-scopes": [
+          "im:message",
+          "im:message.reactions:write_only"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/messages/{message_id}/read_users": {
+      "get": {
+        "description": "查询消息已读信息。Identity: `bot` only (`tenant_access_token`); the bot must be in the chat, and can only query read status for messages it sent within the last 7 days.",
+        "operationId": "imMessagesReadUsers",
+        "parameters": [
+          {
+            "description": "待查询的消息 ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "待查询的消息 ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+              "example": "om_dc13264520392913993dd051dba21dcf",
+              "type": "string"
+            }
+          },
+          {
+            "description": "分页大小，用于限制单次请求所返回的数据条目数。",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "description": "分页大小，用于限制单次请求所返回的数据条目数。",
+              "example": "20",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "分页标记，第一次请求不填，表示从头开始遍历；分页查询结果还有更多项时会同时返回新的 page_token，下次遍历可采用该 page_token 获取查询结果",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "description": "分页标记，第一次请求不填，表示从头开始遍历；分页查询结果还有更多项时会同时返回新的 page_token，下次遍历可采用该 page_token 获取查询结果",
+              "example": "GxmvlNRvP0NdQZpa7yIqf_Lv_QuBwTQ8tXkX7w-irAghVD_TvuYd1aoJ1LQph86O-XImC4X9j9FhUPhXQDvtrQ==",
+              "type": "string"
+            }
+          },
+          {
+            "description": "此次调用中使用的用户ID的类型",
+            "in": "query",
+            "name": "user_id_type",
+            "required": true,
+            "schema": {
+              "description": "此次调用中使用的用户ID的类型",
+              "enum": [
+                "user_id",
+                "union_id",
+                "open_id"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "description": "是否还有更多项",
+                      "example": "true",
+                      "type": "boolean"
+                    },
+                    "items": {
+                      "description": "-",
+                      "items": {
+                        "properties": {
+                          "tenant_key": {
+                            "description": "租户唯一标识。该标识用来识别租户，也可以用来获取租户访问凭证（tenant_access_token）。",
+                            "example": "736588c9260f175e",
+                            "type": "string"
+                          },
+                          "timestamp": {
+                            "description": "已读消息的时间，毫秒级时间戳。",
+                            "example": "1609484183000",
+                            "type": "string"
+                          },
+                          "user_id": {
+                            "description": "用户 ID，ID 类型与查询参数 user_id_type 取值一致。",
+                            "example": "ou_9b851f7b51a9d58d109982337c46f3de",
+                            "type": "string"
+                          },
+                          "user_id_type": {
+                            "description": "用户id类型",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "timestamp",
+                          "user_id",
+                          "user_id_type"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page_token": {
+                      "description": "分页标记，当 has_more 为 true 时，会同时返回新的 page_token，否则不返回 page_token",
+                      "example": "GxmvlNRvP0NdQZpa7yIqf_Lv_QuBwTQ8tXkX7w-irAghVD_TvuYd1aoJ1LQph86O-XImC4X9j9FhUPhXQDvtrQ==",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "has_more"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "查询消息已读信息。Identity: `bot` only (`tenant_access_token`); the bot must be in the chat, and can only query read status for messages it sent within the last 7 days.",
+        "x-feishu-access-tokens": [
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/read_users",
+        "x-feishu-scopes": [
+          "im:message:basic",
+          "im:message:readonly",
+          "im:message"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/messages/{message_id}/reply": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Message identifier to reply to",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReplyMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Reply message response"
+          }
+        },
+        "summary": "Reply to an existing message"
+      }
+    },
+    "/im/v1/pins": {
+      "get": {
+        "description": "获取群内 Pin 消息。Identity: supports `user` and `bot`.",
+        "operationId": "imPinsList",
+        "parameters": [
+          {
+            "description": "待获取 Pin 消息的群组 ID。获取方式参见[群 ID 说明](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat-id-description)。",
+            "in": "query",
+            "name": "chat_id",
+            "required": true,
+            "schema": {
+              "description": "待获取 Pin 消息的群组 ID。获取方式参见[群 ID 说明](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat-id-description)。",
+              "example": "oc_234jsi43d3ssi993d43545f",
+              "type": "string"
+            }
+          },
+          {
+            "description": "获取 Pin 消息的结束时间，毫秒级时间戳。;;**注意**：;;- 若未传值默认从群聊内最新的 Pin 消息开始获取。;- 传值时需大于 `start_time` 值。",
+            "in": "query",
+            "name": "end_time",
+            "required": false,
+            "schema": {
+              "description": "获取 Pin 消息的结束时间，毫秒级时间戳。;;**注意**：;;- 若未传值默认从群聊内最新的 Pin 消息开始获取。;- 传值时需大于 `start_time` 值。",
+              "example": "1658731646425",
+              "type": "string"
+            }
+          },
+          {
+            "description": "分页大小，用于限制一次请求返回的数据条目数。",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "description": "分页大小，用于限制一次请求返回的数据条目数。",
+              "example": "20",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "下一页分页的token",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "description": "下一页分页的token",
+              "example": "GxmvlNRvP0NdQZpa7yIqf_Lv_QuBwTQ8tXkX7w-irAghVD_TvuYd1aoJ1LQph86O-XImC4X9j9FhUPhXQDvtrQ==",
+              "type": "string"
+            }
+          },
+          {
+            "description": "获取 Pin 消息的起始时间，毫秒级时间戳。;;**注意**：;;- 若未传值默认获取到群聊内最早的 Pin 消息。;- 传值时需小于 `end_time` 值。",
+            "in": "query",
+            "name": "start_time",
+            "required": false,
+            "schema": {
+              "description": "获取 Pin 消息的起始时间，毫秒级时间戳。;;**注意**：;;- 若未传值默认获取到群聊内最早的 Pin 消息。;- 传值时需小于 `end_time` 值。",
+              "example": "1658632251800",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "description": "是否还有更多项",
+                      "example": "false",
+                      "type": "boolean"
+                    },
+                    "items": {
+                      "description": "Pin 的操作信息",
+                      "items": {
+                        "properties": {
+                          "chat_id": {
+                            "description": "Pin 消息所在的群聊 ID",
+                            "example": "oc_a0553eda9014c201e6969b478895c230",
+                            "type": "string"
+                          },
+                          "create_time": {
+                            "description": "Pin 的创建时间（毫秒级时间戳）",
+                            "example": "1615380573211",
+                            "type": "string"
+                          },
+                          "message_id": {
+                            "description": "Pin 的消息 ID",
+                            "example": "om_dc13264520392913993dd051dba21dcf",
+                            "type": "string"
+                          },
+                          "operator_id": {
+                            "description": "Pin 的操作人 ID",
+                            "example": "ou_7d8a6e6df7621556ce0d21922b676706ccs",
+                            "type": "string"
+                          },
+                          "operator_id_type": {
+                            "description": "Pin 的操作人 ID 类型。可能值有：;;- open_id：表示操作人为用户，此时 `operator_id` 返回值为用户的 open_id。;- app_id：表示操作人为应用，此时 `operator_id` 返回值为应用的 app_id。",
+                            "example": "open_id",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "message_id"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page_token": {
+                      "description": "分页标记，当 has_more 为 true 时，会同时返回新的 page_token，否则不返回 page_token",
+                      "example": "GxmvlNRvP0NdQZpa7yIqf_Lv_QuBwTQ8tXkX7w-irAghVD_TvuYd1aoJ1LQph86O-XImC4X9j9FhUPhXQDvtrQ==",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "获取群内 Pin 消息。Identity: supports `user` and `bot`.",
+        "x-feishu-access-tokens": [
+          "tenant",
+          "user"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/pin/list",
+        "x-feishu-scopes": [
+          "im:message:readonly",
+          "im:message",
+          "im:message.pins:read"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      },
+      "post": {
+        "description": "Pin 消息。Identity: supports `user` and `bot`.",
+        "operationId": "imPinsCreate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "message_id": {
+                    "description": "待 Pin 的消息 ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+                    "example": "om_dc13264520392913993dd051dba21dcf",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message_id"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "pin": {
+                      "description": "Pin 的操作信息",
+                      "properties": {
+                        "chat_id": {
+                          "description": "Pin 消息所在的群聊 ID",
+                          "example": "oc_a0553eda9014c201e6969b478895c230",
+                          "type": "string"
+                        },
+                        "create_time": {
+                          "description": "Pin 的创建时间（毫秒级时间戳）",
+                          "example": "1615380573211",
+                          "type": "string"
+                        },
+                        "message_id": {
+                          "description": "Pin 的消息 ID",
+                          "example": "om_dc13264520392913993dd051dba21dcf",
+                          "type": "string"
+                        },
+                        "operator_id": {
+                          "description": "Pin 的操作人 ID",
+                          "example": "ou_7d8a6e6df7621556ce0d21922b676706ccs",
+                          "type": "string"
+                        },
+                        "operator_id_type": {
+                          "description": "Pin 的操作人 ID 类型。可能值有：;;- open_id：表示操作人为用户，此时 `operator_id` 返回值为用户的 open_id。;- app_id：表示操作人为应用，此时 `operator_id` 返回值为应用的 app_id。",
+                          "example": "open_id",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "message_id"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "Pin 消息。Identity: supports `user` and `bot`.",
+        "x-feishu-access-tokens": [
+          "tenant",
+          "user"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/pin/create",
+        "x-feishu-scopes": [
+          "im:message:send_as_bot",
+          "im:message",
+          "im:message.pins:write_only"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/pins/{message_id}": {
+      "delete": {
+        "description": "移除 Pin 消息。Identity: supports `user` and `bot`.",
+        "operationId": "imPinsDelete",
+        "parameters": [
+          {
+            "description": "待移除 Pin 的消息 ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "description": "待移除 Pin 的消息 ID。ID 获取方式：;  ;- 调用[发送消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/create)接口后，从响应结果的 `message_id` 参数获取。;- 监听[接收消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/events/receive)事件，当触发该事件后可以从事件体内获取消息的 `message_id`。;- 调用[获取会话历史消息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/list)接口，从响应结果的 `message_id` 参数获取。",
+              "example": "om_dc13264520392913993dd051dba21dcf",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "移除 Pin 消息。Identity: supports `user` and `bot`.",
+        "x-feishu-access-tokens": [
+          "tenant",
+          "user"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/pin/delete",
+        "x-feishu-scopes": [
+          "im:message:send_as_bot",
+          "im:message",
+          "im:message.pins:write_only"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    },
+    "/im/v1/threads/{thread_id}/forward": {
+      "post": {
+        "description": "转发话题。Identity: supports `user` and `bot`.",
+        "operationId": "imThreadsForward",
+        "parameters": [
+          {
+            "description": "消息接收者 ID 类型。",
+            "in": "query",
+            "name": "receive_id_type",
+            "required": true,
+            "schema": {
+              "description": "消息接收者 ID 类型。",
+              "enum": [
+                "open_id",
+                "user_id",
+                "union_id",
+                "email",
+                "chat_id",
+                "thread_id"
+              ],
+              "example": "open_id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "要转发的话题ID，获取方式参见[话题概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/thread-introduction)的 **如何获取 thread_id** 章节。",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "description": "要转发的话题ID，获取方式参见[话题概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/thread-introduction)的 **如何获取 thread_id** 章节。",
+              "example": "omt_dc132645203",
+              "type": "string"
+            }
+          },
+          {
+            "description": "自定义设置的唯一字符串序列，用于在转发话题时请求去重。持有相同 uuid 的请求，在 1 小时内向同一目标的转发只可成功一次。",
+            "in": "query",
+            "name": "uuid",
+            "required": false,
+            "schema": {
+              "description": "自定义设置的唯一字符串序列，用于在转发话题时请求去重。持有相同 uuid 的请求，在 1 小时内向同一目标的转发只可成功一次。",
+              "example": "b13g2t38-1jd2-458b-8djf-dtbca5104204",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "receive_id": {
+                    "description": "消息接收者 ID，ID 类型与 `receive_id_type` 的值一致。",
+                    "example": "oc_a0553eda9014c201e6969b478895c230",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "receive_id"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "body": {
+                      "description": "通过 `body` 内的 `content` 参数，返回所发送的消息内容。 ",
+                      "example": "json结构",
+                      "properties": {
+                        "content": {
+                          "description": "消息内容，JSON 结构序列化后的字符串，转发话题生成的新消息的消息内容为固定值==Merged and Forwarded Message==，其中的子消息可以使用[获取指定消息的内容](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/get)接口获取。",
+                          "example": "Merged and Forwarded Message",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "content"
+                      ],
+                      "type": "object"
+                    },
+                    "chat_id": {
+                      "description": "消息所属的群 ID。你可以调用[获取群信息](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/chat/get)接口，根据群 ID 获取群详情。",
+                      "example": "oc_5ad11d72b830411d72b836c20",
+                      "type": "string"
+                    },
+                    "create_time": {
+                      "description": "消息生成的时间戳。单位：毫秒",
+                      "example": "1615380573411",
+                      "type": "string"
+                    },
+                    "deleted": {
+                      "description": "消息是否被撤回。返回 false 表示未被撤回。",
+                      "example": "false",
+                      "type": "boolean"
+                    },
+                    "mentions": {
+                      "description": "发送的消息内，被 @ 的用户或机器人列表。",
+                      "items": {
+                        "properties": {
+                          "id": {
+                            "description": "被 @ 的用户或者机器人的 open_id。",
+                            "example": "ou_155184d1e73cbfb8973e5a9e698e74f2",
+                            "type": "string"
+                          },
+                          "id_type": {
+                            "description": "被 @ 的用户或机器人 ID 类型，目前仅支持 `open_id` ([什么是 Open ID](https://open.feishu.cn/document/home/user-identity-introduction/open-id))。",
+                            "example": "open_id",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "被 @ 的用户或机器人序号。例如，第 3 个被 @ 到的成员，取值为 `@_user_3`。",
+                            "example": "@_user_1",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "被 @ 的用户或机器人的姓名。",
+                            "example": "Tom",
+                            "type": "string"
+                          },
+                          "tenant_key": {
+                            "description": "租户唯一标识。该标识用来识别被 @ 用户或机器人的租户，也可以用来获取租户访问凭证（tenant_access_token）。",
+                            "example": "736588c9260f175e",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "id_type",
+                          "key",
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "message_app_link": {
+                      "description": "消息跳转链接",
+                      "example": "https://xxxx/client/thread/open?chatid=xxx&threadid=xxx&thread_position=xxx",
+                      "type": "string"
+                    },
+                    "message_id": {
+                      "description": "消息 ID。消息转发后，由系统自动生成的消息唯一标识。后续对消息的管理维护操作均需要使用该 ID。",
+                      "example": "om_dc13264520392913993dd051dba21dcf",
+                      "type": "string"
+                    },
+                    "msg_type": {
+                      "description": "消息类型。类型定义参考[接收消息内容](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/im-v1/message/events/message_content)。",
+                      "example": "merge_forward",
+                      "type": "string"
+                    },
+                    "parent_id": {
+                      "description": "父消息 ID，仅在回复消息场景会有返回值。了解 parent_id 可参见[消息管理概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/intro)。",
+                      "example": "om_d4be107c616aed9c1da8ed8068570a9f",
+                      "type": "string"
+                    },
+                    "root_id": {
+                      "description": "根消息 ID，仅在回复消息场景会有返回值。了解 root_id 可参见[消息管理概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/intro)。",
+                      "example": "om_40eb06e7b84dc71c03e009ad3c754195",
+                      "type": "string"
+                    },
+                    "sender": {
+                      "description": "消息的发送者信息。",
+                      "example": "object",
+                      "properties": {
+                        "id": {
+                          "description": "发送者的 ID。",
+                          "example": "cli_9f427eec54ae901b",
+                          "type": "string"
+                        },
+                        "id_type": {
+                          "description": "发送者的 ID 类型。;;**可能值有：**;- `open_id`：表示发送者为用户，且返回的 ID 是用户的 open_id。;- `app_id`：表示发送者为应用，切返回的 ID 是应用的 app_id。",
+                          "example": "app_id",
+                          "type": "string"
+                        },
+                        "sender_name": {
+                          "description": "该字段标识发送者的名称",
+                          "type": "string"
+                        },
+                        "sender_type": {
+                          "description": "发送者类型。;;**可能值有：**;- `user`: 用户;- `app`: 应用;- `anonymous`: 匿名;- `unknown`: 未知",
+                          "example": "app",
+                          "type": "string"
+                        },
+                        "tenant_key": {
+                          "description": "租户唯一标识。该标识用来识别租户，也可以用来获取租户访问凭证（tenant_access_token）。",
+                          "example": "736588c9260f175e",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "id_type",
+                        "sender_type"
+                      ],
+                      "type": "object"
+                    },
+                    "thread_id": {
+                      "description": "消息所属的话题 ID（不返回说明该消息非话题消息），了解话题可参见[话题概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/thread-introduction)。",
+                      "example": "omt_d4be107c616a",
+                      "type": "string"
+                    },
+                    "update_time": {
+                      "description": "消息更新的时间戳。单位：毫秒",
+                      "example": "1615380573411",
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "消息是否被更新。返回 false 表示未被更新。",
+                      "example": "false",
+                      "type": "boolean"
+                    },
+                    "upper_message_id": {
+                      "description": "合并转发消息中，上一层级的消息 ID，仅在合并转发场景会有返回值。了解 upper_message_id 可参见[消息管理概述](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/intro)。",
+                      "example": "om_40eb06e7b84dc71c03e009ad3c754195",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Feishu/Lark OpenAPI response"
+          }
+        },
+        "summary": "转发话题。Identity: supports `user` and `bot`.",
+        "x-feishu-access-tokens": [
+          "user",
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/api-explorer?from=op_doc_tab&apiName=forward&project=im&resource=thread&version=v1",
+        "x-feishu-scopes": [
+          "im:message:send_as_bot",
+          "im:message"
+        ],
+        "x-feishu-source": "api_definition:meta"
+      }
+    }
   },
   "servers": [
     {
@@ -13,572 +3855,5 @@
       "url": "https://open.larksuite.com/open-apis"
     }
   ],
-  "security": [
-    {
-      "FeishuBearerAuth": []
-    }
-  ],
-  "paths": {
-    "/im/v1/chats": {
-      "get": {
-        "summary": "List chats visible to the app",
-        "parameters": [
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100
-            },
-            "description": "Number of chats to return"
-          },
-          {
-            "name": "page_token",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Pagination token from a previous response"
-          },
-          {
-            "name": "sort_type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "ByCreateTimeAsc",
-                "ByCreateTimeDesc",
-                "ByActiveTimeAsc",
-                "ByActiveTimeDesc"
-              ]
-            },
-            "description": "Sort order for the chat list"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Chat list response"
-          }
-        }
-      }
-    },
-    "/im/v1/chats/{chat_id}": {
-      "get": {
-        "summary": "Get details for one chat",
-        "parameters": [
-          {
-            "name": "chat_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Feishu chat identifier"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Chat detail response"
-          }
-        }
-      }
-    },
-    "/im/v1/chats/{chat_id}/members": {
-      "get": {
-        "summary": "List members of a chat",
-        "parameters": [
-          {
-            "name": "chat_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Feishu chat identifier"
-          },
-          {
-            "name": "member_id_type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "open_id",
-                "union_id",
-                "user_id"
-              ]
-            },
-            "description": "Identifier type for returned members"
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100
-            },
-            "description": "Number of members to return"
-          },
-          {
-            "name": "page_token",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Pagination token from a previous response"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Chat member list response"
-          }
-        }
-      }
-    },
-    "/im/v1/messages": {
-      "get": {
-        "summary": "List historical messages for a container",
-        "parameters": [
-          {
-            "name": "container_id_type",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "chat"
-              ]
-            },
-            "description": "Container type used for the lookup"
-          },
-          {
-            "name": "container_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Chat identifier whose history should be returned"
-          },
-          {
-            "name": "sort_type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "ByCreateTimeAsc",
-                "ByCreateTimeDesc"
-              ]
-            },
-            "description": "Sort order for the message history"
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 50
-            },
-            "description": "Number of messages to return"
-          },
-          {
-            "name": "page_token",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Pagination token from a previous response"
-          },
-          {
-            "name": "start_time",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Inclusive start time filter, typically epoch milliseconds as a string"
-          },
-          {
-            "name": "end_time",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Inclusive end time filter, typically epoch milliseconds as a string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Message history response"
-          }
-        }
-      },
-      "post": {
-        "summary": "Send a message to a user, chat, or thread target",
-        "parameters": [
-          {
-            "name": "receive_id_type",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "open_id",
-                "user_id",
-                "union_id",
-                "chat_id",
-                "email"
-              ]
-            },
-            "description": "Identifier type for the receive_id field"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateMessageRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Send message response"
-          }
-        }
-      }
-    },
-    "/im/v1/messages/{message_id}": {
-      "get": {
-        "summary": "Get one message by ID",
-        "parameters": [
-          {
-            "name": "message_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Feishu message identifier"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Message detail response"
-          }
-        }
-      }
-    },
-    "/im/v1/messages/{message_id}/reply": {
-      "post": {
-        "summary": "Reply to an existing message",
-        "parameters": [
-          {
-            "name": "message_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Message identifier to reply to"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ReplyMessageRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Reply message response"
-          }
-        }
-      }
-    },
-    "/im/v1/images": {
-      "post": {
-        "summary": "Upload an image and receive an image_key",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/UploadImageRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Image upload response"
-          }
-        }
-      }
-    },
-    "/im/v1/files": {
-      "post": {
-        "summary": "Upload a file and receive a file_key",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/UploadFileRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "File upload response"
-          }
-        }
-      }
-    },
-    "/contact/v3/users/{user_id}": {
-      "get": {
-        "summary": "Get one user profile",
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "User identifier"
-          },
-          {
-            "name": "user_id_type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "open_id",
-                "union_id",
-                "user_id"
-              ]
-            },
-            "description": "Identifier type used for the path parameter"
-          },
-          {
-            "name": "department_id_type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "department_id",
-                "open_department_id"
-              ]
-            },
-            "description": "Preferred department ID type in the response"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User profile response"
-          }
-        }
-      }
-    },
-    "/contact/v3/users/batch_get_id": {
-      "post": {
-        "summary": "Resolve user IDs from email or mobile values",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BatchGetUserIdRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Batch user ID lookup response"
-          }
-        }
-      }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "FeishuBearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "tenant_access_token"
-      }
-    },
-    "schemas": {
-      "CreateMessageRequest": {
-        "type": "object",
-        "required": [
-          "receive_id",
-          "msg_type",
-          "content"
-        ],
-        "properties": {
-          "receive_id": {
-            "type": "string",
-            "description": "Target identifier whose type is defined by receive_id_type"
-          },
-          "msg_type": {
-            "type": "string",
-            "enum": [
-              "text",
-              "post",
-              "image",
-              "interactive",
-              "share_chat",
-              "share_user",
-              "audio",
-              "media",
-              "file",
-              "sticker"
-            ],
-            "description": "Message content type"
-          },
-          "content": {
-            "type": "string",
-            "description": "Stringified JSON payload expected by Feishu, for example {\"text\":\"hello\"}"
-          },
-          "uuid": {
-            "type": "string",
-            "description": "Optional client-generated idempotency token"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ReplyMessageRequest": {
-        "type": "object",
-        "required": [
-          "content"
-        ],
-        "properties": {
-          "content": {
-            "type": "string",
-            "description": "Stringified JSON payload expected by Feishu, for example {\"text\":\"reply\"}"
-          },
-          "msg_type": {
-            "type": "string",
-            "enum": [
-              "text",
-              "post",
-              "image",
-              "interactive",
-              "share_chat",
-              "share_user",
-              "audio",
-              "media",
-              "file",
-              "sticker"
-            ],
-            "description": "Message content type. Defaults vary by API behavior; set it explicitly."
-          },
-          "uuid": {
-            "type": "string",
-            "description": "Optional client-generated idempotency token"
-          }
-        },
-        "additionalProperties": false
-      },
-      "UploadImageRequest": {
-        "type": "object",
-        "required": [
-          "image_type",
-          "image"
-        ],
-        "properties": {
-          "image_type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "Image upload purpose. Use message for IM sends."
-          },
-          "image": {
-            "type": "string",
-            "format": "binary",
-            "description": "Local image file path to upload"
-          }
-        },
-        "additionalProperties": false
-      },
-      "UploadFileRequest": {
-        "type": "object",
-        "required": [
-          "file_type",
-          "file_name",
-          "file"
-        ],
-        "properties": {
-          "file_type": {
-            "type": "string",
-            "description": "File upload type. Use stream for general file uploads."
-          },
-          "file_name": {
-            "type": "string",
-            "description": "Original filename shown in Feishu"
-          },
-          "file": {
-            "type": "string",
-            "format": "binary",
-            "description": "Local file path to upload"
-          },
-          "duration": {
-            "type": "integer",
-            "description": "Optional duration in milliseconds for audio or video uploads"
-          }
-        },
-        "additionalProperties": false
-      },
-      "BatchGetUserIdRequest": {
-        "type": "object",
-        "properties": {
-          "emails": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "email"
-            },
-            "description": "Email addresses to resolve"
-          },
-          "mobiles": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Mobile numbers to resolve"
-          },
-          "include_resigned": {
-            "type": "boolean",
-            "description": "Whether to include resigned users in the lookup"
-          }
-        },
-        "additionalProperties": false
-      }
-    }
-  }
+  "x-feishu-meta-version": "1.0.0"
 }

--- a/skills/feishu-openapi-skill/references/feishu-openapi.overlay.json
+++ b/skills/feishu-openapi-skill/references/feishu-openapi.overlay.json
@@ -1,0 +1,643 @@
+{
+  "components": {
+    "schemas": {
+      "BatchGetUserIdRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "emails": {
+            "description": "Email addresses to resolve",
+            "items": {
+              "format": "email",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "include_resigned": {
+            "description": "Whether to include resigned users in the lookup",
+            "type": "boolean"
+          },
+          "mobiles": {
+            "description": "Mobile numbers to resolve",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "BotInfo": {
+        "properties": {
+          "activate_status": {
+            "description": "Current app activation status in the tenant.",
+            "type": "integer"
+          },
+          "app_name": {
+            "description": "App bot display name.",
+            "type": "string"
+          },
+          "avatar_url": {
+            "description": "App bot avatar URL.",
+            "type": "string"
+          },
+          "ip_white_list": {
+            "description": "Configured IP allow list for the app.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "open_id": {
+            "description": "Bot open_id for the configured app.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "app_name",
+          "open_id"
+        ],
+        "type": "object"
+      },
+      "BotInfoResponse": {
+        "properties": {
+          "bot": {
+            "$ref": "#/components/schemas/BotInfo"
+          },
+          "code": {
+            "description": "Feishu/Lark API status code. 0 means success.",
+            "type": "integer"
+          },
+          "msg": {
+            "description": "Feishu/Lark API status message.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "msg",
+          "bot"
+        ],
+        "type": "object"
+      },
+      "CreateMessageRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "description": "Stringified JSON payload expected by Feishu, for example {\"text\":\"hello\"}",
+            "type": "string"
+          },
+          "msg_type": {
+            "description": "Message content type",
+            "enum": [
+              "text",
+              "post",
+              "image",
+              "interactive",
+              "share_chat",
+              "share_user",
+              "audio",
+              "media",
+              "file",
+              "sticker"
+            ],
+            "type": "string"
+          },
+          "receive_id": {
+            "description": "Target identifier whose type is defined by receive_id_type",
+            "type": "string"
+          },
+          "uuid": {
+            "description": "Optional client-generated idempotency token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "receive_id",
+          "msg_type",
+          "content"
+        ],
+        "type": "object"
+      },
+      "ReplyMessageRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "description": "Stringified JSON payload expected by Feishu, for example {\"text\":\"reply\"}",
+            "type": "string"
+          },
+          "msg_type": {
+            "description": "Message content type. Defaults vary by API behavior; set it explicitly.",
+            "enum": [
+              "text",
+              "post",
+              "image",
+              "interactive",
+              "share_chat",
+              "share_user",
+              "audio",
+              "media",
+              "file",
+              "sticker"
+            ],
+            "type": "string"
+          },
+          "uuid": {
+            "description": "Optional client-generated idempotency token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
+      "UploadFileRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "duration": {
+            "description": "Optional duration in milliseconds for audio or video uploads",
+            "type": "integer"
+          },
+          "file": {
+            "description": "Local file path to upload",
+            "format": "binary",
+            "type": "string"
+          },
+          "file_name": {
+            "description": "Original filename shown in Feishu",
+            "type": "string"
+          },
+          "file_type": {
+            "description": "File upload type. Use stream for general file uploads.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_type",
+          "file_name",
+          "file"
+        ],
+        "type": "object"
+      },
+      "UploadImageRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "image": {
+            "description": "Local image file path to upload",
+            "format": "binary",
+            "type": "string"
+          },
+          "image_type": {
+            "description": "Image upload purpose. Use message for IM sends.",
+            "enum": [
+              "message"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "image_type",
+          "image"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "FeishuBearerAuth": {
+        "bearerFormat": "tenant_access_token",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "paths": {
+    "/bot/v3/info": {
+      "get": {
+        "description": "Returns the configured Feishu/Lark app bot identity, including bot.open_id and bot.app_name. Requires tenant_access_token but no additional API scope.",
+        "operationId": "botGetInfo",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotInfoResponse"
+                }
+              }
+            },
+            "description": "Bot identity response"
+          }
+        },
+        "summary": "Get bot identity information for the configured app",
+        "x-feishu-access-tokens": [
+          "tenant"
+        ],
+        "x-feishu-doc-url": "https://open.feishu.cn/document/client-docs/bot-v3/obtain-bot-info.md",
+        "x-feishu-scopes": [],
+        "x-feishu-source": "llms.txt:bot-v3/obtain-bot-info"
+      }
+    },
+    "/contact/v3/users/batch_get_id": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchGetUserIdRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Batch user ID lookup response"
+          }
+        },
+        "summary": "Resolve user IDs from email or mobile values"
+      }
+    },
+    "/contact/v3/users/{user_id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "User identifier",
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Identifier type used for the path parameter",
+            "in": "query",
+            "name": "user_id_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "open_id",
+                "union_id",
+                "user_id"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Preferred department ID type in the response",
+            "in": "query",
+            "name": "department_id_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "department_id",
+                "open_department_id"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User profile response"
+          }
+        },
+        "summary": "Get one user profile"
+      }
+    },
+    "/im/v1/chats": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Number of chats to return",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination token from a previous response",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort order for the chat list",
+            "in": "query",
+            "name": "sort_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ByCreateTimeAsc",
+                "ByCreateTimeDesc",
+                "ByActiveTimeAsc",
+                "ByActiveTimeDesc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chat list response"
+          }
+        },
+        "summary": "List chats visible to the app"
+      }
+    },
+    "/im/v1/chats/{chat_id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Feishu chat identifier",
+            "in": "path",
+            "name": "chat_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chat detail response"
+          }
+        },
+        "summary": "Get details for one chat"
+      }
+    },
+    "/im/v1/chats/{chat_id}/members": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Feishu chat identifier",
+            "in": "path",
+            "name": "chat_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Identifier type for returned members",
+            "in": "query",
+            "name": "member_id_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "open_id",
+                "union_id",
+                "user_id"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of members to return",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination token from a previous response",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chat member list response"
+          }
+        },
+        "summary": "List members of a chat"
+      }
+    },
+    "/im/v1/files": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadFileRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "File upload response"
+          }
+        },
+        "summary": "Upload a file and receive a file_key"
+      }
+    },
+    "/im/v1/images": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadImageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Image upload response"
+          }
+        },
+        "summary": "Upload an image and receive an image_key"
+      }
+    },
+    "/im/v1/messages": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Container type used for the lookup",
+            "in": "query",
+            "name": "container_id_type",
+            "required": true,
+            "schema": {
+              "enum": [
+                "chat"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Chat identifier whose history should be returned",
+            "in": "query",
+            "name": "container_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort order for the message history",
+            "in": "query",
+            "name": "sort_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ByCreateTimeAsc",
+                "ByCreateTimeDesc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of messages to return",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "maximum": 50,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination token from a previous response",
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive start time filter, typically epoch milliseconds as a string",
+            "in": "query",
+            "name": "start_time",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive end time filter, typically epoch milliseconds as a string",
+            "in": "query",
+            "name": "end_time",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Message history response"
+          }
+        },
+        "summary": "List historical messages for a container"
+      },
+      "post": {
+        "parameters": [
+          {
+            "description": "Identifier type for the receive_id field",
+            "in": "query",
+            "name": "receive_id_type",
+            "required": true,
+            "schema": {
+              "enum": [
+                "open_id",
+                "user_id",
+                "union_id",
+                "chat_id",
+                "email"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Send message response"
+          }
+        },
+        "summary": "Send a message to a user, chat, or thread target"
+      }
+    },
+    "/im/v1/messages/{message_id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Feishu message identifier",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Message detail response"
+          }
+        },
+        "summary": "Get one message by ID"
+      }
+    },
+    "/im/v1/messages/{message_id}/reply": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Message identifier to reply to",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReplyMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Reply message response"
+          }
+        },
+        "summary": "Reply to an existing message"
+      }
+    }
+  }
+}

--- a/skills/feishu-openapi-skill/scripts/generate_openapi.py
+++ b/skills/feishu-openapi-skill/scripts/generate_openapi.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Generate the Feishu/Lark OpenAPI schema from official CLI metadata.
+
+The upstream Feishu/Lark endpoint exposes a custom `protocol=meta` format, not a
+standard OpenAPI document. This script converts the selected metadata services
+into OpenAPI 3 and then applies a small curated overlay for operations that are
+missing from metadata or need UXC-specific guardrails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SKILL_DIR = ROOT / "skills" / "feishu-openapi-skill"
+DEFAULT_OUTPUT = SKILL_DIR / "references" / "feishu-im.openapi.json"
+DEFAULT_OVERLAY = SKILL_DIR / "references" / "feishu-openapi.overlay.json"
+
+META_ENDPOINTS = {
+    "feishu": "https://open.feishu.cn/api/tools/open/api_definition",
+    "lark": "https://open.larksuite.com/api/tools/open/api_definition",
+}
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def fetch_meta(brand: str, client_version: str) -> dict[str, Any]:
+    base = META_ENDPOINTS[brand]
+    query = urllib.parse.urlencode(
+        {"protocol": "meta", "client_version": client_version}
+    )
+    with urllib.request.urlopen(f"{base}?{query}", timeout=15) as resp:
+        envelope = json.load(resp)
+    if envelope.get("msg") != "succeeded":
+        raise RuntimeError(f"unexpected metadata response: {envelope!r}")
+    data = envelope.get("data")
+    if not isinstance(data, dict) or not data.get("services"):
+        raise RuntimeError("metadata response did not include services")
+    return data
+
+
+def deep_merge(base: Any, overlay: Any) -> Any:
+    if isinstance(base, dict) and isinstance(overlay, dict):
+        merged = copy.deepcopy(base)
+        for key, value in overlay.items():
+            if key in merged:
+                merged[key] = deep_merge(merged[key], value)
+            else:
+                merged[key] = copy.deepcopy(value)
+        return merged
+    return copy.deepcopy(overlay)
+
+
+def openapi_path(service_path: str, method_path: str) -> str:
+    path = f"{service_path.rstrip('/')}/{method_path.lstrip('/')}"
+    if path.startswith("/open-apis/"):
+        path = path[len("/open-apis") :]
+    return path
+
+
+def schema_name(value: str) -> str:
+    parts = [
+        part
+        for part in (
+            value.replace(".", " ")
+            .replace("_", " ")
+            .replace("-", " ")
+            .replace("/", " ")
+            .split()
+        )
+        if part
+    ]
+    return "".join(part[:1].upper() + part[1:] for part in parts)
+
+
+def convert_type(value: str | None) -> str:
+    if value in {"int", "int32", "int64", "integer"}:
+        return "integer"
+    if value in {"float", "double", "number"}:
+        return "number"
+    if value in {"bool", "boolean"}:
+        return "boolean"
+    if value == "array":
+        return "array"
+    if value == "object":
+        return "object"
+    if value == "file":
+        return "string"
+    return "string"
+
+
+def convert_field(field: dict[str, Any]) -> dict[str, Any]:
+    field_type = convert_type(str(field.get("type") or "string"))
+    schema: dict[str, Any] = {"type": field_type}
+
+    if field.get("type") == "file":
+        schema["format"] = "binary"
+
+    description = field.get("description")
+    if isinstance(description, str) and description:
+        schema["description"] = description
+
+    example = field.get("example")
+    if example not in (None, ""):
+        schema["example"] = example
+
+    options = field.get("options")
+    if isinstance(options, list) and options:
+        enum_values = [
+            option.get("value")
+            for option in options
+            if isinstance(option, dict) and option.get("value") is not None
+        ]
+        if enum_values:
+            schema["enum"] = enum_values
+
+    if field_type == "array":
+        properties = field.get("properties")
+        if isinstance(properties, dict) and properties:
+            schema["items"] = convert_object_schema(properties)
+        else:
+            schema["items"] = {"type": "string"}
+    elif field_type == "object":
+        properties = field.get("properties")
+        if isinstance(properties, dict) and properties:
+            schema = deep_merge(schema, convert_object_schema(properties))
+
+    return schema
+
+
+def convert_object_schema(fields: dict[str, Any]) -> dict[str, Any]:
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for name in sorted(fields):
+        field = fields[name]
+        if not isinstance(field, dict):
+            continue
+        properties[name] = convert_field(field)
+        if field.get("required") is True:
+            required.append(name)
+    schema: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def convert_parameter(name: str, spec: dict[str, Any]) -> dict[str, Any]:
+    location = spec.get("location") or "query"
+    if location == "body":
+        location = "query"
+    parameter = {
+        "name": name,
+        "in": location,
+        "required": bool(spec.get("required") or location == "path"),
+        "schema": convert_field(spec),
+    }
+    description = spec.get("description")
+    if isinstance(description, str) and description:
+        parameter["description"] = description
+    return parameter
+
+
+def request_body_for(method: dict[str, Any]) -> dict[str, Any] | None:
+    fields = method.get("requestBody")
+    if not isinstance(fields, dict) or not fields:
+        return None
+    schema = convert_object_schema(fields)
+    has_file = any(
+        isinstance(field, dict) and field.get("type") == "file"
+        for field in fields.values()
+    )
+    media_type = "multipart/form-data" if has_file else "application/json"
+    return {
+        "required": any(
+            isinstance(field, dict) and field.get("required") is True
+            for field in fields.values()
+        ),
+        "content": {media_type: {"schema": schema}},
+    }
+
+
+def response_for(method: dict[str, Any]) -> dict[str, Any]:
+    fields = method.get("responseBody")
+    if not isinstance(fields, dict) or not fields:
+        return {"description": "Feishu/Lark OpenAPI response"}
+    return {
+        "description": "Feishu/Lark OpenAPI response",
+        "content": {
+            "application/json": {
+                "schema": convert_object_schema(fields),
+            }
+        },
+    }
+
+
+def operation_id(service: str, resource: str, method: str) -> str:
+    return service + schema_name(resource) + schema_name(method)
+
+
+def convert_method(
+    service_name: str,
+    resource_name: str,
+    method_name: str,
+    method: dict[str, Any],
+) -> dict[str, Any]:
+    op: dict[str, Any] = {
+        "operationId": operation_id(service_name, resource_name, method_name),
+        "summary": method.get("summary") or method.get("description") or method_name,
+        "responses": {"200": response_for(method)},
+        "x-feishu-source": "api_definition:meta",
+    }
+
+    description = method.get("description")
+    if isinstance(description, str) and description:
+        op["description"] = description
+
+    parameters = method.get("parameters")
+    if isinstance(parameters, dict) and parameters:
+        op["parameters"] = [
+            convert_parameter(name, parameters[name]) for name in sorted(parameters)
+        ]
+
+    body = request_body_for(method)
+    if body is not None:
+        op["requestBody"] = body
+
+    for src_key, dst_key in (
+        ("scopes", "x-feishu-scopes"),
+        ("accessTokens", "x-feishu-access-tokens"),
+        ("docUrl", "x-feishu-doc-url"),
+    ):
+        value = method.get(src_key)
+        if value:
+            op[dst_key] = value
+
+    return op
+
+
+def convert_meta(meta: dict[str, Any], selected_services: set[str]) -> dict[str, Any]:
+    paths: dict[str, Any] = {}
+    services = meta.get("services")
+    if not isinstance(services, list):
+        return paths
+
+    for service in services:
+        if not isinstance(service, dict):
+            continue
+        service_name = service.get("name")
+        if service_name not in selected_services:
+            continue
+        service_path = service.get("servicePath")
+        resources = service.get("resources")
+        if not isinstance(service_path, str) or not isinstance(resources, dict):
+            continue
+        for resource_name in sorted(resources):
+            resource = resources[resource_name]
+            if not isinstance(resource, dict):
+                continue
+            methods = resource.get("methods")
+            if not isinstance(methods, dict):
+                continue
+            for method_name in sorted(methods):
+                method = methods[method_name]
+                if not isinstance(method, dict):
+                    continue
+                http_method = str(method.get("httpMethod") or "").lower()
+                method_path = method.get("path")
+                if not http_method or not isinstance(method_path, str):
+                    continue
+                path = openapi_path(service_path, method_path)
+                paths.setdefault(path, {})[http_method] = convert_method(
+                    str(service_name), str(resource_name), str(method_name), method
+                )
+    return paths
+
+
+def build_schema(meta: dict[str, Any], overlay: dict[str, Any], services: set[str]) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "openapi": "3.0.3",
+        "info": {
+            "title": "Feishu / Lark IM API (Curated)",
+            "version": "1.0.0",
+            "description": "Curated Feishu / Lark IM, bot identity, and contact surface for UXC messaging workflows.",
+        },
+        "servers": [
+            {"url": "https://open.feishu.cn/open-apis"},
+            {"url": "https://open.larksuite.com/open-apis"},
+        ],
+        "paths": convert_meta(meta, services),
+        "components": {"schemas": {}},
+        "x-feishu-meta-version": meta.get("version"),
+    }
+    return deep_merge(schema, overlay)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--brand", choices=sorted(META_ENDPOINTS), default="feishu")
+    parser.add_argument("--client-version", default="uxc-generator")
+    parser.add_argument("--meta-json", type=Path)
+    parser.add_argument("--overlay", type=Path, default=DEFAULT_OVERLAY)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--service",
+        action="append",
+        default=["im"],
+        help="metadata service to include; can be repeated",
+    )
+    args = parser.parse_args()
+
+    meta = load_json(args.meta_json) if args.meta_json else fetch_meta(args.brand, args.client_version)
+    if "data" in meta and isinstance(meta["data"], dict):
+        meta = meta["data"]
+
+    overlay = load_json(args.overlay)
+    schema = build_schema(meta, overlay, set(args.service))
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as fp:
+        json.dump(schema, fp, ensure_ascii=False, indent=2, sort_keys=True)
+        fp.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/feishu-openapi-skill/scripts/generate_openapi.py
+++ b/skills/feishu-openapi-skill/scripts/generate_openapi.py
@@ -297,6 +297,7 @@ def build_schema(meta: dict[str, Any], overlay: dict[str, Any], services: set[st
             {"url": "https://open.feishu.cn/open-apis"},
             {"url": "https://open.larksuite.com/open-apis"},
         ],
+        "security": [{"FeishuBearerAuth": []}],
         "paths": convert_meta(meta, services),
         "components": {"schemas": {}},
         "x-feishu-meta-version": meta.get("version"),

--- a/skills/feishu-openapi-skill/scripts/validate.sh
+++ b/skills/feishu-openapi-skill/scripts/validate.sh
@@ -7,6 +7,8 @@ SKILL_FILE="${SKILL_DIR}/SKILL.md"
 OPENAI_FILE="${SKILL_DIR}/agents/openai.yaml"
 USAGE_FILE="${SKILL_DIR}/references/usage-patterns.md"
 SCHEMA_FILE="${SKILL_DIR}/references/feishu-im.openapi.json"
+OVERLAY_FILE="${SKILL_DIR}/references/feishu-openapi.overlay.json"
+GENERATOR_FILE="${SKILL_DIR}/scripts/generate_openapi.py"
 
 fail() {
   printf '[validate] error: %s\n' "$*" >&2
@@ -20,14 +22,16 @@ need_cmd() {
 need_cmd rg
 need_cmd jq
 
-for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}" "${SCHEMA_FILE}"; do
+for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}" "${SCHEMA_FILE}" "${OVERLAY_FILE}" "${GENERATOR_FILE}"; do
   [[ -f "${file}" ]] || fail "missing required file: ${file}"
 done
 
 jq -e '.openapi and .paths' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'invalid OpenAPI schema JSON or missing .openapi/.paths'
+jq -e '.paths["/bot/v3/info"].get' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing /bot/v3/info path'
 jq -e '.paths["/im/v1/chats"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing /im/v1/chats path'
 jq -e '.paths["/im/v1/images"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing /im/v1/images path'
 jq -e '.paths["/im/v1/files"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing /im/v1/files path'
+jq -e '.paths["/bot/v3/info"].get and .components.schemas.BotInfo' "${OVERLAY_FILE}" >/dev/null 2>&1 || fail 'overlay missing bot identity operation'
 
 rg -q '^name:\s*feishu-openapi-skill\s*$' "${SKILL_FILE}" || fail 'invalid skill name'
 rg -q '^description:\s*.+' "${SKILL_FILE}" || fail 'missing description'
@@ -35,6 +39,7 @@ rg -q '^description:\s*.+' "${SKILL_FILE}" || fail 'missing description'
 rg -q 'command -v feishu-openapi-cli' "${SKILL_FILE}" || fail 'missing link-first command check'
 rg -q 'uxc link feishu-openapi-cli https://open.feishu.cn/open-apis --schema-url ' "${SKILL_FILE}" || fail 'missing fixed link create command with schema-url'
 rg -q 'feishu-openapi-cli -h' "${SKILL_FILE}" || fail 'missing help-first host discovery example'
+rg -q 'feishu-openapi-cli get:/bot/v3/info -h' "${SKILL_FILE}" || fail 'missing bot identity help example'
 rg -q 'feishu-openapi-cli get:/im/v1/chats -h' "${SKILL_FILE}" || fail 'missing operation-level help example'
 rg -q 'feishu-openapi-cli post:/im/v1/images -h' "${SKILL_FILE}" || fail 'missing image upload help example'
 rg -q 'feishu-openapi-cli post:/im/v1/files -h' "${SKILL_FILE}" || fail 'missing file upload help example'

--- a/skills/feishu-openapi-skill/scripts/validate.sh
+++ b/skills/feishu-openapi-skill/scripts/validate.sh
@@ -27,6 +27,7 @@ for file in "${SKILL_FILE}" "${OPENAI_FILE}" "${USAGE_FILE}" "${SCHEMA_FILE}" "$
 done
 
 jq -e '.openapi and .paths' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'invalid OpenAPI schema JSON or missing .openapi/.paths'
+jq -e '.security[]? | has("FeishuBearerAuth")' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing FeishuBearerAuth security requirement'
 jq -e '.paths["/bot/v3/info"].get' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing /bot/v3/info path'
 jq -e '.paths["/im/v1/chats"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing /im/v1/chats path'
 jq -e '.paths["/im/v1/images"]' "${SCHEMA_FILE}" >/dev/null 2>&1 || fail 'OpenAPI schema missing /im/v1/images path'


### PR DESCRIPTION
## What

- Add a Feishu/Lark metadata-to-OpenAPI generator for the Feishu skill schema.
- Add a curated overlay for UXC-specific Feishu endpoints and guardrails.
- Regenerate the Feishu OpenAPI schema from official `api_definition?protocol=meta` plus overlay.
- Add `GET /bot/v3/info` with `bot.open_id` / `bot.app_name` response schema.
- Document the periodic schema maintenance workflow.

## Why

Closes #407.

AgentInbox should be able to resolve a configured Feishu/Lark app bot identity through UXC instead of shipping its own mini schema. The previous schema was also hand-curated and hard to refresh from official sources.

## How

- Convert selected official CLI metadata into OpenAPI 3.
- Keep missing or UXC-validated operations in `feishu-openapi.overlay.json`.
- Validate that the generated schema still exposes the existing IM operations and the new bot identity operation.

## Testing

- `python3 skills/feishu-openapi-skill/scripts/generate_openapi.py`
- `bash skills/feishu-openapi-skill/scripts/validate.sh`
- `python3 -m py_compile skills/feishu-openapi-skill/scripts/generate_openapi.py`
- `git diff --check HEAD~1..HEAD`
- `jq -e '.paths["/bot/v3/info"].get and .components.schemas.BotInfo.properties.open_id.type == "string" and .components.schemas.BotInfo.properties.app_name.type == "string"' skills/feishu-openapi-skill/references/feishu-im.openapi.json`
