### PR TITLE
chore: prepare v0.15.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.6] - 2026-06-06
+
+### Fixed
+- Stabilized daemon socket, log, and database paths by keeping UXC-managed runtime state under the UXC data directory instead of XDG runtime or state environment overrides.
+- Report `cursor_out_of_range` when managed-source stream reads request an offset beyond the latest available stream offset.
+- Refreshed the Feishu OpenAPI schema.
+
+### Performance
+- Reduced managed-source poller hot-path overhead.
+
 ## [0.15.5] - 2026-05-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3104,7 +3104,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uxc"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxc"
-version = "0.15.5"
+version = "0.15.6"
 edition = "2021"
 authors = ["UXC Contributors"]
 description = "A unified CLI for discovering and invoking tools across OpenAPI, MCP, GraphQL, gRPC, and JSON-RPC"

--- a/packages/uxc-daemon-client/package.json
+++ b/packages/uxc-daemon-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holon-run/uxc-daemon-client",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Thin Node.js client for UXC daemon-backed operations",
   "license": "MIT",
   "repository": {

--- a/packages/uxc-daemon-client/src/index.ts
+++ b/packages/uxc-daemon-client/src/index.ts
@@ -1,5 +1,4 @@
 import { execFile } from "node:child_process";
-import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import net from "node:net";
@@ -942,17 +941,17 @@ function normalizeOptions(options: RuntimeInvokeOptions | undefined): RuntimeInv
 }
 
 function defaultSocketPath(env: NodeJS.ProcessEnv | undefined): string {
-  if (env?.XDG_RUNTIME_DIR) {
-    return join(env.XDG_RUNTIME_DIR, "uxc", "uxc.sock");
-  }
   if (env?.HOME) {
     return join(env.HOME, ".uxc", "daemon", "uxc.sock");
   }
-  const label = createHash("sha1")
-    .update(env?.USER ?? env?.USERNAME ?? "user")
-    .digest("hex")
-    .slice(0, 8);
+  const label = bestEffortUserLabel(env);
   return join(tmpdir(), `uxc-${label}`, "daemon", "uxc.sock");
+}
+
+function bestEffortUserLabel(env: NodeJS.ProcessEnv | undefined): string {
+  const raw = env?.USER ?? env?.USERNAME ?? "unknown";
+  const filtered = raw.replace(/[^A-Za-z0-9_-]/g, "_");
+  return filtered.length > 0 ? filtered : "unknown";
 }
 
 function requestId(prefix: string): string {


### PR DESCRIPTION
## What
Prepare the v0.15.6 release.

## Why
Cut a patch release with the fixes merged since v0.15.5 and keep the npm daemon client aligned with the Rust daemon default runtime paths.

## How
- Bumped the Rust crate and `@holon-run/uxc-daemon-client` versions to `0.15.6`.
- Added the `0.15.6` CHANGELOG section.
- Updated the TS daemon client default socket path to use `~/.uxc/daemon/uxc.sock`, matching the Rust daemon default.

## Changes

- [x] Version bumped to `0.15.6`
- [x] CHANGELOG updated for `0.15.6`
- [x] TS daemon client default socket path stabilized to match the Rust daemon

## Testing

### Unit Tests
- [x] All existing tests pass
- [x] `cargo test` passes via release-check

### Manual Testing
- [x] Release validation script completed successfully
- [x] Verified TS daemon client autostart regression test

### Test Results
```bash
./scripts/release-check.sh v0.15.6 --allow-dirty
# [release-check] OK: version=0.15.6

UXC_BIN="$PWD/target/debug/uxc" npm run --workspace @holon-run/uxc-daemon-client test -- test/client.test.ts -t "daemonStatus autostarts"
# 1 test passed

UXC_BIN="$PWD/target/debug/uxc" npm run test:ts
# 18 tests passed
```

## Checklist

- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings (`cargo clippy -- -D warnings`) via release-check
- [x] All tests pass (`cargo test`) via release-check
- [x] Documentation updated (CHANGELOG)
- [x] Commit messages follow convention
- [x] PR title follows convention

## Breaking Changes

None.

## Additional Notes

The daemon client socket path change was required because release-check exposed a mismatch: the TS client used `XDG_RUNTIME_DIR/uxc/uxc.sock` when present, while the Rust daemon default is `~/.uxc/daemon/uxc.sock`.
