### PR TITLE
release: v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-15
+
+### Added
+- Email support: IMAP IDLE source for real-time email event notifications (#421).
+- Email support: SMTP send and reply commands (#422).
+- Email support: Provider poll source transport for periodic email checking (#423).
+
+### Fixed
+- Invalidated stale ETag in managed source poll to prevent silent event loss during GitHub Events polling (#425).
+
 ## [0.15.8] - 2026-06-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3227,7 +3227,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uxc"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxc"
-version = "0.15.8"
+version = "0.16.0"
 edition = "2021"
 authors = ["UXC Contributors"]
 description = "A unified CLI for discovering and invoking tools across OpenAPI, MCP, GraphQL, gRPC, and JSON-RPC"

--- a/packages/uxc-daemon-client/package.json
+++ b/packages/uxc-daemon-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holon-run/uxc-daemon-client",
-  "version": "0.15.8",
+  "version": "0.16.0",
   "description": "Thin Node.js client for UXC daemon-backed operations",
   "license": "MIT",
   "repository": {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -79,6 +79,8 @@ const STOP_POLL_TRIES: usize = 50;
 const STOP_POLL_INTERVAL_MS: u64 = 100;
 const START_LOCK_STALE_SECS: u64 = 30;
 const DAEMON_OWNER_TERM_SIGNAL: i32 = 15;
+const DAEMON_OWNER_KILL_SIGNAL: i32 = 9;
+const KILL_POLL_TRIES: usize = 20;
 const STDIO_INIT_LOCK_STALE_SECS: u64 = 30;
 const MCP_IDLE_TTL_DEFAULT_SECS: u64 = 3600;
 const MCP_IDLE_TTL_ENV: &str = "UXC_DAEMON_MCP_IDLE_TTL_SECS";
@@ -7693,10 +7695,29 @@ pub async fn daemon_stop_local() -> Result<bool> {
                 }
             }
 
+            // Escalate to SIGKILL when SIGTERM does not produce a clean shutdown.
+            // SAFETY: kill with SIGKILL forcefully terminates the owner pid that
+            // did not respond to SIGTERM within the polling window.
+            if unsafe { kill(pid as i32, DAEMON_OWNER_KILL_SIGNAL) } == -1 {
+                return Err(std::io::Error::last_os_error().into());
+            }
+
+            for _ in 0..KILL_POLL_TRIES {
+                tokio::time::sleep(Duration::from_millis(STOP_POLL_INTERVAL_MS)).await;
+                let diagnostics = inspect_daemon_local_diagnostics()?;
+                if !diagnostics.owner_lock_held {
+                    let _ = clear_daemon_owner_metadata_path(&daemon_lock_path());
+                    if socket_path().exists() {
+                        let _ = fs::remove_file(socket_path());
+                    }
+                    return Ok(true);
+                }
+            }
+
             return Err(StructuredError::new(
                 "DAEMON_STOP_TIMEOUT",
                 format!(
-                    "Daemon owner pid {} did not stop in time. Run `uxc daemon doctor`.",
+                    "Daemon owner pid {} did not stop after SIGTERM and SIGKILL. Run `uxc daemon doctor`.",
                     pid
                 ),
                 Some(serde_json::to_value(diagnostics)?),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7664,7 +7664,19 @@ pub async fn daemon_stop_local() -> Result<bool> {
         // Graceful stop did not produce shutdown within the polling window.
         // Fall through to the force-kill path below.
     }
-    force_kill_daemon_owner().await
+    match force_kill_daemon_owner().await {
+        Ok(true) => Ok(true),
+        Ok(false) => {
+            // No owner lock held. If the socket is still reachable, the
+            // daemon is running without an owner lock (e.g., a third-party
+            // process on the socket). Return an error since we cannot stop it.
+            if daemon_status_client().await.is_ok() {
+                bail!("Daemon did not stop in time. Run `uxc daemon status` for diagnostics.");
+            }
+            Ok(false)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 #[cfg(unix)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7652,8 +7652,10 @@ pub async fn daemon_start_local() -> Result<EnsureDaemonOutcome> {
 }
 
 pub async fn daemon_stop_local() -> Result<bool> {
-    // Try graceful stop via the daemon socket when it is reachable.
-    if daemon_status_client().await.is_ok() {
+    // Track whether the daemon socket was reachable at entry so we can
+    // distinguish "no daemon" from "daemon was reachable but stop failed".
+    let socket_was_reachable = daemon_status_client().await.is_ok();
+    if socket_was_reachable {
         let _ = daemon_stop_client().await;
         for _ in 0..STOP_POLL_TRIES {
             tokio::time::sleep(Duration::from_millis(STOP_POLL_INTERVAL_MS)).await;
@@ -7667,10 +7669,11 @@ pub async fn daemon_stop_local() -> Result<bool> {
     match force_kill_daemon_owner().await {
         Ok(true) => Ok(true),
         Ok(false) => {
-            // No owner lock held. If the socket is still reachable, the
-            // daemon is running without an owner lock (e.g., a third-party
-            // process on the socket). Return an error since we cannot stop it.
-            if daemon_status_client().await.is_ok() {
+            // No owner lock held. If the socket was reachable at entry or is
+            // still reachable now, the daemon is running without an owner
+            // lock (e.g., a third-party process on the socket). Return an
+            // error since we could not stop it.
+            if socket_was_reachable || daemon_status_client().await.is_ok() {
                 bail!("Daemon did not stop in time. Run `uxc daemon status` for diagnostics.");
             }
             Ok(false)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6973,6 +6973,11 @@ pub async fn ensure_compatible_daemon_running() -> Result<EnsureDaemonOutcome> {
             })
         }
         Err(_) => {
+            // Clean up any stale daemon (unreachable socket, lingering owner
+            // lock) before spawning a new one. daemon_stop_local handles the
+            // "no daemon" case (Ok(false)) and the stale-daemon case
+            // (SIGTERM → SIGKILL → lock release + artifact cleanup).
+            let _ = daemon_stop_local().await;
             start_daemon_process().await?;
             Ok(EnsureDaemonOutcome {
                 started_now: true,
@@ -7652,100 +7657,102 @@ pub async fn daemon_start_local() -> Result<EnsureDaemonOutcome> {
 }
 
 pub async fn daemon_stop_local() -> Result<bool> {
-    if daemon_status_client().await.is_err() {
-        let diagnostics = inspect_daemon_local_diagnostics()?;
-        if !diagnostics.owner_lock_held {
-            return Ok(false);
-        }
-
-        let pid = diagnostics.owner_pid.ok_or_else(|| {
-            StructuredError::new(
-                "DAEMON_OWNER_METADATA_MISSING",
-                "Daemon owner lock is held but owner pid metadata is missing. Run `uxc daemon doctor`."
-                    .to_string(),
-                Some(serde_json::to_value(&diagnostics).unwrap_or(Value::Null)),
-            )
-        })?;
-
-        if !diagnostics.owner_pid_alive {
-            return Err(StructuredError::new(
-                "DAEMON_OWNER_STALE",
-                "Daemon owner metadata is stale. Run `uxc daemon doctor`.".to_string(),
-                Some(serde_json::to_value(&diagnostics)?),
-            )
-            .into());
-        }
-
-        #[cfg(unix)]
-        {
-            // SAFETY: kill with SIGTERM targets the owner pid discovered from local metadata.
-            if unsafe { kill(pid as i32, DAEMON_OWNER_TERM_SIGNAL) } == -1 {
-                return Err(std::io::Error::last_os_error().into());
+    // Try graceful stop via the daemon socket when it is reachable.
+    if daemon_status_client().await.is_ok() {
+        let _ = daemon_stop_client().await;
+        for _ in 0..STOP_POLL_TRIES {
+            tokio::time::sleep(Duration::from_millis(STOP_POLL_INTERVAL_MS)).await;
+            if daemon_status_client().await.is_err() {
+                return Ok(true);
             }
-
-            for _ in 0..STOP_POLL_TRIES {
-                tokio::time::sleep(Duration::from_millis(STOP_POLL_INTERVAL_MS)).await;
-                let diagnostics = inspect_daemon_local_diagnostics()?;
-                if !diagnostics.owner_lock_held {
-                    let _ = clear_daemon_owner_metadata_path(&daemon_lock_path());
-                    if socket_path().exists() {
-                        let _ = fs::remove_file(socket_path());
-                    }
-                    return Ok(true);
-                }
-            }
-
-            // Escalate to SIGKILL when SIGTERM does not produce a clean shutdown.
-            // SAFETY: kill with SIGKILL forcefully terminates the owner pid that
-            // did not respond to SIGTERM within the polling window.
-            if unsafe { kill(pid as i32, DAEMON_OWNER_KILL_SIGNAL) } == -1 {
-                return Err(std::io::Error::last_os_error().into());
-            }
-
-            for _ in 0..KILL_POLL_TRIES {
-                tokio::time::sleep(Duration::from_millis(STOP_POLL_INTERVAL_MS)).await;
-                let diagnostics = inspect_daemon_local_diagnostics()?;
-                if !diagnostics.owner_lock_held {
-                    let _ = clear_daemon_owner_metadata_path(&daemon_lock_path());
-                    if socket_path().exists() {
-                        let _ = fs::remove_file(socket_path());
-                    }
-                    return Ok(true);
-                }
-            }
-
-            return Err(StructuredError::new(
-                "DAEMON_STOP_TIMEOUT",
-                format!(
-                    "Daemon owner pid {} did not stop after SIGTERM and SIGKILL. Run `uxc daemon doctor`.",
-                    pid
-                ),
-                Some(serde_json::to_value(diagnostics)?),
-            )
-            .into());
         }
-
-        #[cfg(not(unix))]
-        {
-            return Err(StructuredError::new(
-                "DAEMON_STOP_UNSUPPORTED_PLATFORM",
-                format!(
-                    "Daemon owner pid {} cannot be stopped via Unix signals on this platform.",
-                    pid
-                ),
-                Some(serde_json::to_value(&diagnostics)?),
-            )
-            .into());
-        }
+        // Graceful stop did not produce shutdown within the polling window.
+        // Fall through to the force-kill path below.
     }
-    daemon_stop_client().await?;
+    force_kill_daemon_owner().await
+}
+
+#[cfg(unix)]
+async fn force_kill_daemon_owner() -> Result<bool> {
+    let diagnostics = inspect_daemon_local_diagnostics()?;
+    if !diagnostics.owner_lock_held {
+        return Ok(false);
+    }
+
+    let pid = diagnostics.owner_pid.ok_or_else(|| {
+        StructuredError::new(
+            "DAEMON_OWNER_METADATA_MISSING",
+            "Daemon owner lock is held but owner pid metadata is missing. Run `uxc daemon doctor`."
+                .to_string(),
+            Some(serde_json::to_value(&diagnostics).unwrap_or(Value::Null)),
+        )
+    })?;
+
+    if !diagnostics.owner_pid_alive {
+        return Err(StructuredError::new(
+            "DAEMON_OWNER_STALE",
+            "Daemon owner metadata is stale. Run `uxc daemon doctor`.".to_string(),
+            Some(serde_json::to_value(&diagnostics)?),
+        )
+        .into());
+    }
+
+    // SAFETY: kill with SIGTERM targets the owner pid discovered from local metadata.
+    if unsafe { kill(pid as i32, DAEMON_OWNER_TERM_SIGNAL) } == -1 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
     for _ in 0..STOP_POLL_TRIES {
         tokio::time::sleep(Duration::from_millis(STOP_POLL_INTERVAL_MS)).await;
-        if daemon_status_client().await.is_err() {
+        let diagnostics = inspect_daemon_local_diagnostics()?;
+        if !diagnostics.owner_lock_held {
+            let _ = clear_daemon_owner_metadata_path(&daemon_lock_path());
+            if socket_path().exists() {
+                let _ = fs::remove_file(socket_path());
+            }
             return Ok(true);
         }
     }
-    bail!("Daemon did not stop in time. Run `uxc daemon status` for diagnostics.")
+
+    // Escalate to SIGKILL when SIGTERM does not produce a clean shutdown.
+    // SAFETY: kill with SIGKILL forcefully terminates the owner pid that
+    // did not respond to SIGTERM within the polling window.
+    if unsafe { kill(pid as i32, DAEMON_OWNER_KILL_SIGNAL) } == -1 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    for _ in 0..KILL_POLL_TRIES {
+        tokio::time::sleep(Duration::from_millis(STOP_POLL_INTERVAL_MS)).await;
+        let diagnostics = inspect_daemon_local_diagnostics()?;
+        if !diagnostics.owner_lock_held {
+            let _ = clear_daemon_owner_metadata_path(&daemon_lock_path());
+            if socket_path().exists() {
+                let _ = fs::remove_file(socket_path());
+            }
+            return Ok(true);
+        }
+    }
+
+    Err(StructuredError::new(
+        "DAEMON_STOP_TIMEOUT",
+        format!(
+            "Daemon owner pid {} did not stop after SIGTERM and SIGKILL. Run `uxc daemon doctor`.",
+            pid
+        ),
+        Some(serde_json::to_value(diagnostics)?),
+    )
+    .into())
+}
+
+#[cfg(not(unix))]
+async fn force_kill_daemon_owner() -> Result<bool> {
+    Err(StructuredError::new(
+        "DAEMON_STOP_UNSUPPORTED_PLATFORM",
+        "Cannot force-kill daemon owner on non-Unix platforms. Run `uxc daemon doctor`."
+            .to_string(),
+        None,
+    )
+    .into())
 }
 
 #[cfg(unix)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6973,11 +6973,6 @@ pub async fn ensure_compatible_daemon_running() -> Result<EnsureDaemonOutcome> {
             })
         }
         Err(_) => {
-            // Clean up any stale daemon (unreachable socket, lingering owner
-            // lock) before spawning a new one. daemon_stop_local handles the
-            // "no daemon" case (Ok(false)) and the stale-daemon case
-            // (SIGTERM → SIGKILL → lock release + artifact cleanup).
-            let _ = daemon_stop_local().await;
             start_daemon_process().await?;
             Ok(EnsureDaemonOutcome {
                 started_now: true,

--- a/tests/benchmark_test.rs
+++ b/tests/benchmark_test.rs
@@ -162,7 +162,12 @@ fn benchmark_repeated_call_latency_p95() {
         .arg("start")
         .output()
         .expect("daemon start should run");
-    assert!(start.status.success());
+    assert!(
+        start.status.success(),
+        "daemon start failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr)
+    );
 
     let sample_count = benchmark_sample_count();
     let mut latencies_ms = Vec::with_capacity(sample_count);

--- a/tests/benchmark_test.rs
+++ b/tests/benchmark_test.rs
@@ -41,7 +41,12 @@ fn benchmark_mcp_stdio_cold_vs_warm_latency() {
         .arg("start")
         .output()
         .expect("daemon start should run");
-    assert!(start.status.success());
+    assert!(
+        start.status.success(),
+        "daemon start failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr)
+    );
 
     let cold_t0 = Instant::now();
     let cold_output = uxc_command()
@@ -103,7 +108,12 @@ fn benchmark_openapi_http_cold_vs_warm_latency() {
         .arg("start")
         .output()
         .expect("daemon start should run");
-    assert!(start.status.success());
+    assert!(
+        start.status.success(),
+        "daemon start failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr)
+    );
 
     let cold_t0 = Instant::now();
     let cold_output = uxc_command()


### PR DESCRIPTION
## What
- Release uxc v0.16.0
- Includes email support (IMAP IDLE source, SMTP send/reply, provider poll transport)
- Includes ETag stale fix (#425) for managed source poll
- Includes daemon stop escalation fixes (SIGTERM/SIGKILL, socket reachability)

## Why
Aggregate email feature PRs (#421, #422, #423) and bug fix #425 into a release tag. Daemon stop fixes resolve flaky test issues and improve graceful shutdown reliability.

## How
- Version bump to 0.16.0 in Cargo.toml, Cargo.lock, packages/uxc-daemon-client/package.json
- CHANGELOG updated with v0.16.0 entry
- Daemon stop logic: escalate from SIGTERM to SIGKILL on timeout, preserve socket reachability state, revert stale daemon cleanup

## Testing
- `cargo test --locked -- --test-threads=1` passed (513 unit tests + all integration tests, 0 failures)
- `cargo clippy` clean