### PR TITLE
feat(email): add IMAP IDLE source events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +409,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -450,6 +474,15 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -623,6 +656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +824,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1395,6 +1440,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2188,6 +2243,8 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2212,6 +2269,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3135,6 +3193,7 @@ dependencies = [
  "reqwest",
  "rusqlite",
  "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3143,6 +3202,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-test",
  "tokio-tungstenite",
@@ -3154,6 +3214,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,11 @@ tokio = { version = "1.35", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+tokio-rustls = "0.26"
 async-trait = "0.1"
 futures = "0.3"
+rustls-pki-types = "1"
+webpki-roots = "0.26"
 
 # Web server for test servers
 axum = { version = "0.7", optional = true, features = ["ws"] }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -22,6 +22,10 @@ use crate::subscription_discord::{
     DiscordGatewayBotResponse, DiscordGatewayHandler, DiscordGatewayRuntimeConfig,
     DiscordIdentifyProperties, DISCORD_DEFAULT_MESSAGE_INTENTS,
 };
+use crate::subscription_email::{
+    resolve_email_imap_idle_runtime_config, run_email_imap_idle_subscription_runtime,
+    EmailImapIdleRuntimeConfig,
+};
 use crate::subscription_feishu::{
     derive_feishu_ws_config_endpoint, parse_feishu_long_connection_open_response,
     resolve_feishu_long_connection_runtime_config, FeishuLongConnectionHandler,
@@ -236,6 +240,7 @@ pub enum SubscriptionTransportHint {
     DiscordGateway,
     SlackSocketMode,
     FeishuLongConnection,
+    EmailImapIdle,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -2270,6 +2275,12 @@ fn resolve_stream_subscription_protocol(request: &SubscribeStartRequest) -> Resu
                     );
                 }
                 return Ok("feishu_long_connection".to_string());
+            }
+            SubscriptionTransportHint::EmailImapIdle => {
+                if !lower.starts_with("imap://") && !lower.starts_with("imaps://") {
+                    bail!("email-imap-idle transport requires an imap:// or imaps:// endpoint");
+                }
+                return Ok("email_imap_idle".to_string());
             }
         }
     }
@@ -4655,7 +4666,7 @@ async fn update_subscription_view(
 }
 
 #[async_trait::async_trait]
-trait SubscriptionEventRecorder: Send {
+pub(crate) trait SubscriptionEventRecorder: Send {
     async fn emit(
         &mut self,
         source_kind: &str,
@@ -5192,6 +5203,13 @@ async fn run_stream_subscription_job(
         )
         .await;
     }
+    if matches!(
+        request.transport_hint,
+        Some(SubscriptionTransportHint::EmailImapIdle)
+    ) {
+        return run_email_imap_idle_subscription_job(job_id, request, event_tx, view, stop_rx)
+            .await;
+    }
 
     if request.operation_id.is_some() {
         if request
@@ -5703,6 +5721,29 @@ async fn run_slack_socket_mode_subscription_job(
             }
         }
     }
+}
+
+async fn run_email_imap_idle_subscription_job(
+    _job_id: &str,
+    request: &SubscribeStartRequest,
+    event_tx: mpsc::Sender<SubscriptionEventEnvelope>,
+    view: Arc<Mutex<SubscriptionJobView>>,
+    mut stop_rx: watch::Receiver<bool>,
+) -> Result<()> {
+    let auth_profile =
+        auth::resolve_auth_for_endpoint(&request.endpoint, request.options.auth.clone())?
+            .ok_or_else(|| {
+                anyhow!("email-imap-idle requires an auth profile with username/password fields")
+            })?;
+    let config: EmailImapIdleRuntimeConfig =
+        resolve_email_imap_idle_runtime_config(request, &auth_profile)?;
+    let mut seq = 0u64;
+    let mut recorder = ChannelSubscriptionRecorder {
+        tx: &event_tx,
+        view: &view,
+        seq: &mut seq,
+    };
+    run_email_imap_idle_subscription_runtime(config, &mut recorder, &mut stop_rx).await
 }
 
 async fn run_feishu_long_connection_subscription_job(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod output;
 pub mod protocol;
 pub mod schema_mapping;
 pub mod subscription_discord;
+pub mod subscription_email;
 pub mod subscription_feishu;
 pub mod subscription_graphql;
 pub mod subscription_jsonrpc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod managed_source_streams;
 mod output;
 mod schema_mapping;
 mod subscription_discord;
+mod subscription_email;
 mod subscription_feishu;
 mod subscription_graphql;
 mod subscription_jsonrpc;
@@ -76,6 +77,7 @@ enum SubscribeTransportArg {
     DiscordGateway,
     SlackSocketMode,
     FeishuLongConnection,
+    EmailImapIdle,
 }
 
 #[derive(Parser)]
@@ -2253,18 +2255,19 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
         ["source", "ensure"] => HelpData {
             path: "uxc source ensure".to_string(),
             about: "Ensure a managed source exists and is running".to_string(),
-            usage: "uxc source ensure <namespace> <source_key> <endpoint> [<operation_id> [key=value ... | '{...}']] [--transport websocket|discord-gateway|slack-socket-mode|feishu-long-connection] [--subprotocol <value> ...] [--init-frame <text-or-json> ...] [--mode <stream|poll>] [--poll-config <json>] [--resource-uri <uri>] [--read-resource]".to_string(),
+            usage: "uxc source ensure <namespace> <source_key> <endpoint> [<operation_id> [key=value ... | '{...}']] [--transport websocket|discord-gateway|slack-socket-mode|feishu-long-connection|email-imap-idle] [--subprotocol <value> ...] [--init-frame <text-or-json> ...] [--mode <stream|poll>] [--poll-config <json>] [--resource-uri <uri>] [--read-resource]".to_string(),
             commands: vec![],
             notes: vec![
                 "Managed source identity is (namespace, source_key); the durable stream stays stable across spec replacements for the same identity.".to_string(),
                 "Spec changes replace the current run and reset checkpoint state by default, while preserving the managed stream.".to_string(),
                 "Managed source streams persist only raw payload rows. Lifecycle/runtime events remain visible through source status rather than stream rows.".to_string(),
-                "Supports raw websocket, GraphQL subscription, JSON-RPC pubsub, MCP resource subscriptions, Discord Gateway, Slack Socket Mode, Feishu long connection, and poll mode.".to_string(),
+                "Supports raw websocket, GraphQL subscription, JSON-RPC pubsub, MCP resource subscriptions, Discord Gateway, Slack Socket Mode, Feishu long connection, email IMAP IDLE, and poll mode.".to_string(),
             ],
             examples: vec![
                 "uxc source ensure agentinbox github_repo:holon-run/uxc https://api.github.com get:/repos/{owner}/{repo}/events owner=holon-run repo=uxc --mode poll --poll-config '{\"interval_secs\":30,\"extract_items_pointer\":\"\",\"checkpoint_strategy\":{\"type\":\"item_key\",\"item_key_pointer\":\"/id\"}}'".to_string(),
                 "uxc source ensure market okx:btc-usdt wss://ws.okx.com:8443/ws/v5/public --transport websocket --init-frame '{\"op\":\"subscribe\",\"args\":[{\"channel\":\"tickers\",\"instId\":\"BTC-USDT\"}]}'".to_string(),
                 "uxc source ensure team discord-gateway https://discord.com/api/v10 --transport discord-gateway --auth discord-bot '{\"intents\":37377}'".to_string(),
+                "uxc source ensure agentinbox email:primary imaps://imap.example.com:993 --transport email-imap-idle --auth email-primary mailbox=INBOX".to_string(),
             ],
         },
         ["source", "status"] => HelpData {
@@ -5396,6 +5399,7 @@ fn build_managed_source_spec(
         SubscribeTransportArg::FeishuLongConnection => {
             daemon::SubscriptionTransportHint::FeishuLongConnection
         }
+        SubscribeTransportArg::EmailImapIdle => daemon::SubscriptionTransportHint::EmailImapIdle,
     });
     let mut transport_operation_id = input.operation_id.clone();
     let mut transport_input_json = input.input_json.clone();
@@ -5523,6 +5527,29 @@ fn build_managed_source_spec(
             .into());
         }
     }
