### PR TITLE
feat(email): add provider poll source transport

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -23,7 +23,8 @@ use crate::subscription_discord::{
     DiscordIdentifyProperties, DISCORD_DEFAULT_MESSAGE_INTENTS,
 };
 use crate::subscription_email::{
-    resolve_email_imap_idle_runtime_config, run_email_imap_idle_subscription_runtime,
+    fetch_email_provider_poll, resolve_email_imap_idle_runtime_config,
+    resolve_email_provider_poll_runtime_config, run_email_imap_idle_subscription_runtime,
     EmailImapIdleRuntimeConfig,
 };
 use crate::subscription_feishu::{
@@ -241,6 +242,7 @@ pub enum SubscriptionTransportHint {
     SlackSocketMode,
     FeishuLongConnection,
     EmailImapIdle,
+    EmailProviderPoll,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -2282,6 +2284,12 @@ fn resolve_stream_subscription_protocol(request: &SubscribeStartRequest) -> Resu
                 }
                 return Ok("email_imap_idle".to_string());
             }
+            SubscriptionTransportHint::EmailProviderPoll => {
+                if !lower.starts_with("http://") && !lower.starts_with("https://") {
+                    bail!("email-provider-poll transport requires an http:// or https:// endpoint");
+                }
+                return Ok("email_provider_poll".to_string());
+            }
         }
     }
 
