### PR TITLE
fix: report stream cursor out of range

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9923,6 +9923,16 @@ mod tests {
             .await
             .unwrap();
 
+        let zero_limit = runtime
+            .managed_sources
+            .store
+            .read_stream(&record.stream_id, 0, 0)
+            .await
+            .unwrap();
+        assert!(zero_limit.events.is_empty());
+        assert_eq!(zero_limit.next_after_offset, 0);
+        assert!(!zero_limit.has_more);
+
         let caught_up = runtime
             .stream_read(&ManagedStreamReadRequest {
                 stream_id: record.stream_id.clone(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9891,6 +9891,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stream_read_reports_cursor_out_of_range_after_latest_offset() {
+        let temp = tempdir().unwrap();
+        let runtime = test_runtime_with_store(&temp);
+        let record = poll_checkpoint_test_record("test", "poll-cursor-range", "run-cursor-range");
+        runtime
+            .managed_sources
+            .store
+            .upsert_source(&record, true)
+            .await
+            .unwrap();
+
+        let checkpoint = crate::subscription_poll::PollCheckpointState {
+            cursor: Some(json!(1)),
+            ..Default::default()
+        };
+        runtime
+            .managed_sources
+            .store
+            .append_events_and_store_poll_checkpoint(
+                &record.namespace,
+                &record.source_key,
+                &record.run_id,
+                &record.stream_id,
+                &[PendingStreamEvent {
+                    ingested_at_unix: now_unix_secs(),
+                    payload: json!({"id": 1}),
+                }],
+                &checkpoint,
+            )
+            .await
+            .unwrap();
+
+        let caught_up = runtime
+            .stream_read(&ManagedStreamReadRequest {
+                stream_id: record.stream_id.clone(),
+                after_offset: 1,
+                limit: 10,
+            })
+            .await
+            .unwrap();
+        assert!(caught_up.events.is_empty());
+        assert_eq!(caught_up.next_after_offset, 1);
+
+        let err = runtime
+            .stream_read(&ManagedStreamReadRequest {
+                stream_id: record.stream_id.clone(),
+                after_offset: 2,
+                limit: 10,
+            })
+            .await
+            .unwrap_err();
+        let structured =
+            structured_error_from_anyhow(&err).expect("cursor error should be structured");
+        assert_eq!(structured.code, "cursor_out_of_range");
+        let details = structured
+            .details
+            .expect("cursor error should include details");
+        assert_eq!(details["stream_id"], record.stream_id);
+        assert_eq!(details["after_offset"], json!(2));
+        assert_eq!(details["latest_offset"], json!(1));
+    }
+
+    #[tokio::test]
     async fn poll_checkpoint_write_failure_does_not_advance_checkpoint() {
         let temp = tempdir().unwrap();
         let runtime = test_runtime_with_store(&temp);

--- a/src/managed_source_streams.rs
+++ b/src/managed_source_streams.rs
@@ -700,6 +700,13 @@ impl ManagedSourceStore {
                     .into());
                 }
             }
+            if limit == 0 {
+                return Ok(StreamReadPage {
+                    events: Vec::new(),
+                    next_after_offset: after_offset,
+                    has_more: false,
+                });
+            }
             let query_limit = limit.saturating_add(1) as u64;
             let mut stmt = conn.prepare(
                 r#"

--- a/src/managed_source_streams.rs
+++ b/src/managed_source_streams.rs
@@ -1,6 +1,8 @@
+use crate::error::StructuredError;
 use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -673,6 +675,31 @@ impl ManagedSourceStore {
         let stream_id = stream_id.to_string();
         tokio::task::spawn_blocking(move || {
             let conn = Connection::open(&path)?;
+            let latest_offset = conn
+                .query_row(
+                    "select max(offset) from stream_events where stream_id = ?1",
+                    params![stream_id],
+                    |row| row.get::<_, Option<u64>>(0),
+                )
+                .optional()?
+                .flatten();
+            if let Some(latest_offset) = latest_offset {
+                if after_offset > latest_offset {
+                    return Err(StructuredError::new(
+                        "cursor_out_of_range",
+                        format!(
+                            "stream read cursor is out of range: after_offset {} is greater than latest_offset {} for stream {}",
+                            after_offset, latest_offset, stream_id
+                        ),
+                        Some(json!({
+                            "stream_id": stream_id,
+                            "after_offset": after_offset,
+                            "latest_offset": latest_offset,
+                        })),
+                    )
+                    .into());
+                }
+            }
             let query_limit = limit.saturating_add(1) as u64;
             let mut stmt = conn.prepare(
                 r#"


### PR DESCRIPTION
## What
- Return a typed `cursor_out_of_range` structured error when `stream read` is called with an `after_offset` greater than the stream's latest event offset.
- Preserve the caught-up behavior where `after_offset == latest_offset` returns an empty events page.
- Add a regression test covering both cases.

## Why
Closes #409.

Consumers need to distinguish a genuinely caught-up stream from a stale cursor after a stream reset/truncate/recreate scenario. Returning an empty page for a future cursor can leave consumers silently stuck.

## How
- Check the current `max(offset)` for the stream before reading events.
- When `after_offset > latest_offset`, return a `StructuredError` with code `cursor_out_of_range` and details including `stream_id`, `after_offset`, and `latest_offset`.
- Leave empty streams and caught-up reads unchanged.

## Testing
- `cargo fmt --all -- --check`
- `cargo test stream_read_reports_cursor_out_of_range_after_latest_offset`
- `cargo check --all-targets`