+    if matches!(
+        transport_hint,
+        Some(daemon::SubscriptionTransportHint::EmailImapIdle)
+    ) {
+        if input.operation_id.is_some() {
+            return Err(UxcError::InvalidArguments(
+                "--transport email-imap-idle cannot be combined with an operation_id".to_string(),
+            )
+            .into());
+        }
+        if input.resource_uri.is_some() {
+            return Err(UxcError::InvalidArguments(
+                "--transport email-imap-idle cannot be combined with --resource-uri".to_string(),
+            )
+            .into());
+        }
+        if !matches!(input.mode, SubscribeModeArg::Stream) {
+            return Err(UxcError::InvalidArguments(
+                "--transport email-imap-idle is only valid with --mode stream".to_string(),
+            )
+            .into());
+        }
+    }
     if input.read_resource && input.resource_uri.is_none() {
         return Err(UxcError::InvalidArguments(
             "--read-resource requires --resource-uri".to_string(),
@@ -5561,14 +5588,22 @@ fn build_managed_source_spec(
             ) || matches!(
                 transport_hint,
                 Some(daemon::SubscriptionTransportHint::FeishuLongConnection)
+            ) || matches!(
+                transport_hint,
+                Some(daemon::SubscriptionTransportHint::EmailImapIdle)
             ) {
                 let fallback_op = if matches!(
                     transport_hint,
                     Some(daemon::SubscriptionTransportHint::DiscordGateway)
                 ) {
                     "discord-gateway"
-                } else {
+                } else if matches!(
+                    transport_hint,
+                    Some(daemon::SubscriptionTransportHint::FeishuLongConnection)
+                ) {
                     "feishu-long-connection"
+                } else {
+                    "email-imap-idle"
                 };
                 let mut explicit_args = Vec::new();
                 let mut positional = Vec::new();

--- a/src/subscription_email.rs
+++ b/src/subscription_email.rs
@@ -9,7 +9,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{
-    AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, ReadHalf, WriteHalf,
+    AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader, ReadHalf,
+    WriteHalf,
 };
 use tokio::net::TcpStream;
 use tokio::sync::watch;
@@ -196,7 +197,7 @@ where
         .await?;
     recorder.update_status(Some("running"), None, false).await?;
 
-    emit_recent_messages(config, &mut conn, recorder).await?;
+    let mut last_seen_uid = emit_recent_messages(config, &mut conn, recorder).await?;
 
     loop {
         if *stop_rx.borrow() {
@@ -204,12 +205,11 @@ where
             close_email_subscription(recorder, "stopped").await?;
             return Ok(());
         }
-        conn.write_line("IDLE").await?;
-        conn.read_idle_continuation().await?;
+        let idle_tag = conn.start_idle().await?;
         tokio::select! {
             changed = stop_rx.changed() => {
                 if changed.is_ok() && *stop_rx.borrow() {
-                    conn.done_idle().await?;
+                    conn.done_idle(&idle_tag).await?;
                     let _ = conn.logout().await;
                     close_email_subscription(recorder, "stopped").await?;
                     return Ok(());
@@ -218,8 +218,14 @@ where
             line = conn.read_line() => {
                 let line = line?;
                 if line.contains(" EXISTS") || line.contains(" RECENT") {
-                    conn.done_idle().await?;
-                    emit_recent_messages(config, &mut conn, recorder).await?;
+                    conn.done_idle(&idle_tag).await?;
+                    let messages = match last_seen_uid {
+                        Some(uid) => conn.fetch_since_uid(uid).await?,
+                        None => conn.fetch_recent(config.initial_fetch_limit).await?,
+                    };
+                    if let Some(uid) = emit_messages(config, messages, recorder).await? {
+                        last_seen_uid = Some(last_seen_uid.map_or(uid, |last| last.max(uid)));
+                    }
                 }
             }
         }
@@ -264,12 +270,27 @@ async fn emit_recent_messages<R>(
     config: &EmailImapIdleRuntimeConfig,
     conn: &mut ImapConnection,
     recorder: &mut R,
-) -> Result<()>
+) -> Result<Option<u64>>
 where
     R: SubscriptionEventRecorder,
 {
     let messages = conn.fetch_recent(config.initial_fetch_limit).await?;
+    emit_messages(config, messages, recorder).await
+}
+
+async fn emit_messages<R>(
+    config: &EmailImapIdleRuntimeConfig,
+    messages: Vec<ImapFetchedMessage>,
+    recorder: &mut R,
+) -> Result<Option<u64>>
+where
+    R: SubscriptionEventRecorder,
+{
+    let mut max_uid = None;
     for message in messages {
+        if let Some(uid) = parse_uid_number(&message.uid) {
+            max_uid = Some(max_uid.map_or(uid, |max: u64| max.max(uid)));
+        }
         recorder
             .emit(
                 "email_imap_idle",
@@ -279,7 +300,7 @@ where
             )
             .await?;
     }
-    Ok(())
+    Ok(max_uid)
 }
 
 fn build_email_event(config: &EmailImapIdleRuntimeConfig, message: &ImapFetchedMessage) -> Value {
@@ -473,7 +494,7 @@ impl ImapConnection {
         self.write_line(&format!("{tag} {command}")).await?;
         let mut lines = Vec::new();
         loop {
-            let line = self.read_line().await?;
+            let line = self.read_response_line_with_literals().await?;
             let done = line.starts_with(&format!("{tag} "));
             lines.push(line);
             if done {
@@ -481,6 +502,24 @@ impl ImapConnection {
             }
         }
         Ok(lines)
+    }
+
+    async fn read_response_line_with_literals(&mut self) -> Result<String> {
+        let mut line = self.read_line().await?;
+        while let Some(len) = trailing_literal_len(&line) {
+            let mut literal = vec![0u8; len];
+            tokio::time::timeout(
+                Duration::from_secs(IMAP_COMMAND_TIMEOUT_SECS),
+                self.reader.read_exact(&mut literal),
+            )
+            .await
+            .context("IMAP literal read timed out")??;
+            let suffix = self.read_line().await?;
+            line.push_str("\r\n");
+            line.push_str(&String::from_utf8_lossy(&literal));
+            line.push_str(&suffix);
+        }
+        Ok(line)
     }
 
     async fn command_ok(&mut self, command: &str) -> Result<Vec<String>> {
@@ -496,37 +535,55 @@ impl ImapConnection {
     }
 
     async fn fetch_recent(&mut self, limit: usize) -> Result<Vec<ImapFetchedMessage>> {
-        let range = if limit == 0 {
-            "*".to_string()
-        } else {
-            format!("{}:*", limit)
-        };
+        let search_lines = self.command_ok("UID SEARCH ALL").await?;
+        let mut uids = parse_uid_search_uids(&search_lines);
+        if limit > 0 && uids.len() > limit {
+            uids = uids.split_off(uids.len() - limit);
+        }
+        if uids.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.fetch_uid_set(&uids.join(",")).await
+    }
+
+    async fn fetch_since_uid(&mut self, last_uid: u64) -> Result<Vec<ImapFetchedMessage>> {
+        self.fetch_uid_set(&format!("{}:*", last_uid.saturating_add(1)))
+            .await
+    }
+
+    async fn fetch_uid_set(&mut self, uid_set: &str) -> Result<Vec<ImapFetchedMessage>> {
         let lines = self
-            .command_ok(&format!("UID FETCH {range} (UID FLAGS BODY.PEEK[])"))
+            .command_ok(&format!("UID FETCH {uid_set} (UID FLAGS BODY.PEEK[])"))
             .await?;
         Ok(parse_uid_fetch_messages(&lines))
     }
 
-    async fn read_idle_continuation(&mut self) -> Result<()> {
+    async fn start_idle(&mut self) -> Result<String> {
+        let tag = format!("A{:04}", self.next_tag);
+        self.next_tag = self.next_tag.saturating_add(1);
+        self.write_line(&format!("{tag} IDLE")).await?;
         let line = self.read_line().await?;
         if !line.starts_with('+') {
             bail!("IMAP IDLE expected continuation, got: {}", line);
         }
-        Ok(())
+        Ok(tag)
     }
 
-    async fn done_idle(&mut self) -> Result<()> {
+    async fn done_idle(&mut self, tag: &str) -> Result<()> {
         self.write_line("DONE").await?;
-        let _ = tokio::time::timeout(Duration::from_secs(IMAP_IDLE_DONE_TIMEOUT_SECS), async {
+        tokio::time::timeout(Duration::from_secs(IMAP_IDLE_DONE_TIMEOUT_SECS), async {
             loop {
                 let line = self.read_line().await?;
-                if line.contains(" IDLE") || line.contains(" OK") {
-                    return Ok::<_, anyhow::Error>(());
+                if line.starts_with(&format!("{tag} ")) {
+                    if line.contains(" OK") {
+                        return Ok::<_, anyhow::Error>(());
+                    }
+                    bail!("IMAP IDLE DONE failed: {}", line);
                 }
             }
         })
-        .await;
-        Ok(())
+        .await
+        .context("IMAP IDLE DONE timed out")?
     }
 
     async fn logout(&mut self) -> Result<()> {
@@ -557,6 +614,29 @@ pub fn parse_uid_fetch_messages(lines: &[String]) -> Vec<ImapFetchedMessage> {
     out
 }
 
+fn parse_uid_search_uids(lines: &[String]) -> Vec<String> {
+    lines
+        .iter()
+        .filter_map(|line| line.strip_prefix("* SEARCH "))
+        .flat_map(|line| line.split_whitespace())
+        .filter(|uid| uid.chars().all(|ch| ch.is_ascii_digit()))
+        .map(str::to_string)
+        .collect()
+}
+
+fn parse_uid_number(uid: &str) -> Option<u64> {
+    uid.parse().ok()
+}
+
+fn trailing_literal_len(line: &str) -> Option<usize> {
+    let open = line.rfind('{')?;
+    let len = line.get(open + 1..line.len().checked_sub(1)?)?;
+    if !line.ends_with('}') || len.is_empty() || !len.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    len.parse().ok()
+}
+
 fn extract_imap_atom_after(line: &str, marker: &str) -> Option<String> {
     let start = line.find(marker)? + marker.len();
     let tail = &line[start..];
@@ -581,10 +661,13 @@ fn extract_imap_literal_or_quoted_body(line: &str) -> Option<String> {
         return Some(tail[..end].replace("\\\"", "\"").replace("\\\\", "\\"));
     }
     if let Some(start) = line.find("BODY[] {") {
-        let tail = &line[start..];
-        if let Some(pos) = tail.find("}\r\n") {
-            return Some(tail[pos + 3..].trim_end_matches(')').to_string());
-        }
+        let len_start = start + "BODY[] {".len();
+        let len_end = line[len_start..].find('}')? + len_start;
+        let len: usize = line[len_start..len_end].parse().ok()?;
+        let raw_start = line[len_end..].find("\r\n")? + len_end + 2;
+        let raw_end = raw_start.checked_add(len)?;
+        let bytes = line.as_bytes().get(raw_start..raw_end)?;
+        return Some(String::from_utf8_lossy(bytes).to_string());
     }
     None
 }
@@ -639,5 +722,90 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].uid, "42");
         assert_eq!(messages[0].flags, vec!["\\Seen"]);
+    }
+
+    #[test]
+    fn parses_uid_fetch_literal_with_embedded_newlines() {
+        let raw = "Subject: Hi\r\n\r\nLine one\r\nLine two) end";
+        let lines = vec![
+            format!(
+                "* 1 FETCH (UID 42 FLAGS (\\Seen) BODY[] {{{}}}\r\n{})",
+                raw.len(),
+                raw
+            ),
+            "A0001 OK done".to_string(),
+        ];
+        let messages = parse_uid_fetch_messages(&lines);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].uid, "42");
+        assert_eq!(messages[0].raw, raw.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn imap_command_reads_literal_bytes_before_next_response_line() {
+        let raw = "Subject: Hi\r\n\r\nLine one\r\nLine two";
+        let (client, server) = tokio::io::duplex(2048);
+        let mut conn = ImapConnection::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut command = String::new();
+            reader.read_line(&mut command).await.unwrap();
+            assert_eq!(command, "A0001 UID FETCH 42 (UID FLAGS BODY.PEEK[])\r\n");
+            writer
+                .write_all(
+                    format!(
+                        "* 1 FETCH (UID 42 FLAGS (\\Seen) BODY[] {{{}}}\r\n{})\r\nA0001 OK done\r\n",
+                        raw.len(),
+                        raw
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+
+        let messages = conn.fetch_uid_set("42").await.unwrap();
+        server.await.unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].raw, raw.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn fetch_recent_searches_all_uids_and_fetches_last_limit() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut conn = ImapConnection::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut command = String::new();
+
+            reader.read_line(&mut command).await.unwrap();
+            assert_eq!(command, "A0001 UID SEARCH ALL\r\n");
+            writer
+                .write_all(b"* SEARCH 1 2 42 43\r\nA0001 OK search done\r\n")
+                .await
+                .unwrap();
+
+            command.clear();
+            reader.read_line(&mut command).await.unwrap();
+            assert_eq!(command, "A0002 UID FETCH 42,43 (UID FLAGS BODY.PEEK[])\r\n");
+            writer
+                .write_all(
+                    b"* 3 FETCH (UID 42 FLAGS () BODY[] \"Subject: Old\r\n\r\nOld\")\r\n* 4 FETCH (UID 43 FLAGS () BODY[] \"Subject: New\r\n\r\nNew\")\r\nA0002 OK fetch done\r\n",
+                )
+                .await
+                .unwrap();
+        });
+
+        let messages = conn.fetch_recent(2).await.unwrap();
+        server.await.unwrap();
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.uid.as_str())
+                .collect::<Vec<_>>(),
+            vec!["42", "43"]
+        );
     }
 }

--- a/src/subscription_email.rs
+++ b/src/subscription_email.rs
@@ -1,0 +1,643 @@
+use crate::auth::Profile;
+use crate::daemon::{SubscribeStartRequest, SubscriptionEventRecorder};
+use crate::daemon_log::redact_endpoint;
+use anyhow::{anyhow, bail, Context, Result};
+use rustls_pki_types::ServerName;
+use serde_json::{json, Map, Value};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{
+    AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, ReadHalf, WriteHalf,
+};
+use tokio::net::TcpStream;
+use tokio::sync::watch;
+use tokio_rustls::rustls::{ClientConfig, RootCertStore};
+use tokio_rustls::TlsConnector;
+use url::Url;
+
+const DEFAULT_MAILBOX: &str = "INBOX";
+const IMAP_CONNECT_TIMEOUT_SECS: u64 = 10;
+const IMAP_COMMAND_TIMEOUT_SECS: u64 = 30;
+const IMAP_IDLE_DONE_TIMEOUT_SECS: u64 = 5;
+const EMAIL_SNIPPET_CHARS: usize = 512;
+const EMAIL_RAW_INLINE_BYTES: usize = 32 * 1024;
+
+trait AsyncReadWrite: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T> AsyncReadWrite for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
+
+type BoxedIo = Box<dyn AsyncReadWrite>;
+type BoxFutureResult<T> = Pin<Box<dyn Future<Output = Result<T>> + Send>>;
+
+#[derive(Debug, Clone)]
+pub struct EmailImapIdleRuntimeConfig {
+    pub endpoint: String,
+    pub host: String,
+    pub port: u16,
+    pub use_tls: bool,
+    pub username: String,
+    pub password: String,
+    pub mailbox: String,
+    pub account: Option<String>,
+    pub initial_fetch_limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImapFetchedMessage {
+    pub uid: String,
+    pub flags: Vec<String>,
+    pub raw: Vec<u8>,
+}
+
+pub fn resolve_email_imap_idle_runtime_config(
+    request: &SubscribeStartRequest,
+    auth_profile: &Profile,
+) -> Result<EmailImapIdleRuntimeConfig> {
+    let url = Url::parse(&request.endpoint).context("invalid email IMAP endpoint")?;
+    let use_tls = match url.scheme() {
+        "imaps" => true,
+        "imap" => false,
+        other => bail!(
+            "email-imap-idle transport requires imap:// or imaps:// endpoint, got '{}'",
+            other
+        ),
+    };
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow!("email-imap-idle endpoint missing host"))?
+        .to_string();
+    let port = url.port().unwrap_or(if use_tls { 993 } else { 143 });
+    let args = request.args.as_ref();
+    let mailbox = args
+        .and_then(|args| args.get("mailbox"))
+        .and_then(Value::as_str)
+        .unwrap_or(DEFAULT_MAILBOX)
+        .to_string();
+    let account = args
+        .and_then(|args| args.get("account"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| auth_profile.resolve_field_value("account").ok().flatten());
+    let initial_fetch_limit = args
+        .and_then(|args| args.get("initial_fetch_limit"))
+        .and_then(Value::as_u64)
+        .unwrap_or(25)
+        .min(100) as usize;
+    let username = resolve_first_profile_field(auth_profile, &["username", "user", "email"])?
+        .ok_or_else(|| {
+            anyhow!("email-imap-idle auth profile requires username/user/email field")
+        })?;
+    let password =
+        resolve_first_profile_field(auth_profile, &["password", "app_password", "secret"])?
+            .ok_or_else(|| {
+                anyhow!("email-imap-idle auth profile requires password/app_password/secret field")
+            })?;
+    Ok(EmailImapIdleRuntimeConfig {
+        endpoint: request.endpoint.clone(),
+        host,
+        port,
+        use_tls,
+        username,
+        password,
+        mailbox,
+        account,
+        initial_fetch_limit,
+    })
+}
+
+fn resolve_first_profile_field(profile: &Profile, names: &[&str]) -> Result<Option<String>> {
+    for name in names {
+        if let Some(value) = profile.resolve_field_value(name)? {
+            return Ok(Some(value));
+        }
+    }
+    Ok(None)
+}
+
+pub(crate) async fn run_email_imap_idle_subscription_runtime<R>(
+    config: EmailImapIdleRuntimeConfig,
+    recorder: &mut R,
+    stop_rx: &mut watch::Receiver<bool>,
+) -> Result<()>
+where
+    R: SubscriptionEventRecorder,
+{
+    let mut delay_secs = 1u64;
+    loop {
+        match run_email_imap_idle_session_once(&config, recorder, stop_rx, connect_imap).await {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                let message = err.to_string();
+                recorder
+                    .emit(
+                        "email_imap_idle",
+                        "error",
+                        None,
+                        Some(json!({ "message": message })),
+                    )
+                    .await?;
+                recorder
+                    .update_status(Some("reconnecting"), Some(message), true)
+                    .await?;
+                recorder
+                    .emit(
+                        "email_imap_idle",
+                        "reconnect",
+                        None,
+                        Some(json!({ "delay_secs": delay_secs })),
+                    )
+                    .await?;
+                if wait_for_stop_or_timeout(stop_rx, Duration::from_secs(delay_secs)).await {
+                    close_email_subscription(recorder, "stopped").await?;
+                    return Ok(());
+                }
+                delay_secs = delay_secs.saturating_mul(2).min(60);
+            }
+        }
+    }
+}
+
+async fn run_email_imap_idle_session_once<R, C>(
+    config: &EmailImapIdleRuntimeConfig,
+    recorder: &mut R,
+    stop_rx: &mut watch::Receiver<bool>,
+    connector: C,
+) -> Result<()>
+where
+    R: SubscriptionEventRecorder,
+    C: Fn(EmailImapIdleRuntimeConfig) -> BoxFutureResult<ImapConnection> + Copy,
+{
+    if *stop_rx.borrow() {
+        close_email_subscription(recorder, "stopped").await?;
+        return Ok(());
+    }
+    let mut conn = connector(config.clone()).await?;
+    conn.expect_greeting().await?;
+    conn.command_ok(&format!(
+        "LOGIN {} {}",
+        quote_imap_string(&config.username),
+        quote_imap_string(&config.password)
+    ))
+    .await?;
+    conn.command_ok(&format!("SELECT {}", quote_imap_string(&config.mailbox)))
+        .await?;
+    recorder
+        .emit(
+            "email_imap_idle",
+            "open",
+            None,
+            Some(json!({
+                "url": redact_endpoint(&config.endpoint),
+                "mailbox": config.mailbox,
+                "account": config.account,
+            })),
+        )
+        .await?;
+    recorder.update_status(Some("running"), None, false).await?;
+
+    emit_recent_messages(config, &mut conn, recorder).await?;
+
+    loop {
+        if *stop_rx.borrow() {
+            let _ = conn.logout().await;
+            close_email_subscription(recorder, "stopped").await?;
+            return Ok(());
+        }
+        conn.write_line("IDLE").await?;
+        conn.read_idle_continuation().await?;
+        tokio::select! {
+            changed = stop_rx.changed() => {
+                if changed.is_ok() && *stop_rx.borrow() {
+                    conn.done_idle().await?;
+                    let _ = conn.logout().await;
+                    close_email_subscription(recorder, "stopped").await?;
+                    return Ok(());
+                }
+            }
+            line = conn.read_line() => {
+                let line = line?;
+                if line.contains(" EXISTS") || line.contains(" RECENT") {
+                    conn.done_idle().await?;
+                    emit_recent_messages(config, &mut conn, recorder).await?;
+                }
+            }
+        }
+    }
+}
+
+fn connect_imap(config: EmailImapIdleRuntimeConfig) -> BoxFutureResult<ImapConnection> {
+    Box::pin(async move {
+        let tcp = tokio::time::timeout(
+            Duration::from_secs(IMAP_CONNECT_TIMEOUT_SECS),
+            TcpStream::connect((config.host.as_str(), config.port)),
+        )
+        .await
+        .context("IMAP connect timed out")?
+        .with_context(|| format!("failed to connect to {}:{}", config.host, config.port))?;
+        let io: BoxedIo = if config.use_tls {
+            let mut roots = RootCertStore::empty();
+            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            let tls_config = ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth();
+            let connector = TlsConnector::from(Arc::new(tls_config));
+            let server_name = ServerName::try_from(config.host.clone())
+                .map_err(|_| anyhow!("invalid IMAP TLS server name"))?;
+            Box::new(
+                tokio::time::timeout(
+                    Duration::from_secs(IMAP_CONNECT_TIMEOUT_SECS),
+                    connector.connect(server_name, tcp),
+                )
+                .await
+                .context("IMAP TLS handshake timed out")?
+                .context("IMAP TLS handshake failed")?,
+            )
+        } else {
+            Box::new(tcp)
+        };
+        Ok(ImapConnection::new(io))
+    })
+}
+
+async fn emit_recent_messages<R>(
+    config: &EmailImapIdleRuntimeConfig,
+    conn: &mut ImapConnection,
+    recorder: &mut R,
+) -> Result<()>
+where
+    R: SubscriptionEventRecorder,
+{
+    let messages = conn.fetch_recent(config.initial_fetch_limit).await?;
+    for message in messages {
+        recorder
+            .emit(
+                "email_imap_idle",
+                "data",
+                Some(build_email_event(config, &message)),
+                None,
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+fn build_email_event(config: &EmailImapIdleRuntimeConfig, message: &ImapFetchedMessage) -> Value {
+    let raw_len = message.raw.len();
+    let raw_text = String::from_utf8_lossy(&message.raw);
+    let headers = parse_email_headers(&raw_text);
+    let subject = header_value(&headers, "subject");
+    let message_id = header_value(&headers, "message-id").unwrap_or_else(|| message.uid.clone());
+    let thread_id =
+        header_value(&headers, "references").or_else(|| header_value(&headers, "in-reply-to"));
+    let account = config.account.as_deref().unwrap_or(&config.username);
+    json!({
+        "type": "email_event",
+        "version": "v1",
+        "provider": "imap",
+        "account": account,
+        "mailbox": config.mailbox,
+        "event_kind": "message_received",
+        "message": {
+            "uid": message.uid,
+            "message_id": message_id,
+            "thread_id": thread_id,
+            "conversation_id": null,
+            "from": header_value(&headers, "from"),
+            "to": split_address_header(header_value(&headers, "to").as_deref()),
+            "cc": split_address_header(header_value(&headers, "cc").as_deref()),
+            "bcc": split_address_header(header_value(&headers, "bcc").as_deref()),
+            "subject": subject,
+            "date": header_value(&headers, "date"),
+            "snippet": body_snippet(&raw_text),
+            "attachments": [],
+            "flags": message.flags,
+        },
+        "raw": {
+            "mime_inline": if raw_len <= EMAIL_RAW_INLINE_BYTES { Some(raw_text.to_string()) } else { None },
+            "mime_truncated": raw_len > EMAIL_RAW_INLINE_BYTES,
+            "size_bytes": raw_len,
+        },
+        "reply_handle": {
+            "type": "email_imap",
+            "provider": "imap",
+            "account": account,
+            "mailbox": config.mailbox,
+            "message_id": message_id,
+            "uid": message.uid,
+        }
+    })
+}
+
+fn parse_email_headers(raw: &str) -> Map<String, Value> {
+    let header_text = raw
+        .split("\r\n\r\n")
+        .next()
+        .unwrap_or(raw)
+        .split("\n\n")
+        .next()
+        .unwrap_or(raw);
+    let mut headers = Map::new();
+    let mut current_name: Option<String> = None;
+    let mut current_value = String::new();
+    for line in header_text.lines() {
+        if line.starts_with(' ') || line.starts_with('\t') {
+            if !current_value.is_empty() {
+                current_value.push(' ');
+            }
+            current_value.push_str(line.trim());
+            continue;
+        }
+        if let Some(name) = current_name.take() {
+            headers.insert(name, Value::String(current_value.trim().to_string()));
+            current_value.clear();
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            current_name = Some(name.trim().to_ascii_lowercase());
+            current_value.push_str(value.trim());
+        }
+    }
+    if let Some(name) = current_name {
+        headers.insert(name, Value::String(current_value.trim().to_string()));
+    }
+    headers
+}
+
+fn header_value(headers: &Map<String, Value>, name: &str) -> Option<String> {
+    headers
+        .get(&name.to_ascii_lowercase())
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn split_address_header(value: Option<&str>) -> Vec<Value> {
+    value
+        .into_iter()
+        .flat_map(|value| value.split(','))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| json!({ "raw": value }))
+        .collect()
+}
+
+fn body_snippet(raw: &str) -> Option<String> {
+    let body = raw
+        .split_once("\r\n\r\n")
+        .map(|(_, body)| body)
+        .or_else(|| raw.split_once("\n\n").map(|(_, body)| body))?;
+    let normalized = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized.chars().take(EMAIL_SNIPPET_CHARS).collect())
+    }
+}
+
+fn quote_imap_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+async fn close_email_subscription<R: SubscriptionEventRecorder>(
+    recorder: &mut R,
+    reason: &str,
+) -> Result<()> {
+    recorder
+        .emit(
+            "email_imap_idle",
+            "closed",
+            None,
+            Some(json!({ "reason": reason })),
+        )
+        .await?;
+    recorder.update_status(Some("stopped"), None, false).await
+}
+
+async fn wait_for_stop_or_timeout(stop_rx: &mut watch::Receiver<bool>, duration: Duration) -> bool {
+    if *stop_rx.borrow() {
+        return true;
+    }
+    tokio::select! {
+        changed = stop_rx.changed() => matches!(changed, Ok(())) && *stop_rx.borrow(),
+        _ = tokio::time::sleep(duration) => false,
+    }
+}
+
+pub struct ImapConnection {
+    reader: BufReader<ReadHalf<BoxedIo>>,
+    writer: WriteHalf<BoxedIo>,
+    next_tag: u64,
+}
+
+impl ImapConnection {
+    fn new(io: BoxedIo) -> Self {
+        let (reader, writer) = tokio::io::split(io);
+        Self {
+            reader: BufReader::new(reader),
+            writer,
+            next_tag: 1,
+        }
+    }
+
+    async fn expect_greeting(&mut self) -> Result<()> {
+        let line = self.read_line().await?;
+        if !line.starts_with("* OK") && !line.starts_with("* PREAUTH") {
+            bail!("unexpected IMAP greeting: {}", line);
+        }
+        Ok(())
+    }
+
+    async fn write_line(&mut self, line: &str) -> Result<()> {
+        self.writer.write_all(line.as_bytes()).await?;
+        self.writer.write_all(b"\r\n").await?;
+        self.writer.flush().await?;
+        Ok(())
+    }
+
+    async fn read_line(&mut self) -> Result<String> {
+        let mut line = String::new();
+        let read = tokio::time::timeout(
+            Duration::from_secs(IMAP_COMMAND_TIMEOUT_SECS),
+            self.reader.read_line(&mut line),
+        )
+        .await
+        .context("IMAP read timed out")??;
+        if read == 0 {
+            bail!("IMAP connection closed");
+        }
+        Ok(line.trim_end_matches(['\r', '\n']).to_string())
+    }
+
+    async fn command(&mut self, command: &str) -> Result<Vec<String>> {
+        let tag = format!("A{:04}", self.next_tag);
+        self.next_tag = self.next_tag.saturating_add(1);
+        self.write_line(&format!("{tag} {command}")).await?;
+        let mut lines = Vec::new();
+        loop {
+            let line = self.read_line().await?;
+            let done = line.starts_with(&format!("{tag} "));
+            lines.push(line);
+            if done {
+                break;
+            }
+        }
+        Ok(lines)
+    }
+
+    async fn command_ok(&mut self, command: &str) -> Result<Vec<String>> {
+        let lines = self.command(command).await?;
+        if lines.last().is_some_and(|line| line.contains(" OK")) {
+            Ok(lines)
+        } else {
+            bail!(
+                "IMAP command failed: {}",
+                lines.last().cloned().unwrap_or_default()
+            )
+        }
+    }
+
+    async fn fetch_recent(&mut self, limit: usize) -> Result<Vec<ImapFetchedMessage>> {
+        let range = if limit == 0 {
+            "*".to_string()
+        } else {
+            format!("{}:*", limit)
+        };
+        let lines = self
+            .command_ok(&format!("UID FETCH {range} (UID FLAGS BODY.PEEK[])"))
+            .await?;
+        Ok(parse_uid_fetch_messages(&lines))
+    }
+
+    async fn read_idle_continuation(&mut self) -> Result<()> {
+        let line = self.read_line().await?;
+        if !line.starts_with('+') {
+            bail!("IMAP IDLE expected continuation, got: {}", line);
+        }
+        Ok(())
+    }
+
+    async fn done_idle(&mut self) -> Result<()> {
+        self.write_line("DONE").await?;
+        let _ = tokio::time::timeout(Duration::from_secs(IMAP_IDLE_DONE_TIMEOUT_SECS), async {
+            loop {
+                let line = self.read_line().await?;
+                if line.contains(" IDLE") || line.contains(" OK") {
+                    return Ok::<_, anyhow::Error>(());
+                }
+            }
+        })
+        .await;
+        Ok(())
+    }
+
+    async fn logout(&mut self) -> Result<()> {
+        let _ = self.command("LOGOUT").await;
+        Ok(())
+    }
+}
+
+pub fn parse_uid_fetch_messages(lines: &[String]) -> Vec<ImapFetchedMessage> {
+    let mut out = Vec::new();
+    for line in lines {
+        if !line.starts_with('*') || !line.contains(" FETCH ") {
+            continue;
+        }
+        let Some(uid) = extract_imap_atom_after(line, "UID ") else {
+            continue;
+        };
+        let flags = extract_imap_parenthesized_after(line, "FLAGS ")
+            .map(|raw| raw.split_whitespace().map(str::to_string).collect())
+            .unwrap_or_default();
+        let raw = extract_imap_literal_or_quoted_body(line).unwrap_or_default();
+        out.push(ImapFetchedMessage {
+            uid,
+            flags,
+            raw: raw.into_bytes(),
+        });
+    }
+    out
+}
+
+fn extract_imap_atom_after(line: &str, marker: &str) -> Option<String> {
+    let start = line.find(marker)? + marker.len();
+    let tail = &line[start..];
+    let end = tail
+        .find(|ch: char| ch.is_whitespace() || ch == ')' || ch == '(')
+        .unwrap_or(tail.len());
+    Some(tail[..end].to_string())
+}
+
+fn extract_imap_parenthesized_after(line: &str, marker: &str) -> Option<String> {
+    let start = line.find(marker)? + marker.len();
+    let tail = &line[start..];
+    let open = tail.find('(')? + 1;
+    let close = tail[open..].find(')')? + open;
+    Some(tail[open..close].to_string())
+}
+
+fn extract_imap_literal_or_quoted_body(line: &str) -> Option<String> {
+    if let Some(start) = line.find("BODY[] \"") {
+        let tail = &line[start + "BODY[] \"".len()..];
+        let end = tail.rfind('"')?;
+        return Some(tail[..end].replace("\\\"", "\"").replace("\\\\", "\\"));
+    }
+    if let Some(start) = line.find("BODY[] {") {
+        let tail = &line[start..];
+        if let Some(pos) = tail.find("}\r\n") {
+            return Some(tail[pos + 3..].trim_end_matches(')').to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_email_headers_and_snippet() {
+        let raw = "Message-ID: <m1@example.com>\r\nSubject: Hello\r\n folded\r\nFrom: A <a@example.com>\r\nTo: b@example.com, c@example.com\r\nDate: Mon, 1 Jan 2024 00:00:00 +0000\r\n\r\nHello world";
+        let headers = parse_email_headers(raw);
+        assert_eq!(header_value(&headers, "subject").unwrap(), "Hello folded");
+        assert_eq!(body_snippet(raw).unwrap(), "Hello world");
+    }
+
+    #[test]
+    fn builds_provider_neutral_email_event() {
+        let config = EmailImapIdleRuntimeConfig {
+            endpoint: "imaps://imap.example.com:993".to_string(),
+            host: "imap.example.com".to_string(),
+            port: 993,
+            use_tls: true,
+            username: "agent@example.com".to_string(),
+            password: "secret".to_string(),
+            mailbox: "INBOX".to_string(),
+            account: Some("primary".to_string()),
+            initial_fetch_limit: 25,
+        };
+        let message = ImapFetchedMessage {
+            uid: "42".to_string(),
+            flags: vec!["\\Seen".to_string()],
+            raw: b"Message-ID: <m1@example.com>\r\nSubject: Hi\r\nFrom: sender@example.com\r\n\r\nBody"
+                .to_vec(),
+        };
+        let event = build_email_event(&config, &message);
+        assert_eq!(event["type"], "email_event");
+        assert_eq!(event["provider"], "imap");
+        assert_eq!(event["message"]["uid"], "42");
+        assert_eq!(event["message"]["subject"], "Hi");
+        assert_eq!(event["raw"]["mime_truncated"], false);
+        assert_eq!(event["reply_handle"]["message_id"], "<m1@example.com>");
+    }
+
+    #[test]
+    fn parses_single_line_uid_fetch() {
+        let lines = vec![
+            "* 1 FETCH (UID 42 FLAGS (\\Seen) BODY[] \"Subject: Hi\\r\\n\\r\\nBody\")".to_string(),
+            "A0001 OK done".to_string(),
+        ];
+        let messages = parse_uid_fetch_messages(&lines);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].uid, "42");
+        assert_eq!(messages[0].flags, vec!["\\Seen"]);
+    }
+}


### PR DESCRIPTION
## What
- Add `email-imap-idle` as a managed source/subscribe transport for IMAP/IMAPS endpoints.
- Add a provider-neutral `email_event` v1 envelope with message metadata, bounded raw MIME inline payload, and reply handle metadata.
- Wire the transport into source ensure validation/help and daemon subscription runtime.

## Why
First-stage MVP for #420 focused on local-first email receive/subscribe support. This PR intentionally does not implement SMTP send/reply or provider-specific Gmail/Graph/JMAP integrations.

## How
- Adds `src/subscription_email.rs` with IMAP login/select/IDLE loop, reconnect events, basic UID fetch parsing, and bounded MIME handling.
- Resolves username/password style auth profile fields and mailbox/account source args.
- Emits events through the existing subscription event recorder/source stream path.

## Testing
- `cargo test subscription_email --lib`
- `cargo check --all-targets`

Refs #420