### PR TITLE
feat(email): add SMTP send and reply commands

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -32,6 +32,7 @@ pub struct EmailSendRequest {
     pub in_reply_to: Option<String>,
     pub references: Vec<String>,
     pub auth: Option<String>,
+    pub allow_insecure_auth: bool,
     pub dry_run: bool,
 }
 
@@ -76,6 +77,7 @@ pub async fn send_email(request: EmailSendRequest) -> Result<EmailSendResult> {
 
     if !request.dry_run {
         let auth = resolve_smtp_auth(&request.smtp_url, request.auth.clone()).await?;
+        validate_smtp_auth_transport(&smtp_url, auth.as_ref(), request.allow_insecure_auth)?;
         send_smtp(
             &smtp_url,
             auth.as_ref(),
@@ -146,6 +148,19 @@ fn parse_smtp_url(raw: &str) -> Result<Url> {
         "smtps" => bail!("smtps:// is not supported yet; use smtp:// with a trusted local relay"),
         other => bail!("unsupported SMTP URL scheme '{}'; expected smtp://", other),
     }
+}
+
+fn validate_smtp_auth_transport(
+    url: &Url,
+    auth: Option<&SmtpAuth>,
+    allow_insecure_auth: bool,
+) -> Result<()> {
+    if auth.is_some() && url.scheme() == "smtp" && !allow_insecure_auth {
+        bail!(
+            "refusing to send SMTP credentials over unencrypted smtp://; configure a trusted local relay without --auth, or pass --allow-insecure-auth to acknowledge the cleartext credential risk"
+        );
+    }
+    Ok(())
 }
 
 async fn resolve_smtp_auth(
@@ -289,7 +304,15 @@ async fn send_smtp(
 }
 
 fn local_hostname() -> String {
-    std::env::var("HOSTNAME").unwrap_or_else(|_| "localhost".to_string())
+    sanitize_local_hostname(std::env::var("HOSTNAME").ok())
+        .unwrap_or_else(|| "localhost".to_string())
+}
+
+fn sanitize_local_hostname(value: Option<String>) -> Option<String> {
+    value.filter(|value| {
+        let trimmed = value.trim();
+        !trimmed.is_empty() && !trimmed.contains('\r') && !trimmed.contains('\n')
+    })
 }
 
 fn dot_stuff(message: &str) -> String {
@@ -388,8 +411,35 @@ mod tests {
             in_reply_to: None,
             references: vec![],
             auth: None,
+            allow_insecure_auth: false,
             dry_run: true,
         };
         assert!(build_message(&request, "<id@example.com>").is_err());
+    }
+
+    #[test]
+    fn rejects_plaintext_smtp_auth_without_opt_in() {
+        let url = parse_smtp_url("smtp://localhost:2525").unwrap();
+        let auth = SmtpAuth {
+            username: "user".to_string(),
+            password: "password".to_string(),
+        };
+        assert!(validate_smtp_auth_transport(&url, Some(&auth), false).is_err());
+        assert!(validate_smtp_auth_transport(&url, Some(&auth), true).is_ok());
+        assert!(validate_smtp_auth_transport(&url, None, false).is_ok());
+    }
+
+    #[test]
+    fn local_hostname_rejects_newlines() {
+        assert_eq!(
+            sanitize_local_hostname(Some(
+                "localhost\r\nRCPT TO:<attacker@example.com>".to_string()
+            )),
+            None
+        );
+        assert_eq!(
+            sanitize_local_hostname(Some("smtp-client.example.com".to_string())).as_deref(),
+            Some("smtp-client.example.com")
+        );
     }
 }

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,0 +1,395 @@
+use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use url::Url;
+
+use crate::auth;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EmailReplyHandle {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mailbox: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EmailSendRequest {
+    pub smtp_url: String,
+    pub from: String,
+    pub to: Vec<String>,
+    pub cc: Vec<String>,
+    pub bcc: Vec<String>,
+    pub subject: String,
+    pub text: Option<String>,
+    pub html: Option<String>,
+    pub in_reply_to: Option<String>,
+    pub references: Vec<String>,
+    pub auth: Option<String>,
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EmailSendResult {
+    pub smtp_url: String,
+    pub from: String,
+    pub to: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cc: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bcc: Vec<String>,
+    pub subject: String,
+    pub message_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_reply_to: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub references: Vec<String>,
+    pub dry_run: bool,
+    pub accepted_recipients: usize,
+}
+
+#[derive(Debug, Clone)]
+struct SmtpAuth {
+    username: String,
+    password: String,
+}
+
+pub async fn send_email(request: EmailSendRequest) -> Result<EmailSendResult> {
+    validate_request(&request)?;
+    let smtp_url = parse_smtp_url(&request.smtp_url)?;
+    let message_id = format!(
+        "<uxc-{}-{}@localhost>",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    );
+    let body = build_message(&request, &message_id)?;
+    let accepted_recipients = request.to.len() + request.cc.len() + request.bcc.len();
+
+    if !request.dry_run {
+        let auth = resolve_smtp_auth(&request.smtp_url, request.auth.clone()).await?;
+        send_smtp(
+            &smtp_url,
+            auth.as_ref(),
+            &request.from,
+            all_recipients(&request),
+            &body,
+        )
+        .await?;
+    }
+
+    Ok(EmailSendResult {
+        smtp_url: request.smtp_url,
+        from: request.from,
+        to: request.to,
+        cc: request.cc,
+        bcc: request.bcc,
+        subject: request.subject,
+        message_id,
+        in_reply_to: request.in_reply_to,
+        references: request.references,
+        dry_run: request.dry_run,
+        accepted_recipients,
+    })
+}
+
+pub fn parse_reply_handle_json(raw: &str) -> Result<EmailReplyHandle> {
+    serde_json::from_str(raw).context("invalid --reply-handle JSON")
+}
+
+pub fn references_with_reply_handle(
+    reply_handle: Option<&EmailReplyHandle>,
+    explicit_in_reply_to: Option<String>,
+    mut references: Vec<String>,
+) -> (Option<String>, Vec<String>) {
+    let in_reply_to = explicit_in_reply_to.or_else(|| {
+        reply_handle
+            .and_then(|handle| handle.message_id.clone())
+            .filter(|value| !value.trim().is_empty())
+    });
+    if let Some(message_id) = &in_reply_to {
+        if !references.iter().any(|value| value == message_id) {
+            references.push(message_id.clone());
+        }
+    }
+    (in_reply_to, references)
+}
+
+fn validate_request(request: &EmailSendRequest) -> Result<()> {
+    if request.from.trim().is_empty() {
+        bail!("--from is required");
+    }
+    if request.to.is_empty() && request.cc.is_empty() && request.bcc.is_empty() {
+        bail!("at least one --to, --cc, or --bcc recipient is required");
+    }
+    if request.subject.trim().is_empty() {
+        bail!("--subject is required");
+    }
+    if request.text.is_none() && request.html.is_none() {
+        bail!("one of --text-body or --html-body is required");
+    }
+    Ok(())
+}
+
+fn parse_smtp_url(raw: &str) -> Result<Url> {
+    let url = Url::parse(raw).context("invalid SMTP endpoint URL")?;
+    match url.scheme() {
+        "smtp" => Ok(url),
+        "smtps" => bail!("smtps:// is not supported yet; use smtp:// with a trusted local relay"),
+        other => bail!("unsupported SMTP URL scheme '{}'; expected smtp://", other),
+    }
+}
+
+async fn resolve_smtp_auth(
+    endpoint: &str,
+    explicit_auth: Option<String>,
+) -> Result<Option<SmtpAuth>> {
+    let Some(profile) = auth::resolve_auth_for_endpoint(endpoint, explicit_auth)? else {
+        return Ok(None);
+    };
+    let username = first_field(&profile, &["username", "user", "account"])?
+        .or_else(|| profile.name.clone())
+        .ok_or_else(|| anyhow!("SMTP auth profile requires username/user/account field"))?;
+    let password = first_field(&profile, &["password", "secret"])?
+        .ok_or_else(|| anyhow!("SMTP auth profile requires password or secret field"))?;
+    Ok(Some(SmtpAuth { username, password }))
+}
+
+fn first_field(profile: &auth::Profile, names: &[&str]) -> Result<Option<String>> {
+    for name in names {
+        if let Some(value) = profile.resolve_field_value(name)? {
+            if !value.is_empty() {
+                return Ok(Some(value));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn all_recipients(request: &EmailSendRequest) -> Vec<String> {
+    request
+        .to
+        .iter()
+        .chain(request.cc.iter())
+        .chain(request.bcc.iter())
+        .cloned()
+        .collect()
+}
+
+fn build_message(request: &EmailSendRequest, message_id: &str) -> Result<String> {
+    let mut headers = Vec::new();
+    headers.push(("From", request.from.clone()));
+    headers.push(("To", request.to.join(", ")));
+    if !request.cc.is_empty() {
+        headers.push(("Cc", request.cc.join(", ")));
+    }
+    headers.push(("Subject", request.subject.clone()));
+    headers.push(("Message-ID", message_id.to_string()));
+    if let Some(in_reply_to) = &request.in_reply_to {
+        headers.push(("In-Reply-To", in_reply_to.clone()));
+    }
+    if !request.references.is_empty() {
+        headers.push(("References", request.references.join(" ")));
+    }
+    headers.push(("MIME-Version", "1.0".to_string()));
+
+    let boundary = format!("uxc-boundary-{}", message_id.trim_matches(&['<', '>'][..]));
+    let body = match (&request.text, &request.html) {
+        (Some(text), Some(html)) => {
+            headers.push((
+                "Content-Type",
+                format!("multipart/alternative; boundary=\"{}\"", boundary),
+            ));
+            format!(
+                "--{boundary}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: 8bit\r\n\r\n{text}\r\n--{boundary}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: 8bit\r\n\r\n{html}\r\n--{boundary}--\r\n"
+            )
+        }
+        (Some(text), None) => {
+            headers.push(("Content-Type", "text/plain; charset=utf-8".to_string()));
+            headers.push(("Content-Transfer-Encoding", "8bit".to_string()));
+            format!("{text}\r\n")
+        }
+        (None, Some(html)) => {
+            headers.push(("Content-Type", "text/html; charset=utf-8".to_string()));
+            headers.push(("Content-Transfer-Encoding", "8bit".to_string()));
+            format!("{html}\r\n")
+        }
+        (None, None) => unreachable!("validated before message construction"),
+    };
+
+    let mut message = String::new();
+    for (name, value) in headers {
+        if !value.is_empty() {
+            message.push_str(name);
+            message.push_str(": ");
+            message.push_str(&sanitize_header_value(&value)?);
+            message.push_str("\r\n");
+        }
+    }
+    message.push_str("\r\n");
+    message.push_str(&body);
+    Ok(message)
+}
+
+fn sanitize_header_value(value: &str) -> Result<String> {
+    if value.contains('\r') || value.contains('\n') {
+        bail!("email header values must not contain newlines");
+    }
+    Ok(value.to_string())
+}
+
+async fn send_smtp(
+    url: &Url,
+    auth: Option<&SmtpAuth>,
+    from: &str,
+    recipients: Vec<String>,
+    message: &str,
+) -> Result<()> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow!("SMTP URL must include a host"))?;
+    let port = url.port_or_known_default().unwrap_or(25);
+    let stream = TcpStream::connect((host, port))
+        .await
+        .with_context(|| format!("failed to connect SMTP server {}:{}", host, port))?;
+    let mut client = SmtpClient::new(stream);
+    client.expect_code(&[220]).await?;
+    client
+        .command(&format!("EHLO {}\r\n", local_hostname()), &[250])
+        .await?;
+    if let Some(auth) = auth {
+        let encoded = base64::engine::general_purpose::STANDARD
+            .encode(format!("\0{}\0{}", auth.username, auth.password));
+        client
+            .command(&format!("AUTH PLAIN {}\r\n", encoded), &[235])
+            .await?;
+    }
+    client
+        .command(&format!("MAIL FROM:<{}>\r\n", from), &[250])
+        .await?;
+    for recipient in recipients {
+        client
+            .command(&format!("RCPT TO:<{}>\r\n", recipient), &[250, 251])
+            .await?;
+    }
+    client.command("DATA\r\n", &[354]).await?;
+    client.write_all(dot_stuff(message).as_bytes()).await?;
+    client.write_all(b"\r\n.\r\n").await?;
+    client.expect_code(&[250]).await?;
+    let _ = client.command("QUIT\r\n", &[221]).await;
+    Ok(())
+}
+
+fn local_hostname() -> String {
+    std::env::var("HOSTNAME").unwrap_or_else(|_| "localhost".to_string())
+}
+
+fn dot_stuff(message: &str) -> String {
+    message
+        .replace("\r\n.", "\r\n..")
+        .trim_end_matches(['\r', '\n'])
+        .to_string()
+}
+
+struct SmtpClient {
+    reader: BufReader<TcpStream>,
+}
+
+impl SmtpClient {
+    fn new(stream: TcpStream) -> Self {
+        Self {
+            reader: BufReader::new(stream),
+        }
+    }
+
+    async fn write_all(&mut self, bytes: &[u8]) -> Result<()> {
+        self.reader.get_mut().write_all(bytes).await?;
+        self.reader.get_mut().flush().await?;
+        Ok(())
+    }
+
+    async fn command(&mut self, command: &str, expected: &[u16]) -> Result<u16> {
+        self.write_all(command.as_bytes()).await?;
+        self.expect_code(expected).await
+    }
+
+    async fn expect_code(&mut self, expected: &[u16]) -> Result<u16> {
+        let (code, lines) = self.read_response().await?;
+        if expected.contains(&code) {
+            Ok(code)
+        } else {
+            bail!(
+                "SMTP server returned {}, expected {:?}: {}",
+                code,
+                expected,
+                lines.join(" | ")
+            )
+        }
+    }
+
+    async fn read_response(&mut self) -> Result<(u16, Vec<String>)> {
+        let mut lines = Vec::new();
+        loop {
+            let mut line = String::new();
+            let read = self.reader.read_line(&mut line).await?;
+            if read == 0 {
+                bail!("SMTP server closed connection");
+            }
+            let code: u16 = line
+                .get(0..3)
+                .ok_or_else(|| anyhow!("malformed SMTP response: {}", line.trim_end()))?
+                .parse()
+                .context("malformed SMTP status code")?;
+            let continued = line.as_bytes().get(3) == Some(&b'-');
+            lines.push(line.trim_end().to_string());
+            if !continued {
+                return Ok((code, lines));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reply_handle_sets_reply_headers() {
+        let handle = EmailReplyHandle {
+            message_id: Some("<original@example.com>".to_string()),
+            account: None,
+            mailbox: None,
+            uid: None,
+        };
+        let (in_reply_to, references) = references_with_reply_handle(Some(&handle), None, vec![]);
+        assert_eq!(in_reply_to.as_deref(), Some("<original@example.com>"));
+        assert_eq!(references, vec!["<original@example.com>"]);
+    }
+
+    #[test]
+    fn build_message_rejects_header_injection() {
+        let request = EmailSendRequest {
+            smtp_url: "smtp://localhost:25".to_string(),
+            from: "sender@example.com".to_string(),
+            to: vec!["recipient@example.com".to_string()],
+            cc: vec![],
+            bcc: vec![],
+            subject: "hello\r\nBcc: attacker@example.com".to_string(),
+            text: Some("body".to_string()),
+            html: None,
+            in_reply_to: None,
+            references: vec![],
+            auth: None,
+            dry_run: true,
+        };
+        assert!(build_message(&request, "<id@example.com>").is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod config_import;
 pub mod daemon;
 pub mod daemon_client;
 pub mod daemon_log;
+pub mod email;
 pub mod error;
 pub mod http_client;
 pub mod managed_source_streams;

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,6 +283,10 @@ struct EmailSendArgs {
     #[arg(long = "html-body")]
     html: Option<String>,
 
+    /// Allow AUTH over unencrypted smtp://; credentials are sent in cleartext
+    #[arg(long)]
+    allow_insecure_auth: bool,
+
     /// Validate and render envelope without connecting to SMTP
     #[arg(long)]
     dry_run: bool,
@@ -333,6 +337,10 @@ struct EmailReplyArgs {
     /// HTML body
     #[arg(long = "html-body")]
     html: Option<String>,
+
+    /// Allow AUTH over unencrypted smtp://; credentials are sent in cleartext
+    #[arg(long)]
+    allow_insecure_auth: bool,
 
     /// Validate and render envelope without connecting to SMTP
     #[arg(long)]
@@ -2491,11 +2499,12 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
             ]),
             notes: vec![
                 "Use --auth with credentials containing username/user/account and password/secret fields when SMTP AUTH is required.".to_string(),
+                "SMTP AUTH over smtp:// sends credentials in cleartext and requires explicit --allow-insecure-auth; prefer a trusted local relay without credentials until STARTTLS/TLS is supported.".to_string(),
                 "SMTP sends are direct outbound commands; inbound email source streams remain under `uxc source ensure --transport email-imap-idle`.".to_string(),
             ],
             examples: vec![
-                "uxc email send --smtp smtp://smtp.example.com:587 --auth email-primary --from bot@example.com --to user@example.com --subject 'Hello' --text-body 'Hi'".to_string(),
-                "uxc email reply --smtp smtp://smtp.example.com:587 --auth email-primary --reply-handle '{\"message_id\":\"<msg@example.com>\"}' --from bot@example.com --to user@example.com --subject 'Re: Hello' --text-body 'Thanks'".to_string(),
+                "uxc email send --smtp smtp://localhost:2525 --from bot@example.com --to user@example.com --subject 'Hello' --text-body 'Hi'".to_string(),
+                "uxc email reply --smtp smtp://localhost:2525 --reply-handle '{\"message_id\":\"<msg@example.com>\"}' --from bot@example.com --to user@example.com --subject 'Re: Hello' --text-body 'Thanks'".to_string(),
             ],
         },
         ["email", "send"] => HelpData {
@@ -2506,6 +2515,7 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
             notes: vec![
                 "At least one recipient and one body form are required.".to_string(),
                 "Use --dry-run to validate inputs and inspect the JSON envelope without contacting the SMTP server.".to_string(),
+                "Using --auth with smtp:// requires --allow-insecure-auth because credentials are sent in cleartext.".to_string(),
             ],
             examples: vec![
                 "uxc email send --smtp smtp://localhost:2525 --from bot@example.com --to user@example.com --subject 'Hello' --text-body 'Hi' --dry-run".to_string(),
@@ -2519,6 +2529,7 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
             notes: vec![
                 "--reply-handle accepts the reply_handle object emitted by email_event source records and uses its message_id for In-Reply-To/References.".to_string(),
                 "--in-reply-to overrides reply_handle.message_id when both are provided.".to_string(),
+                "Using --auth with smtp:// requires --allow-insecure-auth because credentials are sent in cleartext.".to_string(),
             ],
             examples: vec![
                 "uxc email reply --smtp smtp://localhost:2525 --reply-handle '{\"message_id\":\"<msg@example.com>\"}' --from bot@example.com --to user@example.com --subject 'Re: Hello' --text-body 'Thanks' --dry-run".to_string(),
@@ -6056,6 +6067,7 @@ async fn handle_email_command(command: &EmailCommands, cli: &Cli) -> Result<Outp
             in_reply_to: None,
             references: vec![],
             auth: cli.auth.clone(),
+            allow_insecure_auth: args.allow_insecure_auth,
             dry_run: args.dry_run,
         },
         EmailCommands::Reply(args) => {
@@ -6081,6 +6093,7 @@ async fn handle_email_command(command: &EmailCommands, cli: &Cli) -> Result<Outp
                 in_reply_to,
                 references,
                 auth: cli.auth.clone(),
+                allow_insecure_auth: args.allow_insecure_auth,
                 dry_run: args.dry_run,
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod codegen;
 mod config_import;
 mod daemon;
 mod daemon_log;
+mod email;
 mod error;
 mod http_client;
 mod managed_source_streams;
@@ -228,9 +229,114 @@ enum Commands {
         stream_command: StreamCommands,
     },
 
+    /// Send and reply to email over SMTP
+    Email {
+        #[command(subcommand)]
+        email_command: EmailCommands,
+    },
+
     /// Dynamic operation execution: `uxc <url> <operation_id> [key=value ...] ['{...}']`
     #[command(external_subcommand)]
     External(Vec<String>),
+}
+
+#[derive(Subcommand)]
+enum EmailCommands {
+    /// Send a new email over SMTP
+    Send(EmailSendArgs),
+
+    /// Reply to an email_event using SMTP reply headers
+    Reply(EmailReplyArgs),
+}
+
+#[derive(Parser)]
+struct EmailSendArgs {
+    /// SMTP endpoint, for example smtp://smtp.example.com:587
+    #[arg(long = "smtp", value_name = "URL")]
+    smtp_url: String,
+
+    /// Sender email address
+    #[arg(long)]
+    from: String,
+
+    /// Recipient email address (repeatable)
+    #[arg(long)]
+    to: Vec<String>,
+
+    /// CC recipient email address (repeatable)
+    #[arg(long)]
+    cc: Vec<String>,
+
+    /// BCC recipient email address (repeatable)
+    #[arg(long)]
+    bcc: Vec<String>,
+
+    /// Email subject
+    #[arg(long)]
+    subject: String,
+
+    /// Plain-text body
+    #[arg(long = "text-body")]
+    text_body: Option<String>,
+
+    /// HTML body
+    #[arg(long = "html-body")]
+    html: Option<String>,
+
+    /// Validate and render envelope without connecting to SMTP
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[derive(Parser)]
+struct EmailReplyArgs {
+    /// SMTP endpoint, for example smtp://smtp.example.com:587
+    #[arg(long = "smtp", value_name = "URL")]
+    smtp_url: String,
+
+    /// JSON reply_handle from an email_event envelope
+    #[arg(long = "reply-handle")]
+    reply_handle: Option<String>,
+
+    /// Explicit Message-ID to reply to; overrides reply_handle.message_id
+    #[arg(long = "in-reply-to")]
+    in_reply_to: Option<String>,
+
+    /// Existing References header value (repeatable)
+    #[arg(long = "reference")]
+    references: Vec<String>,
+
+    /// Sender email address
+    #[arg(long)]
+    from: String,
+
+    /// Recipient email address (repeatable)
+    #[arg(long)]
+    to: Vec<String>,
+
+    /// CC recipient email address (repeatable)
+    #[arg(long)]
+    cc: Vec<String>,
+
+    /// BCC recipient email address (repeatable)
+    #[arg(long)]
+    bcc: Vec<String>,
+
+    /// Email subject
+    #[arg(long)]
+    subject: String,
+
+    /// Plain-text body
+    #[arg(long = "text-body")]
+    text_body: Option<String>,
+
+    /// HTML body
+    #[arg(long = "html-body")]
+    html: Option<String>,
+
+    /// Validate and render envelope without connecting to SMTP
+    #[arg(long)]
+    dry_run: bool,
 }
 
 #[derive(Subcommand)]
@@ -1396,7 +1502,7 @@ fn raw_has_help_token(raw_args: &[String]) -> bool {
 fn is_top_level_command_token(token: &str) -> bool {
     matches!(
         token,
-        "help" | "config" | "cache" | "auth" | "link" | "daemon" | "source" | "stream"
+        "help" | "config" | "cache" | "auth" | "link" | "daemon" | "source" | "stream" | "email"
     )
 }
 
@@ -1506,6 +1612,13 @@ fn infer_help_path_from_tokens(tokens: &[String]) -> Option<Vec<String>> {
         "stream" => {
             if let Some(level1) = tokens.get(idx).map(|s| s.as_str()) {
                 if matches!(level1, "read" | "info" | "trim") {
+                    path.push(level1.to_string());
+                }
+            }
+        }
+        "email" => {
+            if let Some(level1) = tokens.get(idx).map(|s| s.as_str()) {
+                if matches!(level1, "send" | "reply") {
                     path.push(level1.to_string());
                 }
             }
@@ -1625,6 +1738,10 @@ fn static_help_path_from_cli(cli: &Cli) -> Option<Vec<&'static str>> {
             StreamCommands::Read { .. } => Some(vec!["stream", "read"]),
             StreamCommands::Info { .. } => Some(vec!["stream", "info"]),
             StreamCommands::Trim { .. } => Some(vec!["stream", "trim"]),
+        },
+        Some(Commands::Email { email_command }) => match email_command {
+            EmailCommands::Send(_) => Some(vec!["email", "send"]),
+            EmailCommands::Reply(_) => Some(vec!["email", "reply"]),
         },
         Some(Commands::External(_)) | None => None,
     }
@@ -1845,6 +1962,10 @@ async fn execute_cli(cli: &Cli) -> Result<OutputEnvelope> {
         return handle_stream_command(stream_command).await;
     }
 
+    if let Some(Commands::Email { email_command }) = &cli.command {
+        return handle_email_command(email_command, cli).await;
+    }
+
     let url = cli
         .url
         .clone()
@@ -2027,6 +2148,7 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
                 ("daemon", "Manage local runtime daemon"),
                 ("source", "Manage daemon-backed source streams"),
                 ("stream", "Read and maintain durable source streams"),
+                ("email", "Send and reply to email over SMTP"),
             ]),
             notes: vec![
                 "Default output is JSON. Use --text for human-readable output.".to_string(),
@@ -2358,6 +2480,49 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
                 "Deletes all rows with offset less than the requested boundary.".to_string(),
             ],
             examples: vec!["uxc stream trim ms_123 --before-offset 1000".to_string()],
+        },
+        ["email"] => HelpData {
+            path: "uxc email".to_string(),
+            about: "Send and reply to email over SMTP".to_string(),
+            usage: "uxc email <send|reply> ...".to_string(),
+            commands: commands(&[
+                ("send", "Send a new email over SMTP"),
+                ("reply", "Reply to an email_event using SMTP reply headers"),
+            ]),
+            notes: vec![
+                "Use --auth with credentials containing username/user/account and password/secret fields when SMTP AUTH is required.".to_string(),
+                "SMTP sends are direct outbound commands; inbound email source streams remain under `uxc source ensure --transport email-imap-idle`.".to_string(),
+            ],
+            examples: vec![
+                "uxc email send --smtp smtp://smtp.example.com:587 --auth email-primary --from bot@example.com --to user@example.com --subject 'Hello' --text-body 'Hi'".to_string(),
+                "uxc email reply --smtp smtp://smtp.example.com:587 --auth email-primary --reply-handle '{\"message_id\":\"<msg@example.com>\"}' --from bot@example.com --to user@example.com --subject 'Re: Hello' --text-body 'Thanks'".to_string(),
+            ],
+        },
+        ["email", "send"] => HelpData {
+            path: "uxc email send".to_string(),
+            about: "Send a new email over SMTP".to_string(),
+            usage: "uxc email send --smtp <url> --from <addr> --to <addr> [--to <addr> ...] [--cc <addr> ...] [--bcc <addr> ...] --subject <text> [--text-body <text>] [--html-body <html>] [--dry-run]".to_string(),
+            commands: vec![],
+            notes: vec![
+                "At least one recipient and one body form are required.".to_string(),
+                "Use --dry-run to validate inputs and inspect the JSON envelope without contacting the SMTP server.".to_string(),
+            ],
+            examples: vec![
+                "uxc email send --smtp smtp://localhost:2525 --from bot@example.com --to user@example.com --subject 'Hello' --text-body 'Hi' --dry-run".to_string(),
+            ],
+        },
+        ["email", "reply"] => HelpData {
+            path: "uxc email reply".to_string(),
+            about: "Reply to an email_event using SMTP reply headers".to_string(),
+            usage: "uxc email reply --smtp <url> [--reply-handle <json>|--in-reply-to <message-id>] --from <addr> --to <addr> [--to <addr> ...] --subject <text> [--text-body <text>] [--html-body <html>] [--dry-run]".to_string(),
+            commands: vec![],
+            notes: vec![
+                "--reply-handle accepts the reply_handle object emitted by email_event source records and uses its message_id for In-Reply-To/References.".to_string(),
+                "--in-reply-to overrides reply_handle.message_id when both are provided.".to_string(),
+            ],
+            examples: vec![
+                "uxc email reply --smtp smtp://localhost:2525 --reply-handle '{\"message_id\":\"<msg@example.com>\"}' --from bot@example.com --to user@example.com --subject 'Re: Hello' --text-body 'Thanks' --dry-run".to_string(),
+            ],
         },
         ["cache"] => HelpData {
             path: "uxc cache".to_string(),
@@ -3254,7 +3419,8 @@ fn resolve_endpoint_command(cli: &Cli) -> Result<EndpointCommand> {
             | Some(Commands::Link { .. })
             | Some(Commands::Daemon { .. })
             | Some(Commands::Source { .. })
-            | Some(Commands::Stream { .. }) => Err(UxcError::InvalidArguments(
+            | Some(Commands::Stream { .. })
+            | Some(Commands::Email { .. }) => Err(UxcError::InvalidArguments(
                 "--codegen-schema is only supported for endpoint invocations".to_string(),
             )
             .into()),
@@ -3270,7 +3436,8 @@ fn resolve_endpoint_command(cli: &Cli) -> Result<EndpointCommand> {
         | Some(Commands::Link { .. })
         | Some(Commands::Daemon { .. })
         | Some(Commands::Source { .. })
-        | Some(Commands::Stream { .. }) => Err(UxcError::InvalidArguments(
+        | Some(Commands::Stream { .. })
+        | Some(Commands::Email { .. }) => Err(UxcError::InvalidArguments(
             "Internal routing error for management command".to_string(),
         )
         .into()),
@@ -5865,6 +6032,66 @@ async fn handle_stream_command(command: &StreamCommands) -> Result<OutputEnvelop
         true,
         daemon_autostarted,
         daemon_restarted_for_version_mismatch,
+        None,
+    ))
+}
+
+async fn handle_email_command(command: &EmailCommands, cli: &Cli) -> Result<OutputEnvelope> {
+    if cli.schema_url.is_some() {
+        return Err(UxcError::InvalidArguments(
+            "--schema-url is not supported for email commands".to_string(),
+        )
+        .into());
+    }
+    let request = match command {
+        EmailCommands::Send(args) => email::EmailSendRequest {
+            smtp_url: args.smtp_url.clone(),
+            from: args.from.clone(),
+            to: args.to.clone(),
+            cc: args.cc.clone(),
+            bcc: args.bcc.clone(),
+            subject: args.subject.clone(),
+            text: args.text_body.clone(),
+            html: args.html.clone(),
+            in_reply_to: None,
+            references: vec![],
+            auth: cli.auth.clone(),
+            dry_run: args.dry_run,
+        },
+        EmailCommands::Reply(args) => {
+            let reply_handle = args
+                .reply_handle
+                .as_deref()
+                .map(email::parse_reply_handle_json)
+                .transpose()?;
+            let (in_reply_to, references) = email::references_with_reply_handle(
+                reply_handle.as_ref(),
+                args.in_reply_to.clone(),
+                args.references.clone(),
+            );
+            email::EmailSendRequest {
+                smtp_url: args.smtp_url.clone(),
+                from: args.from.clone(),
+                to: args.to.clone(),
+                cc: args.cc.clone(),
+                bcc: args.bcc.clone(),
+                subject: args.subject.clone(),
+                text: args.text_body.clone(),
+                html: args.html.clone(),
+                in_reply_to,
+                references,
+                auth: cli.auth.clone(),
+                dry_run: args.dry_run,
+            }
+        }
+    };
+    let data = serde_json::to_value(email::send_email(request).await?)?;
+    Ok(OutputEnvelope::success(
+        "email_send_result",
+        "email",
+        "uxc email",
+        None,
+        data,
         None,
     ))
 }

--- a/tests/cli_help_regression_test.rs
+++ b/tests/cli_help_regression_test.rs
@@ -120,6 +120,59 @@ fn daemon_doctor_help_outputs_json() {
 
 #[test]
 #[serial]
+fn email_send_help_outputs_json() {
+    let output = uxc_command()
+        .arg("email")
+        .arg("send")
+        .arg("-h")
+        .output()
+        .expect("failed to run uxc email send -h");
+
+    assert!(output.status.success(), "command should succeed");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["kind"], "subcommand_help");
+    assert_eq!(json["data"]["path"], "uxc email send");
+}
+
+#[test]
+#[serial]
+fn email_send_dry_run_outputs_json() {
+    let output = uxc_command()
+        .arg("email")
+        .arg("send")
+        .arg("--smtp")
+        .arg("smtp://localhost:2525")
+        .arg("--from")
+        .arg("bot@example.com")
+        .arg("--to")
+        .arg("user@example.com")
+        .arg("--subject")
+        .arg("Hello")
+        .arg("--text-body")
+        .arg("Hi")
+        .arg("--dry-run")
+        .output()
+        .expect("failed to run uxc email send --dry-run");
+
+    assert!(
+        output.status.success(),
+        "command should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["kind"], "email_send_result");
+    assert_eq!(json["protocol"], "email");
+    assert_eq!(json["data"]["dry_run"], true);
+    assert_eq!(json["data"]["accepted_recipients"], 1);
+}
+
+#[test]
+#[serial]
 fn help_subcommand_defaults_to_json() {
     let output = uxc_command()
         .arg("help")


### PR DESCRIPTION
## What
- Add `uxc email send` for outbound SMTP email commands.
- Add `uxc email reply` that maps stage-1 `email_event.reply_handle.message_id` into `In-Reply-To`/`References` headers.
- Add dry-run JSON output and static help coverage for the new email command surface.

## Why
Continues #420 stage 2 after the IMAP subscribe/email_event envelope landed in PR #421.

## How
- Introduces a focused `email` module for message composition, reply metadata handling, SMTP AUTH PLAIN, and minimal SMTP delivery.
- Reuses existing auth/profile resolution for credentials with `username/user/account` plus `password/secret` fields.
- Keeps inbound email source streams under the existing `email-imap-idle` source transport.

## Testing
- `cargo fmt --check`
- `cargo test email_send_ --test cli_help_regression_test`
- `cargo test email:: --lib`
- `cargo check --all-targets`

Closes #420