### PR TITLE
feat(mcp): support 2026 stdio protocol negotiation

### DIFF
--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -4,6 +4,7 @@ use super::transport::{
     DefaultStdioProcessExecutor, McpStdioTransport, StdioProcessExecutor, StdioSpawnOptions,
 };
 use super::types::*;
+use crate::error::{structured_error_from_anyhow, StructuredError};
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
@@ -26,6 +27,7 @@ pub struct LifecycleContract {
 /// MCP stdio client
 pub struct McpStdioClient {
     transport: McpStdioTransport,
+    protocol_context: McpProtocolContext,
     server_capabilities: Option<ServerCapabilities>,
     server_info: Option<ServerInfo>,
     instructions: Option<String>,
@@ -76,17 +78,106 @@ impl McpStdioClient {
         executor: Arc<dyn StdioProcessExecutor>,
         timeout: Duration,
     ) -> Result<Self> {
-        let mut transport =
-            McpStdioTransport::connect_with_executor(command, args, options, executor).await?;
-
-        // Initialize the session
         let client_info = ClientInfo {
             name: env!("CARGO_PKG_NAME").to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            title: None,
+            description: None,
+            websiteUrl: None,
+            icons: None,
         };
 
+        let mut transport = McpStdioTransport::connect_with_executor(
+            command,
+            args,
+            options.clone(),
+            executor.clone(),
+        )
+        .await?;
+        let modern_context = McpProtocolContext {
+            era: McpProtocolEra::Modern,
+            version: MCP_MODERN_PROTOCOL_VERSION.to_string(),
+            client_capabilities: ClientCapabilities::default(),
+            server_capabilities: ServerCapabilities::default(),
+            client_info: client_info.clone(),
+            server_info: None,
+        };
+        let discover_result = transport
+            .send_request_with_timeout(
+                "server/discover",
+                Some(modern_context.modern_request_params(None)?),
+                timeout.min(Duration::from_secs(1)),
+            )
+            .await;
+
+        match discover_result {
+            Ok(result) => match serde_json::from_value::<DiscoverResult>(result) {
+                Ok(discover) => {
+                    if !discover
+                        .supportedVersions
+                        .iter()
+                        .any(|version| version == MCP_MODERN_PROTOCOL_VERSION)
+                    {
+                        return Err(StructuredError::new(
+                            "UNSUPPORTED_PROTOCOL_VERSION",
+                            format!(
+                                "MCP server does not support protocol version {}",
+                                MCP_MODERN_PROTOCOL_VERSION
+                            ),
+                            Some(json!({
+                                "requested": MCP_MODERN_PROTOCOL_VERSION,
+                                "supported": discover.supportedVersions,
+                            })),
+                        )
+                        .into());
+                    }
+
+                    let server_info = discover.server_info();
+                    tracing::info!(
+                        "Connected to modern MCP server: {} v{}",
+                        server_info
+                            .as_ref()
+                            .map(|server| server.name.as_str())
+                            .unwrap_or("unknown"),
+                        server_info
+                            .as_ref()
+                            .map(|server| server.version.as_str())
+                            .unwrap_or("unknown")
+                    );
+                    let protocol_context = McpProtocolContext {
+                        server_capabilities: discover.capabilities.clone(),
+                        server_info: server_info.clone(),
+                        ..modern_context
+                    };
+                    return Ok(Self {
+                        transport,
+                        protocol_context,
+                        server_capabilities: Some(discover.capabilities),
+                        server_info,
+                        instructions: discover.instructions,
+                    });
+                }
+                Err(err) => tracing::debug!(
+                    "MCP server/discover returned a non-modern result; retrying legacy initialize: {}",
+                    err
+                ),
+            },
+            Err(err) if is_unsupported_protocol_version(&err) => return Err(err),
+            Err(err) => {
+                tracing::debug!(
+                    "MCP server/discover probe did not identify a modern server; retrying legacy initialize: {}",
+                    err
+                );
+            }
+        }
+        let _ = transport.kill_and_wait(Duration::from_millis(250)).await;
+
+        // Never reuse a failed probe process: a late response could otherwise
+        // be mistaken for the legacy initialize response.
+        let mut transport =
+            McpStdioTransport::connect_with_executor(command, args, options, executor).await?;
         let init_result = transport
-            .initialize_with_timeout(client_info, timeout)
+            .initialize_with_timeout(client_info.clone(), timeout)
             .await?;
         tracing::info!(
             "Connected to MCP server: {} v{}",
@@ -105,12 +196,29 @@ impl McpStdioClient {
         // Send initialized notification
         transport.initialized().await?;
 
+        let protocol_context = McpProtocolContext {
+            era: McpProtocolEra::Legacy,
+            version: init_result.protocolVersion.clone(),
+            client_capabilities: ClientCapabilities::default(),
+            server_capabilities: init_result.capabilities.clone(),
+            client_info,
+            server_info: init_result.serverInfo.clone(),
+        };
         Ok(Self {
             transport,
+            protocol_context,
             server_capabilities: Some(init_result.capabilities),
             server_info: init_result.serverInfo,
             instructions: init_result.instructions,
         })
+    }
+
+    pub fn protocol_era(&self) -> McpProtocolEra {
+        self.protocol_context.era
+    }
+
+    pub fn protocol_version(&self) -> &str {
+        &self.protocol_context.version
     }
 
     /// Check if the server supports tools
@@ -130,6 +238,9 @@ impl McpStdioClient {
     }
 
     pub fn supports_resource_subscribe(&self) -> bool {
+        if self.protocol_context.era == McpProtocolEra::Modern {
+            return false;
+        }
         self.server_capabilities
             .as_ref()
             .and_then(|c| c.resources.as_ref())
@@ -175,7 +286,6 @@ impl McpStdioClient {
 
     pub async fn lifecycle_contract(&mut self, timeout: Duration) -> Result<LifecycleContract> {
         let result = self
-            .transport
             .send_request_with_timeout("uxc/lifecycle_contract", Some(json!({})), timeout)
             .await
             .context("Failed to fetch uxc/lifecycle_contract")?;
@@ -197,7 +307,6 @@ impl McpStdioClient {
         }
 
         let result = self
-            .transport
             .send_request_with_timeout("tools/list", None, timeout)
             .await
             .context("Failed to list tools")?;
@@ -250,7 +359,6 @@ impl McpStdioClient {
         };
 
         let result = self
-            .transport
             .send_request_with_timeout("tools/call", Some(serde_json::to_value(params)?), timeout)
             .await
             .context(format!("Failed to call tool '{}'", name))?;
@@ -269,7 +377,6 @@ impl McpStdioClient {
         }
 
         let result = self
-            .transport
             .send_request("resources/list", None)
             .await
             .context("Failed to list resources")?;
@@ -300,7 +407,6 @@ impl McpStdioClient {
         let params = json!({ "uri": uri });
 
         let result = self
-            .transport
             .send_request("resources/read", Some(params))
             .await
             .context(format!("Failed to read resource '{}'", uri))?;
@@ -309,6 +415,9 @@ impl McpStdioClient {
     }
 
     pub async fn subscribe_resource(&mut self, uri: &str) -> Result<()> {
+        if self.protocol_context.era == McpProtocolEra::Modern {
+            bail!("Modern MCP resource subscriptions require subscriptions/listen");
+        }
         if !self.supports_resources() {
             bail!("Server does not support resources");
         }
@@ -317,21 +426,22 @@ impl McpStdioClient {
         }
 
         let params = json!({ "uri": uri });
-        self.transport
-            .send_request("resources/subscribe", Some(params))
+        self.send_request("resources/subscribe", Some(params))
             .await
             .context(format!("Failed to subscribe resource '{}'", uri))?;
         Ok(())
     }
 
     pub async fn unsubscribe_resource(&mut self, uri: &str) -> Result<()> {
+        if self.protocol_context.era == McpProtocolEra::Modern {
+            bail!("Modern MCP resource subscriptions require subscriptions/listen");
+        }
         if !self.supports_resources() {
             bail!("Server does not support resources");
         }
 
         let params = json!({ "uri": uri });
-        self.transport
-            .send_request("resources/unsubscribe", Some(params))
+        self.send_request("resources/unsubscribe", Some(params))
             .await
             .context(format!("Failed to unsubscribe resource '{}'", uri))?;
         Ok(())
@@ -345,7 +455,6 @@ impl McpStdioClient {
         }
 
         let result = self
-            .transport
             .send_request("prompts/list", None)
             .await
             .context("Failed to list prompts")?;
@@ -383,7 +492,6 @@ impl McpStdioClient {
         });
 
         let result = self
-            .transport
             .send_request("prompts/get", Some(params))
             .await
             .context(format!("Failed to get prompt '{}'", name))?;
@@ -393,12 +501,117 @@ impl McpStdioClient {
 
         Ok(prompt_result)
     }
+
+    async fn send_request(&mut self, method: &str, params: Option<JsonValue>) -> Result<JsonValue> {
+        let params = match self.protocol_context.era {
+            McpProtocolEra::Modern => Some(self.protocol_context.modern_request_params(params)?),
+            McpProtocolEra::Legacy => params,
+        };
+        self.transport.send_request(method, params).await
+    }
+
+    async fn send_request_with_timeout(
+        &mut self,
+        method: &str,
+        params: Option<JsonValue>,
+        timeout: Duration,
+    ) -> Result<JsonValue> {
+        let params = match self.protocol_context.era {
+            McpProtocolEra::Modern => Some(self.protocol_context.modern_request_params(params)?),
+            McpProtocolEra::Legacy => params,
+        };
+        self.transport
+            .send_request_with_timeout(method, params, timeout)
+            .await
+    }
+}
+
+fn is_unsupported_protocol_version(err: &anyhow::Error) -> bool {
+    structured_error_from_anyhow(err)
+        .and_then(|error| error.details)
+        .and_then(|details| details.get("jsonrpc_code").and_then(JsonValue::as_i64))
+        == Some(-32022)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::error::structured_error_from_anyhow;
+
+    #[tokio::test]
+    async fn modern_stdio_uses_discover_and_request_metadata_without_initialize() {
+        let script = r#"
+            read discover
+            echo "$discover" | grep -q '"method":"server/discover"' || exit 10
+            echo "$discover" | grep -q '"io.modelcontextprotocol/protocolVersion":"2026-07-28"' || exit 11
+            echo "$discover" | grep -q '"io.modelcontextprotocol/clientCapabilities":{}' || exit 12
+            echo '{"jsonrpc":"2.0","id":1,"result":{"resultType":"complete","supportedVersions":["2026-07-28"],"capabilities":{"tools":{}},"ttlMs":0,"cacheScope":"private","_meta":{"io.modelcontextprotocol/serverInfo":{"name":"modern-test","version":"1.0.0"}}}}'
+            read list
+            echo "$list" | grep -q '"method":"tools/list"' || exit 13
+            echo "$list" | grep -q '"io.modelcontextprotocol/protocolVersion":"2026-07-28"' || exit 14
+            echo "$list" | grep -q '"method":"initialize"' && exit 15
+            echo '{"jsonrpc":"2.0","id":2,"result":{"resultType":"complete","tools":[{"name":"ping","inputSchema":{"type":"object"}}],"ttlMs":0,"cacheScope":"private"}}'
+            read call
+            echo "$call" | grep -q '"method":"tools/call"' || exit 16
+            echo "$call" | grep -q '"name":"ping"' || exit 17
+            echo "$call" | grep -q '"io.modelcontextprotocol/protocolVersion":"2026-07-28"' || exit 18
+            echo '{"jsonrpc":"2.0","id":3,"result":{"resultType":"complete","content":[{"type":"audio","data":"opaque","mimeType":"audio/wav","futureField":true}]}}'
+        "#;
+
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
+
+        assert_eq!(client.protocol_era(), McpProtocolEra::Modern);
+        assert_eq!(client.protocol_version(), MCP_MODERN_PROTOCOL_VERSION);
+        assert_eq!(
+            client.server_info().map(|server| server.name.as_str()),
+            Some("modern-test")
+        );
+        let tools = client.list_tools().await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "ping");
+        assert_eq!(tools[0].description, None);
+        let result = client.call_tool("ping", None).await.unwrap();
+        assert_eq!(result.resultType, "complete");
+        assert_eq!(result.content[0].content_type(), Some("audio"));
+        assert_eq!(result.content[0].as_value()["futureField"], true);
+    }
+
+    #[tokio::test]
+    async fn legacy_fallback_restarts_process_before_initialize() {
+        let dir = tempfile::tempdir().unwrap();
+        let count_path = dir.path().join("spawn-count");
+        let script = format!(
+            r#"
+            count=0
+            if [ -f "{path}" ]; then count=$(cat "{path}"); fi
+            count=$((count + 1))
+            echo "$count" > "{path}"
+            read request
+            if [ "$count" -eq 1 ]; then
+                echo "$request" | grep -q '"method":"server/discover"' || exit 20
+                echo '{{"jsonrpc":"2.0","id":1,"error":{{"code":-32601,"message":"Method not found"}}}}'
+                while read ignored; do :; done
+            else
+                echo "$request" | grep -q '"method":"initialize"' || exit 21
+                echo '{{"jsonrpc":"2.0","id":1,"result":{{"protocolVersion":"2024-11-05","capabilities":{{"tools":{{}}}},"serverInfo":{{"name":"legacy-test","version":"1.0.0"}}}}}}'
+                read initialized
+                echo "$initialized" | grep -q '"method":"notifications/initialized"' || exit 22
+                while read ignored; do :; done
+            fi
+            "#,
+            path = count_path.display()
+        );
+
+        let client = McpStdioClient::connect("sh", &["-c".to_string(), script])
+            .await
+            .unwrap();
+
+        assert_eq!(client.protocol_era(), McpProtocolEra::Legacy);
+        assert_eq!(client.protocol_version(), MCP_PROTOCOL_VERSION);
+        assert_eq!(std::fs::read_to_string(count_path).unwrap().trim(), "2");
+    }
 
     #[tokio::test]
     async fn client_requires_tools_capability() {
@@ -499,7 +712,7 @@ mod tests {
         let tools = client.list_tools().await.unwrap();
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].name, "test_tool");
-        assert_eq!(tools[0].description, "A test tool");
+        assert_eq!(tools[0].description.as_deref(), Some("A test tool"));
     }
 
     #[tokio::test]
@@ -518,11 +731,13 @@ mod tests {
         let args = serde_json::json!({"param1": "value1"});
         let result = client.call_tool("test_tool", Some(args)).await.unwrap();
 
+        assert_eq!(result.resultType, "complete");
         assert_eq!(result.content.len(), 1);
-        match &result.content[0] {
-            ToolContent::Text { text } => assert_eq!(text, "Tool executed successfully"),
-            _ => panic!("Expected text content"),
-        }
+        assert_eq!(result.content[0].content_type(), Some("text"));
+        assert_eq!(
+            result.content[0].as_value()["text"],
+            "Tool executed successfully"
+        );
         assert_eq!(
             result.structuredContent,
             Some(serde_json::json!({ "message": "Tool executed successfully" }))
@@ -683,30 +898,20 @@ mod tests {
         // Test that different tool content types can be deserialized
         let text_json = r#"{"type":"text","text":"Hello"}"#;
         let text: ToolContent = serde_json::from_str(text_json).unwrap();
-        match text {
-            ToolContent::Text { text: t } => assert_eq!(t, "Hello"),
-            _ => panic!("Expected text content"),
-        }
+        assert_eq!(text.content_type(), Some("text"));
+        assert_eq!(text.as_value()["text"], "Hello");
 
         let image_json = r#"{"type":"image","data":"base64data","mimeType":"image/png"}"#;
         let image: ToolContent = serde_json::from_str(image_json).unwrap();
-        match image {
-            ToolContent::Image { data, mimeType } => {
-                assert_eq!(data, "base64data");
-                assert_eq!(mimeType, "image/png");
-            }
-            _ => panic!("Expected image content"),
-        }
+        assert_eq!(image.content_type(), Some("image"));
+        assert_eq!(image.as_value()["data"], "base64data");
+        assert_eq!(image.as_value()["mimeType"], "image/png");
 
         let resource_json = r#"{"type":"resource","uri":"test://resource","text":"content"}"#;
         let resource: ToolContent = serde_json::from_str(resource_json).unwrap();
-        match resource {
-            ToolContent::Resource { uri, text, .. } => {
-                assert_eq!(uri, "test://resource");
-                assert_eq!(text.unwrap(), "content");
-            }
-            _ => panic!("Expected resource content"),
-        }
+        assert_eq!(resource.content_type(), Some("resource"));
+        assert_eq!(resource.as_value()["uri"], "test://resource");
+        assert_eq!(resource.as_value()["text"], "content");
     }
 
     #[tokio::test]

--- a/src/adapters/mcp/http_transport.rs
+++ b/src/adapters/mcp/http_transport.rs
@@ -3422,10 +3422,8 @@ data: invalid json
 
         let result = transport.call_tool("legacy_tool", None).await.unwrap();
         assert_eq!(result.content.len(), 1);
-        match &result.content[0] {
-            ToolContent::Text { text } => assert_eq!(text, "legacy-ok"),
-            other => panic!("expected text tool content, got {:?}", other),
-        }
+        assert_eq!(result.content[0].content_type(), Some("text"));
+        assert_eq!(result.content[0].as_value()["text"], "legacy-ok");
     }
 
     #[tokio::test]

--- a/src/adapters/mcp/mod.rs
+++ b/src/adapters/mcp/mod.rs
@@ -350,6 +350,8 @@ impl McpAdapter {
                 self.request_timeout_or_default(),
             )
             .await?;
+            let protocol_version = client.protocol_version().to_string();
+            let protocol_era = client.protocol_era();
             let server_info = client.server_info().cloned();
             let instructions = client.instructions().map(ToString::to_string);
             let tools = match client
@@ -366,7 +368,8 @@ impl McpAdapter {
             // Build schema from server capabilities
             let mut schema = serde_json::json!({
                 "protocol": "MCP",
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": protocol_version,
+                "protocolEra": protocol_era,
                 "transport": "stdio",
                 "command": cmd,
                 "serverInfo": server_info,
@@ -488,16 +491,16 @@ impl Adapter for McpAdapter {
         let operations = tools
             .into_iter()
             .map(|tool| {
-                let parameters = if let Some(schema) = tool.inputSchema {
-                    parse_schema_to_parameters_for_daemon(&schema)
+                let parameters = if let Some(schema) = tool.inputSchema.as_ref() {
+                    parse_schema_to_parameters_for_daemon(schema)
                 } else {
                     Vec::new()
                 };
 
                 Operation {
                     operation_id: tool.name.clone(),
-                    display_name: tool.name.clone(),
-                    description: Some(tool.description),
+                    display_name: tool.display_name().to_string(),
+                    description: tool.description,
                     parameters,
                     return_type: Some("ToolContent".to_string()),
                 }
@@ -513,8 +516,8 @@ impl Adapter for McpAdapter {
             if tool.name == operation {
                 return Ok(OperationDetail {
                     operation_id: tool.name.clone(),
-                    display_name: tool.name,
-                    description: Some(tool.description),
+                    display_name: tool.display_name().to_string(),
+                    description: tool.description,
                     parameters: tool
                         .inputSchema
                         .as_ref()
@@ -646,6 +649,7 @@ pub(crate) fn parse_schema_to_parameters_for_daemon(schema: &Value) -> Vec<super
 /// Convert MCP tool call result to a JSON value for output.
 pub(crate) fn convert_tool_result_to_value(result: &types::ToolCallResult) -> Value {
     let mut output = serde_json::json!({
+        "resultType": result.resultType,
         "content": convert_tool_content_to_json(&result.content)
     });
 
@@ -655,50 +659,21 @@ pub(crate) fn convert_tool_result_to_value(result: &types::ToolCallResult) -> Va
     if let Some(structured) = &result.structuredContent {
         output["structuredContent"] = structured.clone();
     }
+    if let Some(input_requests) = &result.inputRequests {
+        output["inputRequests"] = input_requests.clone();
+    }
+    if let Some(request_state) = &result.requestState {
+        output["requestState"] = serde_json::json!(request_state);
+    }
+    if let Some(meta) = &result.meta {
+        output["_meta"] = meta.clone();
+    }
 
     output
 }
 
 fn convert_tool_content_to_json(content: &[types::ToolContent]) -> Value {
-    let mut results = Vec::new();
-
-    for item in content {
-        let value = match item {
-            types::ToolContent::Text { text } => serde_json::json!({
-                "type": "text",
-                "text": text
-            }),
-            types::ToolContent::Image { data, mimeType } => serde_json::json!({
-                "type": "image",
-                "data": data,
-                "mimeType": mimeType
-            }),
-            types::ToolContent::Resource {
-                uri,
-                mimeType,
-                text,
-                blob,
-            } => {
-                let mut obj = serde_json::json!({
-                    "type": "resource",
-                    "uri": uri
-                });
-                if let Some(mt) = mimeType {
-                    obj["mimeType"] = serde_json::json!(mt);
-                }
-                if let Some(t) = text {
-                    obj["text"] = serde_json::json!(t);
-                }
-                if let Some(b) = blob {
-                    obj["blob"] = serde_json::json!(b);
-                }
-                obj
-            }
-        };
-        results.push(value);
-    }
-
-    Value::Array(results)
+    Value::Array(content.iter().map(|item| item.as_value().clone()).collect())
 }
 
 #[cfg(test)]
@@ -770,16 +745,22 @@ mod tests {
     #[test]
     fn convert_tool_result_includes_structured_content_and_error_flag() {
         let result = types::ToolCallResult {
-            content: vec![types::ToolContent::Text {
-                text: "hello".to_string(),
-            }],
+            resultType: "complete".to_string(),
+            content: vec![types::ToolContent(json!({
+                "type": "text",
+                "text": "hello"
+            }))],
             isError: Some(true),
             structuredContent: Some(json!({ "message": "hello", "count": 1 })),
+            inputRequests: None,
+            requestState: None,
+            meta: None,
         };
 
         let output = convert_tool_result_to_value(&result);
         assert_eq!(output["content"][0]["type"], "text");
         assert_eq!(output["content"][0]["text"], "hello");
+        assert_eq!(output["resultType"], "complete");
         assert_eq!(output["isError"], true);
         assert_eq!(output["structuredContent"]["message"], "hello");
         assert_eq!(output["structuredContent"]["count"], 1);
@@ -788,6 +769,7 @@ mod tests {
     #[test]
     fn convert_tool_result_preserves_local_artifact_paths() {
         let result = types::ToolCallResult {
+            resultType: "complete".to_string(),
             content: vec![],
             isError: Some(false),
             structuredContent: Some(json!({
@@ -800,6 +782,9 @@ mod tests {
                     }
                 ]
             })),
+            inputRequests: None,
+            requestState: None,
+            meta: None,
         };
 
         let output = convert_tool_result_to_value(&result);

--- a/src/adapters/mcp/transport.rs
+++ b/src/adapters/mcp/transport.rs
@@ -1270,6 +1270,10 @@ mod tests {
         let client_info = ClientInfo {
             name: "uxc".to_string(),
             version: "1.0.0".to_string(),
+            title: None,
+            description: None,
+            websiteUrl: None,
+            icons: None,
         };
 
         let result = transport.initialize(client_info).await.unwrap();
@@ -1439,6 +1443,10 @@ mod tests {
         let client_info = ClientInfo {
             name: "uxc".to_string(),
             version: "1.0.0".to_string(),
+            title: None,
+            description: None,
+            websiteUrl: None,
+            icons: None,
         };
 
         let start = tokio::time::Instant::now();

--- a/src/adapters/mcp/types.rs
+++ b/src/adapters/mcp/types.rs
@@ -5,6 +5,7 @@
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use std::collections::HashMap;
 
 /// JSON-RPC 2.0 Request
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -53,8 +54,57 @@ pub struct JsonRpcError {
     pub data: Option<JsonValue>,
 }
 
-/// MCP Protocol Version
+/// Legacy MCP protocol version currently supported by UXC.
 pub const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+/// Latest stateless MCP protocol version supported by UXC.
+pub const MCP_MODERN_PROTOCOL_VERSION: &str = "2026-07-28";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum McpProtocolEra {
+    Legacy,
+    Modern,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpProtocolContext {
+    pub era: McpProtocolEra,
+    pub version: String,
+    pub client_capabilities: ClientCapabilities,
+    pub server_capabilities: ServerCapabilities,
+    pub client_info: ClientInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_info: Option<ServerInfo>,
+}
+
+impl McpProtocolContext {
+    pub fn modern_request_params(&self, params: Option<JsonValue>) -> Result<JsonValue> {
+        let mut params = match params {
+            Some(JsonValue::Object(params)) => params,
+            Some(_) => return Err(anyhow!("MCP request params must be a JSON object")),
+            None => serde_json::Map::new(),
+        };
+        let mut meta = match params.remove("_meta") {
+            Some(JsonValue::Object(meta)) => meta,
+            Some(_) => return Err(anyhow!("MCP request params._meta must be a JSON object")),
+            None => serde_json::Map::new(),
+        };
+        meta.insert(
+            "io.modelcontextprotocol/protocolVersion".to_string(),
+            JsonValue::String(self.version.clone()),
+        );
+        meta.insert(
+            "io.modelcontextprotocol/clientInfo".to_string(),
+            serde_json::to_value(&self.client_info)?,
+        );
+        meta.insert(
+            "io.modelcontextprotocol/clientCapabilities".to_string(),
+            serde_json::to_value(&self.client_capabilities)?,
+        );
+        params.insert("_meta".to_string(), JsonValue::Object(meta));
+        Ok(JsonValue::Object(params))
+    }
+}
 
 /// Initialize request parameters
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -71,6 +121,14 @@ pub struct ClientCapabilities {
     pub roots: Option<RootsCapability>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sampling: Option<SamplingCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elicitation: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<HashMap<String, JsonValue>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<HashMap<String, JsonValue>>,
+    #[serde(flatten)]
+    pub additional: HashMap<String, JsonValue>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -90,6 +148,14 @@ pub struct SamplingCapability {
 pub struct ClientInfo {
     pub name: String,
     pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub websiteUrl: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<JsonValue>>,
 }
 
 /// Initialize response
@@ -112,6 +178,10 @@ pub struct ServerCapabilities {
     pub resources: Option<ResourcesCapability>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompts: Option<PromptsCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<HashMap<String, JsonValue>>,
+    #[serde(flatten)]
+    pub additional: HashMap<String, JsonValue>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -139,15 +209,73 @@ pub struct PromptsCapability {
 pub struct ServerInfo {
     pub name: String,
     pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub websiteUrl: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<JsonValue>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoverResult {
+    pub supportedVersions: Vec<String>,
+    pub capabilities: ServerCapabilities,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+    #[serde(default = "complete_result_type")]
+    pub resultType: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttlMs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cacheScope: Option<String>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
+}
+
+impl DiscoverResult {
+    pub fn server_info(&self) -> Option<ServerInfo> {
+        self.meta
+            .as_ref()
+            .and_then(|meta| meta.get("io.modelcontextprotocol/serverInfo"))
+            .and_then(|value| serde_json::from_value(value.clone()).ok())
+    }
 }
 
 /// Tool definition
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tool {
     pub name: String,
-    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inputSchema: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outputSchema: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<JsonValue>>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
+}
+
+impl Tool {
+    pub fn display_name(&self) -> &str {
+        self.title
+            .as_deref()
+            .or_else(|| {
+                self.annotations
+                    .as_ref()
+                    .and_then(|annotations| annotations.get("title"))
+                    .and_then(JsonValue::as_str)
+            })
+            .unwrap_or(&self.name)
+    }
 }
 
 /// Tool call parameters
@@ -161,30 +289,39 @@ pub struct CallToolParams {
 /// Tool call result
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CallToolResult {
+    #[serde(default = "complete_result_type")]
+    pub resultType: String,
+    #[serde(default)]
     pub content: Vec<ToolContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub isError: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub structuredContent: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inputRequests: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requestState: Option<String>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
-pub enum ToolContent {
-    #[serde(rename = "text")]
-    Text { text: String },
-    #[serde(rename = "image")]
-    Image { data: String, mimeType: String },
-    #[serde(rename = "resource")]
-    Resource {
-        uri: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        mimeType: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        text: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        blob: Option<String>,
-    },
+fn complete_result_type() -> String {
+    "complete".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
+pub struct ToolContent(pub JsonValue);
+
+impl ToolContent {
+    #[cfg(test)]
+    pub fn content_type(&self) -> Option<&str> {
+        self.0.get("type").and_then(JsonValue::as_str)
+    }
+
+    pub fn as_value(&self) -> &JsonValue {
+        &self.0
+    }
 }
 
 /// Resource definition
@@ -286,4 +423,72 @@ pub struct ResourcesListResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PromptsListResponse {
     pub prompts: Vec<Prompt>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn modern_context() -> McpProtocolContext {
+        McpProtocolContext {
+            era: McpProtocolEra::Modern,
+            version: MCP_MODERN_PROTOCOL_VERSION.to_string(),
+            client_capabilities: ClientCapabilities::default(),
+            server_capabilities: ServerCapabilities::default(),
+            client_info: ClientInfo {
+                name: "uxc".to_string(),
+                version: "1.0.0".to_string(),
+                title: None,
+                description: None,
+                websiteUrl: None,
+                icons: None,
+            },
+            server_info: None,
+        }
+    }
+
+    #[test]
+    fn modern_request_params_add_required_metadata_and_preserve_existing_meta() {
+        let params = modern_context()
+            .modern_request_params(Some(json!({
+                "name": "ping",
+                "_meta": {
+                    "progressToken": "token-1",
+                    "com.example/custom": true
+                }
+            })))
+            .unwrap();
+
+        assert_eq!(params["name"], "ping");
+        assert_eq!(params["_meta"]["progressToken"], "token-1");
+        assert_eq!(params["_meta"]["com.example/custom"], true);
+        assert_eq!(
+            params["_meta"]["io.modelcontextprotocol/protocolVersion"],
+            MCP_MODERN_PROTOCOL_VERSION
+        );
+        assert_eq!(
+            params["_meta"]["io.modelcontextprotocol/clientCapabilities"],
+            json!({})
+        );
+        assert_eq!(
+            params["_meta"]["io.modelcontextprotocol/clientInfo"]["name"],
+            "uxc"
+        );
+    }
+
+    #[test]
+    fn legacy_tool_result_defaults_to_complete_and_preserves_unknown_content() {
+        let result: CallToolResult = serde_json::from_value(json!({
+            "content": [{
+                "type": "future-content",
+                "nested": {"value": 1}
+            }]
+        }))
+        .unwrap();
+
+        assert_eq!(result.resultType, "complete");
+        assert_eq!(result.content[0].content_type(), Some("future-content"));
+        assert_eq!(result.content[0].as_value()["nested"]["value"], 1);
+    }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8823,8 +8823,8 @@ fn live_stdio_service_summary(client: &adapters::mcp::McpStdioClient) -> Option<
 fn operation_from_mcp_tool(tool: &adapters::mcp::types::Tool) -> Operation {
     Operation {
         operation_id: tool.name.clone(),
-        display_name: tool.name.clone(),
-        description: Some(tool.description.clone()),
+        display_name: tool.display_name().to_string(),
+        description: tool.description.clone(),
         parameters: tool
             .inputSchema
             .as_ref()
@@ -8837,8 +8837,8 @@ fn operation_from_mcp_tool(tool: &adapters::mcp::types::Tool) -> Operation {
 fn operation_detail_from_mcp_tool(tool: &adapters::mcp::types::Tool) -> adapters::OperationDetail {
     adapters::OperationDetail {
         operation_id: tool.name.clone(),
-        display_name: tool.name.clone(),
-        description: Some(tool.description.clone()),
+        display_name: tool.display_name().to_string(),
+        description: tool.description.clone(),
         parameters: tool
             .inputSchema
             .as_ref()

--- a/tests/daemon_reuse_test.rs
+++ b/tests/daemon_reuse_test.rs
@@ -1117,7 +1117,10 @@ for line in sys.stdin:
         serde_json::from_slice(&cold.stdout).expect("cold stdout should be valid JSON");
     assert_eq!(cold_json["ok"], true);
     assert_eq!(cold_json["data"]["structuredContent"]["count"], 7);
-    assert_eq!(cold_json["data"]["structuredContent"]["starts"], 1);
+    // A legacy stdio endpoint is first probed with server/discover, then
+    // restarted before initialize so a late probe response cannot contaminate
+    // the legacy session.
+    assert_eq!(cold_json["data"]["structuredContent"]["starts"], 2);
 
     let warm = uxc_command_with_home(temp_home.path())
         .arg(&endpoint)
@@ -1136,7 +1139,7 @@ for line in sys.stdin:
         serde_json::from_slice(&warm.stdout).expect("warm stdout should be valid JSON");
     assert_eq!(warm_json["ok"], true);
     assert_eq!(warm_json["data"]["structuredContent"]["count"], 9);
-    assert_eq!(warm_json["data"]["structuredContent"]["starts"], 1);
+    assert_eq!(warm_json["data"]["structuredContent"]["starts"], 2);
     assert_eq!(warm_json["meta"]["daemon_session_reused"], true);
 
     daemon_stop_best_effort_with_home(temp_home.path());


### PR DESCRIPTION
## What

- add MCP protocol era/context models for `2026-07-28` and legacy `2024-11-05`
- probe stdio servers with `server/discover`, use stateless modern requests, and safely restart before legacy initialize fallback
- inject required modern request `_meta` on every stdio request
- preserve optional/unknown tool metadata and content blocks
- normalize `resultType` to `complete` for legacy results and expose it in JSON output
- report the negotiated stdio protocol version/era in cached schema metadata

## Why

MCP `2026-07-28` removes the initialize lifecycle and requires per-request protocol metadata. UXC needs dual-era stdio support without regressing existing legacy servers or allowing late probe responses to contaminate initialization.

## How

- modern stdio starts with a bounded `server/discover` request
- successful discovery selects `2026-07-28` and skips initialize/initialized
- failed or unrecognized discovery terminates the probe process and spawns a fresh legacy process
- request construction is centralized through the negotiated protocol context
- content blocks use JSON passthrough so future MCP content types remain lossless

## Testing

- `cargo +1.91.1 fmt -- --check`
- `cargo +1.91.1 clippy --lib -- -D warnings`
- `cargo +1.91.1 test adapters::mcp --lib -- --test-threads=1` (163 passed)
- `cargo +1.91.1 test --locked -- --test-threads=1` (passed)

Note: repository `stable` toolchain installation is currently missing a usable `rustc`, so verification used the installed Rust `1.91.1` toolchain. `clippy --all-targets -D warnings` also surfaces pre-existing warnings in unrelated integration tests; the changed library passes strict clippy.

This is PR 1 of the reviewed MCP 2026 compatibility plan. HTTP transport, MRTR flags/cache/pagination, subscriptions, and OAuth/conformance follow in later sequential PRs.
