### PR TITLE
docs: add current Xquik OpenAPI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,12 @@ cargo install --path .
 ```bash
 uxc petstore3.swagger.io/api/v3 -h
 uxc petstore3.swagger.io/api/v3 get:/pet/{petId} petId=1
+
+# Use an explicit schema URL when the OpenAPI document is separate
+uxc xquik.com --schema-url https://xquik.com/openapi.json -h
 ```
+
+Xquik is a closed-source hosted service. Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 
 ### GraphQL
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -235,7 +235,12 @@ cargo install --path .
 ```bash
 uxc petstore3.swagger.io/api/v3 -h
 uxc petstore3.swagger.io/api/v3 get:/pet/{petId} petId=1
+
+# OpenAPI 文档单独托管时，显式指定 schema URL
+uxc xquik.com --schema-url https://xquik.com/openapi.json -h
 ```
+
+Xquik 是闭源托管服务，也是独立的第三方服务，与 X Corp. 无关联。“Twitter”和“X”是 X Corp. 的商标。
 
 ### GraphQL
 


### PR DESCRIPTION
## What

- Add English and Chinese OpenAPI examples for services whose schema is hosted separately from the API origin.
- Use Xquik as a live `--schema-url` example and document its hosted-service boundary.
- Preserve the current v0.17.0 installer examples from upstream.

## Why

Xquik publishes its OpenAPI document separately from its API host, making it a useful real-world example of a UXC feature that is otherwise easy to miss.

## How

Both landing-page examples run:

```bash
uxc xquik.com --schema-url https://xquik.com/openapi.json -h
```

The command currently discovers 127 OpenAPI operations without credentials.

## Testing

- [x] `cargo fmt -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --test cli_help_regression_test schema_url_override_supports_schema_separated_openapi_service`
- [x] Exact Xquik command returns `ok: true`, protocol `openapi`, and 127 operations
- [x] v0.17.0 release URL returns HTTP 200
- [x] `git diff --check`

## Checklist

- [x] Code formatted
- [x] No clippy warnings
- [x] Relevant test passes
- [x] English and Chinese documentation updated
- [x] Commit message follows Conventional Commits

## Closes

No linked issue.