@@ -3116,7 +3124,8 @@ impl ManagedSourceManager {
             let args = runner.build_request_args(&base_args);
             let previous_checkpoint = runner.checkpoint().clone();
             let fetch =
-                fetch_managed_source_poll(runtime, request, args, runner.checkpoint()).await;
+                fetch_managed_source_poll_dispatch(runtime, request, args, runner.checkpoint())
+                    .await;
             let next_interval_secs;
 
             match fetch {
@@ -5910,7 +5919,12 @@ fn resolve_jsonrpc_subscription_config(
 fn resolve_poll_subscription_config(
     request: &SubscribeStartRequest,
 ) -> Result<PollSubscriptionConfig> {
-    if request.operation_id.is_none() {
+    if request.operation_id.is_none()
+        && !matches!(
+            request.transport_hint,
+            Some(SubscriptionTransportHint::EmailProviderPoll)
+        )
+    {
         bail!("poll subscriptions require an operation_id");
     }
     if request.resource_uri.is_some() {
@@ -5924,6 +5938,25 @@ fn resolve_poll_subscription_config(
         serde_json::from_value(raw).context("invalid poll subscription config")?;
     config.validate()?;
     Ok(config)
+}
+
+async fn fetch_managed_source_poll_dispatch(
+    runtime: &DaemonRuntime,
+    request: &SubscribeStartRequest,
+    args: HashMap<String, Value>,
+    checkpoint: &crate::subscription_poll::PollCheckpointState,
+) -> Result<crate::subscription_poll::PollFetchResult> {
+    if matches!(
+        request.transport_hint,
+        Some(SubscriptionTransportHint::EmailProviderPoll)
+    ) {
+        let auth_profile =
+            auth::resolve_auth_for_endpoint(&request.endpoint, request.options.auth.clone())?;
+        let config = resolve_email_provider_poll_runtime_config(request, auth_profile.as_ref())?;
+        return fetch_email_provider_poll(&config, auth_profile.as_ref(), checkpoint).await;
+    }
+
+    fetch_managed_source_poll(runtime, request, args, checkpoint).await
 }
 
 async fn resolve_graphql_subscription_prepared_operation(

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ enum SubscribeTransportArg {
     SlackSocketMode,
     FeishuLongConnection,
     EmailImapIdle,
+    EmailProviderPoll,
 }
 
 #[derive(Parser)]
@@ -2385,19 +2386,20 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
         ["source", "ensure"] => HelpData {
             path: "uxc source ensure".to_string(),
             about: "Ensure a managed source exists and is running".to_string(),
-            usage: "uxc source ensure <namespace> <source_key> <endpoint> [<operation_id> [key=value ... | '{...}']] [--transport websocket|discord-gateway|slack-socket-mode|feishu-long-connection|email-imap-idle] [--subprotocol <value> ...] [--init-frame <text-or-json> ...] [--mode <stream|poll>] [--poll-config <json>] [--resource-uri <uri>] [--read-resource]".to_string(),
+            usage: "uxc source ensure <namespace> <source_key> <endpoint> [<operation_id> [key=value ... | '{...}']] [--transport websocket|discord-gateway|slack-socket-mode|feishu-long-connection|email-imap-idle|email-provider-poll] [--subprotocol <value> ...] [--init-frame <text-or-json> ...] [--mode <stream|poll>] [--poll-config <json>] [--resource-uri <uri>] [--read-resource]".to_string(),
             commands: vec![],
             notes: vec![
                 "Managed source identity is (namespace, source_key); the durable stream stays stable across spec replacements for the same identity.".to_string(),
                 "Spec changes replace the current run and reset checkpoint state by default, while preserving the managed stream.".to_string(),
                 "Managed source streams persist only raw payload rows. Lifecycle/runtime events remain visible through source status rather than stream rows.".to_string(),
-                "Supports raw websocket, GraphQL subscription, JSON-RPC pubsub, MCP resource subscriptions, Discord Gateway, Slack Socket Mode, Feishu long connection, email IMAP IDLE, and poll mode.".to_string(),
+                "Supports raw websocket, GraphQL subscription, JSON-RPC pubsub, MCP resource subscriptions, Discord Gateway, Slack Socket Mode, Feishu long connection, email IMAP IDLE, email provider polling, and poll mode.".to_string(),
             ],
             examples: vec![
                 "uxc source ensure agentinbox github_repo:holon-run/uxc https://api.github.com get:/repos/{owner}/{repo}/events owner=holon-run repo=uxc --mode poll --poll-config '{\"interval_secs\":30,\"extract_items_pointer\":\"\",\"checkpoint_strategy\":{\"type\":\"item_key\",\"item_key_pointer\":\"/id\"}}'".to_string(),
                 "uxc source ensure market okx:btc-usdt wss://ws.okx.com:8443/ws/v5/public --transport websocket --init-frame '{\"op\":\"subscribe\",\"args\":[{\"channel\":\"tickers\",\"instId\":\"BTC-USDT\"}]}'".to_string(),
                 "uxc source ensure team discord-gateway https://discord.com/api/v10 --transport discord-gateway --auth discord-bot '{\"intents\":37377}'".to_string(),
                 "uxc source ensure agentinbox email:primary imaps://imap.example.com:993 --transport email-imap-idle --auth email-primary mailbox=INBOX".to_string(),
+                "uxc source ensure agentinbox email:gmail https://gmail.googleapis.com/gmail/v1/users/me/messages --transport email-provider-poll --mode poll --auth gmail-oauth provider=gmail mailbox=INBOX --poll-config '{\"interval_secs\":60,\"extract_items_pointer\":\"/items\",\"checkpoint_strategy\":{\"type\":\"item_key\",\"item_key_pointer\":\"/message/uid\"}}'".to_string(),
             ],
         },
         ["source", "status"] => HelpData {
@@ -5578,6 +5580,9 @@ fn build_managed_source_spec(
             daemon::SubscriptionTransportHint::FeishuLongConnection
         }
         SubscribeTransportArg::EmailImapIdle => daemon::SubscriptionTransportHint::EmailImapIdle,
+        SubscribeTransportArg::EmailProviderPoll => {
+            daemon::SubscriptionTransportHint::EmailProviderPoll
+        }
     });
     let mut transport_operation_id = input.operation_id.clone();
     let mut transport_input_json = input.input_json.clone();
@@ -5728,6 +5733,31 @@ fn build_managed_source_spec(
             .into());
         }
     }
+    if matches!(
+        transport_hint,
+        Some(daemon::SubscriptionTransportHint::EmailProviderPoll)
+    ) {
+        if transport_operation_id.is_some() {
+            return Err(UxcError::InvalidArguments(
+                "--transport email-provider-poll cannot be combined with an operation_id"
+                    .to_string(),
+            )
+            .into());
+        }
+        if input.resource_uri.is_some() {
+            return Err(UxcError::InvalidArguments(
+                "--transport email-provider-poll cannot be combined with --resource-uri"
+                    .to_string(),
+            )
+            .into());
+        }
+        if !matches!(input.mode, SubscribeModeArg::Poll) {
+            return Err(UxcError::InvalidArguments(
+                "--transport email-provider-poll is only valid with --mode poll".to_string(),
+            )
+            .into());
+        }
+    }
     if input.read_resource && input.resource_uri.is_none() {
         return Err(UxcError::InvalidArguments(
             "--read-resource requires --resource-uri".to_string(),
@@ -5769,6 +5799,9 @@ fn build_managed_source_spec(
             ) || matches!(
                 transport_hint,
                 Some(daemon::SubscriptionTransportHint::EmailImapIdle)
+            ) || matches!(
+                transport_hint,
+                Some(daemon::SubscriptionTransportHint::EmailProviderPoll)
             ) {
                 let fallback_op = if matches!(
                     transport_hint,
@@ -5780,8 +5813,13 @@ fn build_managed_source_spec(
                     Some(daemon::SubscriptionTransportHint::FeishuLongConnection)
                 ) {
                     "feishu-long-connection"
-                } else {
+                } else if matches!(
+                    transport_hint,
+                    Some(daemon::SubscriptionTransportHint::EmailImapIdle)
+                ) {
                     "email-imap-idle"
+                } else {
+                    "email-provider-poll"
                 };
                 let mut explicit_args = Vec::new();
                 let mut positional = Vec::new();

--- a/src/subscription_email.rs
+++ b/src/subscription_email.rs
@@ -1,9 +1,12 @@
 use crate::auth::Profile;
 use crate::daemon::{SubscribeStartRequest, SubscriptionEventRecorder};
 use crate::daemon_log::redact_endpoint;
+use crate::subscription_poll::{PollCheckpointState, PollFetchResult};
 use anyhow::{anyhow, bail, Context, Result};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use rustls_pki_types::ServerName;
 use serde_json::{json, Map, Value};
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -42,6 +45,21 @@ pub struct EmailImapIdleRuntimeConfig {
     pub mailbox: String,
     pub account: Option<String>,
     pub initial_fetch_limit: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmailProviderKind {
+    Gmail,
+    Graph,
+    Jmap,
+}
+
+#[derive(Debug, Clone)]
+pub struct EmailProviderPollRuntimeConfig {
+    pub endpoint: String,
+    pub provider: EmailProviderKind,
+    pub account: Option<String>,
+    pub mailbox: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -348,6 +366,315 @@ fn build_email_event(config: &EmailImapIdleRuntimeConfig, message: &ImapFetchedM
             "uid": message.uid,
         }
     })
+}
+
+pub fn resolve_email_provider_poll_runtime_config(
+    request: &SubscribeStartRequest,
+    auth_profile: Option<&Profile>,
+) -> Result<EmailProviderPollRuntimeConfig> {
+    let url = Url::parse(&request.endpoint).context("invalid email provider endpoint")?;
+    match url.scheme() {
+        "http" | "https" => {}
+        other => bail!(
+            "email-provider-poll transport requires http:// or https:// endpoint, got '{}'",
+            other
+        ),
+    }
+    let args = request.args.as_ref();
+    let provider = args
+        .and_then(|args| args.get("provider"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("email-provider-poll requires provider=gmail|graph|jmap"))?;
+    let provider = match provider.to_ascii_lowercase().as_str() {
+        "gmail" => EmailProviderKind::Gmail,
+        "graph" | "microsoft_graph" | "msgraph" => EmailProviderKind::Graph,
+        "jmap" => EmailProviderKind::Jmap,
+        other => bail!(
+            "unsupported email provider '{}'; expected gmail, graph, or jmap",
+            other
+        ),
+    };
+    let mailbox = args
+        .and_then(|args| args.get("mailbox"))
+        .and_then(Value::as_str)
+        .unwrap_or(DEFAULT_MAILBOX)
+        .to_string();
+    let account = args
+        .and_then(|args| args.get("account"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            auth_profile.and_then(|profile| profile.resolve_field_value("account").ok().flatten())
+        });
+
+    Ok(EmailProviderPollRuntimeConfig {
+        endpoint: request.endpoint.clone(),
+        provider,
+        account,
+        mailbox,
+    })
+}
+
+pub async fn fetch_email_provider_poll(
+    config: &EmailProviderPollRuntimeConfig,
+    auth_profile: Option<&Profile>,
+    checkpoint: &PollCheckpointState,
+) -> Result<PollFetchResult> {
+    let started = std::time::Instant::now();
+    let client = reqwest::Client::new();
+    let request_context = crate::auth::AuthRequestContext::new("GET", &config.endpoint);
+    let resolved_auth = match auth_profile {
+        Some(profile) => Some(crate::auth::resolve_profile_request_auth_with_context(
+            &request_context,
+            profile,
+        )?),
+        None => None,
+    };
+    let url = resolved_auth
+        .as_ref()
+        .map(|auth| auth.url.as_str())
+        .unwrap_or(config.endpoint.as_str());
+    let mut builder = client.get(url);
+    if let Some(auth) = resolved_auth.as_ref() {
+        builder = builder.headers(header_map_from_pairs(&auth.headers)?);
+    }
+    if let Some(etag) = checkpoint.etag.as_ref() {
+        builder = builder.header("if-none-match", etag);
+    }
+    let response = builder
+        .send()
+        .await
+        .context("email provider poll request failed")?;
+    let status = response.status();
+    let response_headers = response
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+        })
+        .collect::<HashMap<_, _>>();
+    if status.as_u16() == 304 {
+        return Ok(PollFetchResult {
+            data: json!({ "items": [] }),
+            duration_ms: Some(started.elapsed().as_millis() as u64),
+            status_code: Some(status.as_u16()),
+            response_headers,
+        });
+    }
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        bail!(
+            "email provider poll request failed with HTTP {}: {}",
+            status.as_u16(),
+            body
+        );
+    }
+    let raw = response
+        .json::<Value>()
+        .await
+        .context("email provider poll response was not JSON")?;
+    let items = normalize_email_provider_items(config, &raw)?;
+    Ok(PollFetchResult {
+        data: json!({ "items": items }),
+        duration_ms: Some(started.elapsed().as_millis() as u64),
+        status_code: Some(status.as_u16()),
+        response_headers,
+    })
+}
+
+fn header_map_from_pairs(headers: &[(String, String)]) -> Result<HeaderMap> {
+    let mut out = HeaderMap::new();
+    for (name, value) in headers {
+        out.insert(
+            HeaderName::from_bytes(name.as_bytes())
+                .with_context(|| format!("invalid auth header name '{}'", name))?,
+            HeaderValue::from_str(value)
+                .with_context(|| format!("invalid auth header value for '{}'", name))?,
+        );
+    }
+    Ok(out)
+}
+
+pub fn normalize_email_provider_items(
+    config: &EmailProviderPollRuntimeConfig,
+    raw: &Value,
+) -> Result<Vec<Value>> {
+    let items = match config.provider {
+        EmailProviderKind::Gmail => raw
+            .get("messages")
+            .or_else(|| raw.get("items"))
+            .and_then(Value::as_array)
+            .ok_or_else(|| anyhow!("Gmail provider response requires messages/items array"))?,
+        EmailProviderKind::Graph => raw
+            .get("value")
+            .or_else(|| raw.get("items"))
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                anyhow!("Microsoft Graph provider response requires value/items array")
+            })?,
+        EmailProviderKind::Jmap => raw
+            .get("list")
+            .or_else(|| raw.get("items"))
+            .and_then(Value::as_array)
+            .ok_or_else(|| anyhow!("JMAP provider response requires list/items array"))?,
+    };
+    Ok(items
+        .iter()
+        .map(|item| build_provider_email_event(config, item))
+        .collect())
+}
+
+fn build_provider_email_event(config: &EmailProviderPollRuntimeConfig, item: &Value) -> Value {
+    let account = config.account.as_deref().unwrap_or("default");
+    let provider = match config.provider {
+        EmailProviderKind::Gmail => "gmail",
+        EmailProviderKind::Graph => "graph",
+        EmailProviderKind::Jmap => "jmap",
+    };
+    let uid = first_string(item, &["id", "blobId"]).unwrap_or_else(|| item.to_string());
+    let message_id = match config.provider {
+        EmailProviderKind::Gmail => gmail_header(item, "Message-ID").unwrap_or_else(|| uid.clone()),
+        EmailProviderKind::Graph => {
+            first_string(item, &["internetMessageId"]).unwrap_or_else(|| uid.clone())
+        }
+        EmailProviderKind::Jmap => {
+            first_string(item, &["messageId"]).unwrap_or_else(|| uid.clone())
+        }
+    };
+    let subject = match config.provider {
+        EmailProviderKind::Gmail => {
+            gmail_header(item, "Subject").or_else(|| first_string(item, &["subject"]))
+        }
+        _ => first_string(item, &["subject"]),
+    };
+    json!({
+        "type": "email_event",
+        "version": "v1",
+        "provider": provider,
+        "account": account,
+        "mailbox": config.mailbox,
+        "event_kind": "message_received",
+        "message": {
+            "uid": uid,
+            "message_id": message_id,
+            "thread_id": first_string(item, &["threadId", "thread_id", "inReplyTo"]),
+            "conversation_id": first_string(item, &["conversationId", "emailId"]),
+            "from": provider_from_address(config.provider, item),
+            "to": provider_address_list(config.provider, item, "to"),
+            "cc": provider_address_list(config.provider, item, "cc"),
+            "bcc": provider_address_list(config.provider, item, "bcc"),
+            "subject": subject,
+            "date": first_string(item, &["receivedDateTime", "receivedAt", "internalDate", "date"]),
+            "snippet": first_string(item, &["snippet", "bodyPreview", "preview"]),
+            "attachments": [],
+            "flags": provider_flags(config.provider, item),
+        },
+        "raw": {
+            "provider_payload": item,
+        },
+        "reply_handle": {
+            "type": "email_provider",
+            "provider": provider,
+            "account": account,
+            "mailbox": config.mailbox,
+            "message_id": message_id,
+            "uid": uid,
+        }
+    })
+}
+
+fn first_string(value: &Value, names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .find_map(|name| value.get(*name).and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+fn gmail_header(item: &Value, name: &str) -> Option<String> {
+    item.pointer("/payload/headers")
+        .and_then(Value::as_array)?
+        .iter()
+        .find(|header| {
+            header
+                .get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|candidate| candidate.eq_ignore_ascii_case(name))
+        })
+        .and_then(|header| header.get("value").and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+fn provider_from_address(provider: EmailProviderKind, item: &Value) -> Option<Value> {
+    match provider {
+        EmailProviderKind::Gmail => gmail_header(item, "From").map(|raw| json!({ "raw": raw })),
+        EmailProviderKind::Graph => item
+            .pointer("/from/emailAddress")
+            .cloned()
+            .or_else(|| first_string(item, &["from"]).map(|raw| json!({ "raw": raw }))),
+        EmailProviderKind::Jmap => item
+            .get("from")
+            .and_then(Value::as_array)
+            .and_then(|values| values.first())
+            .cloned()
+            .or_else(|| first_string(item, &["from"]).map(|raw| json!({ "raw": raw }))),
+    }
+}
+
+fn provider_address_list(provider: EmailProviderKind, item: &Value, field: &str) -> Vec<Value> {
+    match provider {
+        EmailProviderKind::Gmail => {
+            let header = match field {
+                "to" => "To",
+                "cc" => "Cc",
+                "bcc" => "Bcc",
+                _ => field,
+            };
+            split_address_header(gmail_header(item, header).as_deref())
+        }
+        EmailProviderKind::Graph => item
+            .get(format!("{field}Recipients"))
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|value| value.get("emailAddress").cloned())
+                    .collect()
+            })
+            .unwrap_or_default(),
+        EmailProviderKind::Jmap => item
+            .get(field)
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+    }
+}
+
+fn provider_flags(provider: EmailProviderKind, item: &Value) -> Vec<Value> {
+    match provider {
+        EmailProviderKind::Gmail => item
+            .get("labelIds")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        EmailProviderKind::Graph => {
+            let mut flags = Vec::new();
+            if item.get("isRead").and_then(Value::as_bool) == Some(true) {
+                flags.push(Value::String("read".to_string()));
+            }
+            if item.get("hasAttachments").and_then(Value::as_bool) == Some(true) {
+                flags.push(Value::String("has_attachments".to_string()));
+            }
+            flags
+        }
+        EmailProviderKind::Jmap => item
+            .get("keywords")
+            .and_then(Value::as_object)
+            .map(|keywords| keywords.keys().cloned().map(Value::String).collect())
+            .unwrap_or_default(),
+    }
 }
 
 fn parse_email_headers(raw: &str) -> Map<String, Value> {
@@ -710,6 +1037,96 @@ mod tests {
         assert_eq!(event["message"]["subject"], "Hi");
         assert_eq!(event["raw"]["mime_truncated"], false);
         assert_eq!(event["reply_handle"]["message_id"], "<m1@example.com>");
+    }
+
+    #[test]
+    fn normalizes_gmail_provider_messages_to_email_events() {
+        let config = EmailProviderPollRuntimeConfig {
+            endpoint: "https://gmail.googleapis.com/gmail/v1/users/me/messages".to_string(),
+            provider: EmailProviderKind::Gmail,
+            account: Some("gmail-primary".to_string()),
+            mailbox: "INBOX".to_string(),
+        };
+        let raw = json!({
+            "messages": [{
+                "id": "msg-1",
+                "threadId": "thread-1",
+                "labelIds": ["INBOX", "UNREAD"],
+                "snippet": "hello",
+                "payload": {"headers": [
+                    {"name": "Message-ID", "value": "<m1@example.com>"},
+                    {"name": "Subject", "value": "Hi"},
+                    {"name": "From", "value": "Sender <sender@example.com>"},
+                    {"name": "To", "value": "agent@example.com"}
+                ]}
+            }]
+        });
+
+        let events = normalize_email_provider_items(&config, &raw).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["type"], "email_event");
+        assert_eq!(events[0]["provider"], "gmail");
+        assert_eq!(events[0]["account"], "gmail-primary");
+        assert_eq!(events[0]["message"]["uid"], "msg-1");
+        assert_eq!(events[0]["message"]["message_id"], "<m1@example.com>");
+        assert_eq!(events[0]["message"]["subject"], "Hi");
+        assert_eq!(events[0]["reply_handle"]["type"], "email_provider");
+    }
+
+    #[test]
+    fn normalizes_graph_and_jmap_provider_messages_to_email_events() {
+        let graph_config = EmailProviderPollRuntimeConfig {
+            endpoint: "https://graph.microsoft.com/v1.0/me/messages".to_string(),
+            provider: EmailProviderKind::Graph,
+            account: None,
+            mailbox: "Inbox".to_string(),
+        };
+        let graph_raw = json!({
+            "value": [{
+                "id": "graph-1",
+                "conversationId": "conv-1",
+                "internetMessageId": "<graph@example.com>",
+                "subject": "Graph",
+                "bodyPreview": "preview",
+                "from": {"emailAddress": {"address": "sender@example.com"}},
+                "toRecipients": [{"emailAddress": {"address": "agent@example.com"}}],
+                "isRead": true
+            }]
+        });
+        let graph_events = normalize_email_provider_items(&graph_config, &graph_raw).unwrap();
+        assert_eq!(graph_events[0]["provider"], "graph");
+        assert_eq!(graph_events[0]["message"]["uid"], "graph-1");
+        assert_eq!(
+            graph_events[0]["message"]["message_id"],
+            "<graph@example.com>"
+        );
+        assert_eq!(graph_events[0]["message"]["flags"], json!(["read"]));
+
+        let jmap_config = EmailProviderPollRuntimeConfig {
+            endpoint: "https://api.fastmail.com/jmap/session".to_string(),
+            provider: EmailProviderKind::Jmap,
+            account: Some("jmap-primary".to_string()),
+            mailbox: "Inbox".to_string(),
+        };
+        let jmap_raw = json!({
+            "list": [{
+                "id": "email-1",
+                "messageId": "<jmap@example.com>",
+                "subject": "JMAP",
+                "preview": "preview",
+                "from": [{"email": "sender@example.com"}],
+                "to": [{"email": "agent@example.com"}],
+                "keywords": {"$seen": true}
+            }]
+        });
+        let jmap_events = normalize_email_provider_items(&jmap_config, &jmap_raw).unwrap();
+        assert_eq!(jmap_events[0]["provider"], "jmap");
+        assert_eq!(jmap_events[0]["message"]["uid"], "email-1");
+        assert_eq!(
+            jmap_events[0]["message"]["message_id"],
+            "<jmap@example.com>"
+        );
+        assert_eq!(jmap_events[0]["message"]["flags"], json!(["$seen"]));
     }
 
     #[test]

--- a/tests/cli_help_regression_test.rs
+++ b/tests/cli_help_regression_test.rs
@@ -973,6 +973,10 @@ fn source_ensure_help_flag_outputs_subcommand_help_json() {
         .as_str()
         .unwrap_or_default()
         .contains("<namespace> <source_key> <endpoint>"));
+    assert!(json["data"]["usage"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("email-provider-poll"));
 }
 
 #[test]


### PR DESCRIPTION
## What
- Add an email-provider-poll managed source transport for Gmail, Microsoft Graph, and JMAP HTTP polling
- Normalize provider payloads into the existing email_event v1 envelope and email_provider reply_handle
- Document the new source ensure transport in CLI help and cover provider normalization with focused tests

## Why
- Continues #420 stage 3 after IMAP receive and SMTP send/reply support
- Lets provider-specific email APIs feed the same AgentInbox-compatible event contract

## How
- Dispatch managed source poll requests to provider-specific email fetch logic when --transport email-provider-poll is selected
- Resolve auth per endpoint/profile and pass conditional ETag headers through the poll path
- Support Gmail messages/items, Graph value/items, and JMAP list/items response shapes

## Testing
- cargo fmt --check
- cargo test email:: --lib
- cargo test source_ensure_help_flag_outputs_subcommand_help_json --test cli_help_regression_test
- cargo check --all-targets

Closes #420