### PR TITLE
fix: stabilize daemon default paths

### DIFF
--- a/docs/site/daemon/api.md
+++ b/docs/site/daemon/api.md
@@ -21,8 +21,8 @@ UXC exposes a stable local daemon control plane over a Unix socket using
 
 Socket path follows the same daemon rules as the CLI:
 
-- `$XDG_RUNTIME_DIR/uxc/uxc.sock`
-- fallback: `$HOME/.uxc/daemon/uxc.sock`
+- `$HOME/.uxc/daemon/uxc.sock`
+- fallback when `HOME` is unavailable: the OS temporary directory under a per-user `uxc-<user>/daemon/` directory
 
 Frame format:
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7702,9 +7702,6 @@ async fn read_frame(stream: &mut UnixStream) -> Result<Value> {
 }
 
 fn daemon_dir() -> PathBuf {
-    if let Some(runtime) = std::env::var_os("XDG_RUNTIME_DIR") {
-        return PathBuf::from(runtime).join("uxc");
-    }
     if let Some(home) = std::env::var_os("HOME") {
         return PathBuf::from(home).join(".uxc").join("daemon");
     }

--- a/tests/daemon_cli_test.rs
+++ b/tests/daemon_cli_test.rs
@@ -24,7 +24,7 @@ fn daemon_stop_best_effort_with_home(home: &Path) {
 }
 
 fn daemon_runtime_dir(home: &Path) -> PathBuf {
-    home.join("runtime").join("uxc")
+    home.join(".uxc").join("daemon")
 }
 
 fn daemon_socket_path(home: &Path) -> PathBuf {
@@ -49,6 +49,37 @@ fn spawn_daemon_serve(home: &Path) -> Child {
         .stderr(Stdio::null())
         .spawn()
         .expect("daemon _serve should spawn")
+}
+
+#[test]
+#[serial]
+fn daemon_paths_ignore_xdg_runtime_dir_by_default() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+
+    let runtime_dir = temp_home.path().join("runtime");
+    fs::create_dir_all(&runtime_dir).expect("runtime dir should exist");
+
+    let output = uxc_command()
+        .arg("daemon")
+        .arg("start")
+        .env("HOME", temp_home.path())
+        .env("USERPROFILE", temp_home.path())
+        .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .output()
+        .expect("daemon start should run");
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(
+        json["data"]["socket"],
+        daemon_socket_path(temp_home.path()).display().to_string()
+    );
+    assert!(daemon_socket_path(temp_home.path()).exists());
+    assert!(!runtime_dir.join("uxc").join("uxc.sock").exists());
+
+    daemon_stop_best_effort_with_home(temp_home.path());
 }
 
 fn wait_for_path(path: &Path) {

--- a/tests/daemon_logging_test.rs
+++ b/tests/daemon_logging_test.rs
@@ -68,7 +68,7 @@ fn daemon_creates_log_file() {
         .arg("stop")
         .output();
 
-    let log_dir = PathBuf::from(temp_home.path()).join("runtime").join("uxc");
+    let log_dir = PathBuf::from(temp_home.path()).join(".uxc").join("daemon");
 
     // Remove existing log file if present
     let log_file = log_dir.join("daemon.log");
@@ -126,7 +126,7 @@ fn daemon_log_contains_start_event() {
         .arg("stop")
         .output();
 
-    let log_dir = PathBuf::from(temp_home.path()).join("runtime").join("uxc");
+    let log_dir = PathBuf::from(temp_home.path()).join(".uxc").join("daemon");
 
     let log_file = log_dir.join("daemon.log");
     if log_file.exists() {
@@ -180,7 +180,7 @@ fn daemon_log_contains_stdio_session_lifecycle_events() {
         .arg("stop")
         .output();
 
-    let log_dir = PathBuf::from(temp_home.path()).join("runtime").join("uxc");
+    let log_dir = PathBuf::from(temp_home.path()).join(".uxc").join("daemon");
 
     let log_file = log_dir.join("daemon.log");
     if log_file.exists() {
@@ -254,7 +254,7 @@ fn daemon_log_contains_lifecycle_snapshot_metadata_for_stateful_stdio_sessions()
         .arg("stop")
         .output();
 
-    let log_dir = PathBuf::from(temp_home.path()).join("runtime").join("uxc");
+    let log_dir = PathBuf::from(temp_home.path()).join(".uxc").join("daemon");
 
     let log_file = log_dir.join("daemon.log");
     if log_file.exists() {

--- a/tests/daemon_version_mismatch_test.rs
+++ b/tests/daemon_version_mismatch_test.rs
@@ -17,7 +17,7 @@ fn runtime_root(test_home: &Path) -> PathBuf {
 }
 
 fn daemon_socket_path(test_home: &Path) -> PathBuf {
-    runtime_root(test_home).join("uxc").join("uxc.sock")
+    test_home.join(".uxc").join("daemon").join("uxc.sock")
 }
 
 fn read_frame(stream: &mut UnixStream) -> Value {

--- a/tests/source_cli_test.rs
+++ b/tests/source_cli_test.rs
@@ -16,7 +16,7 @@ fn daemon_stop_best_effort_with_home(home: &Path) {
 }
 
 fn daemon_runtime_dir(home: &Path) -> PathBuf {
-    home.join("runtime").join("uxc")
+    home.join(".uxc").join("daemon")
 }
 
 fn read_json_output(output: &std::process::Output) -> serde_json::Value {


### PR DESCRIPTION
## What

- Stop using `XDG_RUNTIME_DIR` when resolving the default UXC daemon directory.
- Keep the default socket, lock, log, and managed source stream DB under `$HOME/.uxc/daemon/`.
- Update daemon path tests and daemon API docs to match the stable default path.

## Why

`XDG_RUNTIME_DIR` is cleared across reboots on typical Linux systems. Using it for the daemon directory can reset `managed-source-streams.db` and split daemon identity between processes with different environments.

## How

`daemon_dir()` now resolves to `$HOME/.uxc/daemon/` by default, with the existing temp-dir fallback when `HOME` is unavailable. Regression coverage asserts that `XDG_RUNTIME_DIR` does not affect the daemon socket path.

## Testing

- `cargo fmt --all -- --check`
- `make check`
- `cargo test --test daemon_cli_test -- --test-threads=1`
- `cargo test --test daemon_logging_test -- --test-threads=1`
- `cargo test --test daemon_version_mismatch_test -- --test-threads=1`
- `cargo test --test source_cli_test -- --test-threads=1`
- `npm run docs:index` (ran; generated unrelated mdorigin metadata changes were reverted to keep this PR focused)

Not completed locally:

- `npm run docs:build` fails in this environment because the installed `@indexbind/native-linux-x64-gnu` addon requires `GLIBC_2.39`, which is not available on this host.

Closes #410
