### PR TITLE
feat(mcp): add results pagination cache and MRTR

### DIFF
--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -303,6 +303,7 @@ impl McpStdioClient {
             .await
     }
 
+    #[allow(dead_code)]
     pub async fn list_tools_catalog(&mut self) -> Result<ToolsCatalog> {
         self.list_tools_catalog_with_timeout(McpStdioTransport::default_request_timeout())
             .await

--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -7,10 +7,9 @@ use super::types::*;
 use super::McpExecutionOptions;
 use crate::error::{structured_error_from_anyhow, StructuredError};
 use anyhow::{bail, Context, Result};
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -549,58 +548,19 @@ impl McpStdioClient {
 
     async fn list_catalog<T, R>(&mut self, method: &str) -> Result<McpListCatalog<T>>
     where
-        R: DeserializeOwned + McpListPage<Item = T>,
+        R: serde::de::DeserializeOwned + McpListPage<Item = T>,
     {
-        let mut items = Vec::new();
-        let mut metadata = McpListCatalogMetadata::default();
-        let mut next_cursor = None;
-        let mut seen_cursors = HashSet::new();
-
+        let mut paginator = McpCatalogPaginator::new(method);
         loop {
-            if metadata.pageCount >= MCP_LIST_MAX_PAGES {
-                bail!(
-                    "MCP {} pagination exceeded maximum of {} pages",
-                    method,
-                    MCP_LIST_MAX_PAGES
-                );
-            }
-
-            let params = next_cursor
-                .as_ref()
-                .map(|cursor| json!({ "cursor": cursor }));
+            let params = paginator.next_request_params()?;
             let result = self
                 .send_request(method, params)
                 .await
                 .with_context(|| format!("Failed to fetch {}", method))?;
-            let response: R = serde_json::from_value(result)
-                .with_context(|| format!("Failed to parse {} response", method))?;
-            let (page_items, page_metadata) = response.into_parts();
-            metadata.absorb_page(&page_metadata, page_items.len());
-            if metadata.itemCount > MCP_LIST_MAX_ITEMS {
-                bail!(
-                    "MCP {} pagination exceeded maximum of {} items",
-                    method,
-                    MCP_LIST_MAX_ITEMS
-                );
-            }
-            items.extend(page_items);
-
-            match page_metadata.nextCursor {
-                Some(cursor) => {
-                    if !seen_cursors.insert(cursor.clone()) {
-                        bail!(
-                            "MCP {} pagination detected cursor cycle at '{}'",
-                            method,
-                            cursor
-                        );
-                    }
-                    next_cursor = Some(cursor);
-                }
-                None => break,
+            if !paginator.absorb_response::<R>(result)? {
+                return Ok(paginator.finish());
             }
         }
-
-        Ok(McpListCatalog { items, metadata })
     }
 
     async fn list_catalog_with_timeout<T, R>(
@@ -609,58 +569,19 @@ impl McpStdioClient {
         timeout: Duration,
     ) -> Result<McpListCatalog<T>>
     where
-        R: DeserializeOwned + McpListPage<Item = T>,
+        R: serde::de::DeserializeOwned + McpListPage<Item = T>,
     {
-        let mut items = Vec::new();
-        let mut metadata = McpListCatalogMetadata::default();
-        let mut next_cursor = None;
-        let mut seen_cursors = HashSet::new();
-
+        let mut paginator = McpCatalogPaginator::new(method);
         loop {
-            if metadata.pageCount >= MCP_LIST_MAX_PAGES {
-                bail!(
-                    "MCP {} pagination exceeded maximum of {} pages",
-                    method,
-                    MCP_LIST_MAX_PAGES
-                );
-            }
-
-            let params = next_cursor
-                .as_ref()
-                .map(|cursor| json!({ "cursor": cursor }));
+            let params = paginator.next_request_params()?;
             let result = self
                 .send_request_with_timeout(method, params, timeout)
                 .await
                 .with_context(|| format!("Failed to fetch {}", method))?;
-            let response: R = serde_json::from_value(result)
-                .with_context(|| format!("Failed to parse {} response", method))?;
-            let (page_items, page_metadata) = response.into_parts();
-            metadata.absorb_page(&page_metadata, page_items.len());
-            if metadata.itemCount > MCP_LIST_MAX_ITEMS {
-                bail!(
-                    "MCP {} pagination exceeded maximum of {} items",
-                    method,
-                    MCP_LIST_MAX_ITEMS
-                );
-            }
-            items.extend(page_items);
-
-            match page_metadata.nextCursor {
-                Some(cursor) => {
-                    if !seen_cursors.insert(cursor.clone()) {
-                        bail!(
-                            "MCP {} pagination detected cursor cycle at '{}'",
-                            method,
-                            cursor
-                        );
-                    }
-                    next_cursor = Some(cursor);
-                }
-                None => break,
+            if !paginator.absorb_response::<R>(result)? {
+                return Ok(paginator.finish());
             }
         }
-
-        Ok(McpListCatalog { items, metadata })
     }
 }
 

--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -7,9 +7,10 @@ use super::types::*;
 use super::McpExecutionOptions;
 use crate::error::{structured_error_from_anyhow, StructuredError};
 use anyhow::{bail, Context, Result};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -302,31 +303,26 @@ impl McpStdioClient {
             .await
     }
 
+    pub async fn list_tools_catalog(&mut self) -> Result<ToolsCatalog> {
+        self.list_tools_catalog_with_timeout(McpStdioTransport::default_request_timeout())
+            .await
+    }
+
     pub async fn list_tools_with_timeout(&mut self, timeout: Duration) -> Result<Vec<Tool>> {
+        Ok(self.list_tools_catalog_with_timeout(timeout).await?.items)
+    }
+
+    pub async fn list_tools_catalog_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<ToolsCatalog> {
         if !self.supports_tools() {
             bail!("Server does not support tools");
         }
 
-        let result = self
-            .send_request_with_timeout("tools/list", None, timeout)
+        self.list_catalog_with_timeout::<Tool, ToolsListResponse>("tools/list", timeout)
             .await
-            .context("Failed to list tools")?;
-
-        // Parse the response - tools are in result.tools
-        let tools_value = result
-            .get("tools")
-            .context("Response missing 'tools' field")?
-            .as_array()
-            .context("'tools' is not an array")?;
-
-        let mut tools = Vec::new();
-        for tool_value in tools_value {
-            let tool: Tool =
-                serde_json::from_value(tool_value.clone()).context("Failed to parse tool")?;
-            tools.push(tool);
-        }
-
-        Ok(tools)
+            .context("Failed to list tools")
     }
 
     /// Call a tool
@@ -407,29 +403,17 @@ impl McpStdioClient {
     /// List available resources
     #[allow(dead_code)]
     pub async fn list_resources(&mut self) -> Result<Vec<Resource>> {
+        Ok(self.list_resources_catalog().await?.items)
+    }
+
+    pub async fn list_resources_catalog(&mut self) -> Result<ResourcesCatalog> {
         if !self.supports_resources() {
             bail!("Server does not support resources");
         }
 
-        let result = self
-            .send_request("resources/list", None)
+        self.list_catalog::<Resource, ResourcesListResponse>("resources/list")
             .await
-            .context("Failed to list resources")?;
-
-        let resources_value = result
-            .get("resources")
-            .context("Response missing 'resources' field")?
-            .as_array()
-            .context("'resources' is not an array")?;
-
-        let mut resources = Vec::new();
-        for resource_value in resources_value {
-            let resource: Resource = serde_json::from_value(resource_value.clone())
-                .context("Failed to parse resource")?;
-            resources.push(resource);
-        }
-
-        Ok(resources)
+            .context("Failed to list resources")
     }
 
     /// Read a resource
@@ -485,29 +469,17 @@ impl McpStdioClient {
     /// List available prompts
     #[allow(dead_code)]
     pub async fn list_prompts(&mut self) -> Result<Vec<Prompt>> {
+        Ok(self.list_prompts_catalog().await?.items)
+    }
+
+    pub async fn list_prompts_catalog(&mut self) -> Result<PromptsCatalog> {
         if !self.supports_prompts() {
             bail!("Server does not support prompts");
         }
 
-        let result = self
-            .send_request("prompts/list", None)
+        self.list_catalog::<Prompt, PromptsListResponse>("prompts/list")
             .await
-            .context("Failed to list prompts")?;
-
-        let prompts_value = result
-            .get("prompts")
-            .context("Response missing 'prompts' field")?
-            .as_array()
-            .context("'prompts' is not an array")?;
-
-        let mut prompts = Vec::new();
-        for prompt_value in prompts_value {
-            let prompt: Prompt =
-                serde_json::from_value(prompt_value.clone()).context("Failed to parse prompt")?;
-            prompts.push(prompt);
-        }
-
-        Ok(prompts)
+            .context("Failed to list prompts")
     }
 
     /// Get a prompt
@@ -572,6 +544,122 @@ impl McpStdioClient {
         self.transport
             .send_request_with_timeout(method, params, timeout)
             .await
+    }
+
+    async fn list_catalog<T, R>(&mut self, method: &str) -> Result<McpListCatalog<T>>
+    where
+        R: DeserializeOwned + McpListPage<Item = T>,
+    {
+        let mut items = Vec::new();
+        let mut metadata = McpListCatalogMetadata::default();
+        let mut next_cursor = None;
+        let mut seen_cursors = HashSet::new();
+
+        loop {
+            if metadata.pageCount >= MCP_LIST_MAX_PAGES {
+                bail!(
+                    "MCP {} pagination exceeded maximum of {} pages",
+                    method,
+                    MCP_LIST_MAX_PAGES
+                );
+            }
+
+            let params = next_cursor
+                .as_ref()
+                .map(|cursor| json!({ "cursor": cursor }));
+            let result = self
+                .send_request(method, params)
+                .await
+                .with_context(|| format!("Failed to fetch {}", method))?;
+            let response: R = serde_json::from_value(result)
+                .with_context(|| format!("Failed to parse {} response", method))?;
+            let (page_items, page_metadata) = response.into_parts();
+            metadata.absorb_page(&page_metadata, page_items.len());
+            if metadata.itemCount > MCP_LIST_MAX_ITEMS {
+                bail!(
+                    "MCP {} pagination exceeded maximum of {} items",
+                    method,
+                    MCP_LIST_MAX_ITEMS
+                );
+            }
+            items.extend(page_items);
+
+            match page_metadata.nextCursor {
+                Some(cursor) => {
+                    if !seen_cursors.insert(cursor.clone()) {
+                        bail!(
+                            "MCP {} pagination detected cursor cycle at '{}'",
+                            method,
+                            cursor
+                        );
+                    }
+                    next_cursor = Some(cursor);
+                }
+                None => break,
+            }
+        }
+
+        Ok(McpListCatalog { items, metadata })
+    }
+
+    async fn list_catalog_with_timeout<T, R>(
+        &mut self,
+        method: &str,
+        timeout: Duration,
+    ) -> Result<McpListCatalog<T>>
+    where
+        R: DeserializeOwned + McpListPage<Item = T>,
+    {
+        let mut items = Vec::new();
+        let mut metadata = McpListCatalogMetadata::default();
+        let mut next_cursor = None;
+        let mut seen_cursors = HashSet::new();
+
+        loop {
+            if metadata.pageCount >= MCP_LIST_MAX_PAGES {
+                bail!(
+                    "MCP {} pagination exceeded maximum of {} pages",
+                    method,
+                    MCP_LIST_MAX_PAGES
+                );
+            }
+
+            let params = next_cursor
+                .as_ref()
+                .map(|cursor| json!({ "cursor": cursor }));
+            let result = self
+                .send_request_with_timeout(method, params, timeout)
+                .await
+                .with_context(|| format!("Failed to fetch {}", method))?;
+            let response: R = serde_json::from_value(result)
+                .with_context(|| format!("Failed to parse {} response", method))?;
+            let (page_items, page_metadata) = response.into_parts();
+            metadata.absorb_page(&page_metadata, page_items.len());
+            if metadata.itemCount > MCP_LIST_MAX_ITEMS {
+                bail!(
+                    "MCP {} pagination exceeded maximum of {} items",
+                    method,
+                    MCP_LIST_MAX_ITEMS
+                );
+            }
+            items.extend(page_items);
+
+            match page_metadata.nextCursor {
+                Some(cursor) => {
+                    if !seen_cursors.insert(cursor.clone()) {
+                        bail!(
+                            "MCP {} pagination detected cursor cycle at '{}'",
+                            method,
+                            cursor
+                        );
+                    }
+                    next_cursor = Some(cursor);
+                }
+                None => break,
+            }
+        }
+
+        Ok(McpListCatalog { items, metadata })
     }
 }
 
@@ -765,6 +853,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_tools_catalog_paginates_and_aggregates_metadata() {
+        let script = r#"
+            read line
+            echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"test","version":"1.0"}}}'
+            read initialized
+            echo "$initialized" | grep -q '"method":"notifications/initialized"' || exit 29
+            read page1
+            echo "$page1" | grep -q '"method":"tools/list"' || exit 30
+            echo '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"tool-1"},{"name":"tool-2"}],"nextCursor":"cursor-2","ttlMs":30,"cacheScope":"public"}}'
+            read page2
+            echo "$page2" | grep -q '"cursor":"cursor-2"' || exit 31
+            echo '{"jsonrpc":"2.0","id":3,"result":{"tools":[{"name":"tool-3"}],"ttlMs":10,"cacheScope":"private"}}'
+        "#;
+
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
+
+        let catalog = client.list_tools_catalog().await.unwrap();
+        assert_eq!(catalog.items.len(), 3);
+        assert_eq!(catalog.items[0].name, "tool-1");
+        assert_eq!(catalog.items[2].name, "tool-3");
+        assert_eq!(catalog.metadata.ttlMs, Some(10));
+        assert_eq!(catalog.metadata.cacheScope.as_deref(), Some("private"));
+        assert_eq!(catalog.metadata.pageCount, 2);
+        assert_eq!(catalog.metadata.itemCount, 3);
+    }
+
+    #[tokio::test]
+    async fn list_tools_catalog_enforces_page_limit() {
+        let script = r#"
+            read line
+            echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"test","version":"1.0"}}}'
+            read initialized
+            echo "$initialized" | grep -q '"method":"notifications/initialized"' || exit 59
+            count=0
+            while read request; do
+                count=$((count + 1))
+                response_id=$((count + 1))
+                if [ "$count" -lt 100 ]; then
+                    next=",\"nextCursor\":\"cursor-$((count + 1))\""
+                else
+                    next=",\"nextCursor\":\"cursor-overflow\""
+                fi
+                echo "{\"jsonrpc\":\"2.0\",\"id\":$response_id,\"result\":{\"tools\":[{\"name\":\"tool-$count\"}]$next}}"
+            done
+        "#;
+
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
+
+        let err = client.list_tools_catalog().await.unwrap_err();
+        assert!(format!("{err:#}").contains("maximum of 100 pages"));
+    }
+
+    #[tokio::test]
     async fn call_tool_executes_tool_with_arguments() {
         let script = r#"
             read line
@@ -851,6 +996,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_resources_paginates() {
+        let script = r#"
+            read line
+            echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"resources":{}},"serverInfo":{"name":"test","version":"1.0"}}}'
+            read initialized
+            echo "$initialized" | grep -q '"method":"notifications/initialized"' || exit 39
+            read page1
+            echo "$page1" | grep -q '"method":"resources/list"' || exit 40
+            echo '{"jsonrpc":"2.0","id":2,"result":{"resources":[{"name":"r1","uri":"test://r1","description":"R1"}],"nextCursor":"cursor-2"}}'
+            read page2
+            echo "$page2" | grep -q '"cursor":"cursor-2"' || exit 41
+            echo '{"jsonrpc":"2.0","id":3,"result":{"resources":[{"name":"r2","uri":"test://r2","description":"R2"}]}}'
+        "#;
+
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
+
+        let resources = client.list_resources().await.unwrap();
+        assert_eq!(resources.len(), 2);
+        assert_eq!(resources[1].uri, "test://r2");
+    }
+
+    #[tokio::test]
     async fn read_resource_returns_resource_contents() {
         let script = r#"
             read line
@@ -903,6 +1072,29 @@ mod tests {
         let prompts = client.list_prompts().await.unwrap();
         assert_eq!(prompts.len(), 1);
         assert_eq!(prompts[0].name, "test_prompt");
+    }
+
+    #[tokio::test]
+    async fn list_prompts_detects_cursor_cycle() {
+        let script = r#"
+            read line
+            echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"prompts":{}},"serverInfo":{"name":"test","version":"1.0"}}}'
+            read initialized
+            echo "$initialized" | grep -q '"method":"notifications/initialized"' || exit 49
+            read page1
+            echo "$page1" | grep -q '"method":"prompts/list"' || exit 50
+            echo '{"jsonrpc":"2.0","id":2,"result":{"prompts":[{"name":"p1","description":"P1"}],"nextCursor":"loop"}}'
+            read page2
+            echo "$page2" | grep -q '"cursor":"loop"' || exit 51
+            echo '{"jsonrpc":"2.0","id":3,"result":{"prompts":[{"name":"p2","description":"P2"}],"nextCursor":"loop"}}'
+        "#;
+
+        let mut client = McpStdioClient::connect("sh", &["-c".to_string(), script.to_string()])
+            .await
+            .unwrap();
+
+        let err = client.list_prompts().await.unwrap_err();
+        assert!(format!("{err:#}").contains("cursor cycle"));
     }
 
     #[tokio::test]

--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -4,6 +4,7 @@ use super::transport::{
     DefaultStdioProcessExecutor, McpStdioTransport, StdioProcessExecutor, StdioSpawnOptions,
 };
 use super::types::*;
+use super::McpExecutionOptions;
 use crate::error::{structured_error_from_anyhow, StructuredError};
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -349,17 +350,51 @@ impl McpStdioClient {
         arguments: Option<JsonValue>,
         timeout: Duration,
     ) -> Result<CallToolResult> {
+        self.call_tool_with_options_and_timeout(
+            name,
+            arguments,
+            &McpExecutionOptions::default(),
+            timeout,
+        )
+        .await
+    }
+
+    pub async fn call_tool_with_options_and_timeout(
+        &mut self,
+        name: &str,
+        arguments: Option<JsonValue>,
+        options: &McpExecutionOptions,
+        timeout: Duration,
+    ) -> Result<CallToolResult> {
         if !self.supports_tools() {
             bail!("Server does not support tools");
         }
 
-        let params = CallToolParams {
-            name: name.to_string(),
-            arguments,
-        };
+        let mut params = serde_json::Map::new();
+        params.insert("name".to_string(), JsonValue::String(name.to_string()));
+        params.insert(
+            "arguments".to_string(),
+            arguments.unwrap_or_else(|| json!({})),
+        );
+        if let Some(continuation) = &options.continuation {
+            let continuation = continuation
+                .as_object()
+                .context("MCP continuation must be a JSON object")?;
+            for (key, value) in continuation {
+                if matches!(key.as_str(), "name" | "arguments" | "_meta") {
+                    bail!("MCP continuation must not override '{}'", key);
+                }
+                params.insert(key.clone(), value.clone());
+            }
+        }
 
         let result = self
-            .send_request_with_timeout("tools/call", Some(serde_json::to_value(params)?), timeout)
+            .send_request_with_timeout_and_capabilities(
+                "tools/call",
+                Some(JsonValue::Object(params)),
+                options.capabilities.as_ref(),
+                timeout,
+            )
             .await
             .context(format!("Failed to call tool '{}'", name))?;
 
@@ -516,8 +551,22 @@ impl McpStdioClient {
         params: Option<JsonValue>,
         timeout: Duration,
     ) -> Result<JsonValue> {
+        self.send_request_with_timeout_and_capabilities(method, params, None, timeout)
+            .await
+    }
+
+    async fn send_request_with_timeout_and_capabilities(
+        &mut self,
+        method: &str,
+        params: Option<JsonValue>,
+        capabilities: Option<&JsonValue>,
+        timeout: Duration,
+    ) -> Result<JsonValue> {
         let params = match self.protocol_context.era {
-            McpProtocolEra::Modern => Some(self.protocol_context.modern_request_params(params)?),
+            McpProtocolEra::Modern => Some(
+                self.protocol_context
+                    .modern_request_params_with_capabilities(params, capabilities)?,
+            ),
             McpProtocolEra::Legacy => params,
         };
         self.transport

--- a/src/adapters/mcp/http_transport.rs
+++ b/src/adapters/mcp/http_transport.rs
@@ -15,9 +15,8 @@ use anyhow::{bail, Context, Result};
 use base64::Engine;
 use reqwest::header::{HeaderName, HeaderValue};
 use reqwest::Client;
-use serde::de::DeserializeOwned;
 use serde_json::Value as JsonValue;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -1810,58 +1809,19 @@ impl McpHttpTransport {
 
     async fn list_catalog<T, R>(&self, method: &str) -> Result<McpListCatalog<T>>
     where
-        R: DeserializeOwned + McpListPage<Item = T>,
+        R: serde::de::DeserializeOwned + McpListPage<Item = T>,
     {
-        let mut items = Vec::new();
-        let mut metadata = McpListCatalogMetadata::default();
-        let mut next_cursor = None;
-        let mut seen_cursors = HashSet::new();
-
+        let mut paginator = McpCatalogPaginator::new(method);
         loop {
-            if metadata.pageCount >= MCP_LIST_MAX_PAGES {
-                bail!(
-                    "MCP {} pagination exceeded maximum of {} pages",
-                    method,
-                    MCP_LIST_MAX_PAGES
-                );
-            }
-
-            let params = next_cursor
-                .as_ref()
-                .map(|cursor| serde_json::json!({ "cursor": cursor }));
+            let params = paginator.next_request_params()?;
             let result = self
                 .send_request(method, params)
                 .await
                 .with_context(|| format!("Failed to fetch {}", method))?;
-            let response: R = serde_json::from_value(result)
-                .with_context(|| format!("Failed to parse {} response", method))?;
-            let (page_items, page_metadata) = response.into_parts();
-            metadata.absorb_page(&page_metadata, page_items.len());
-            if metadata.itemCount > MCP_LIST_MAX_ITEMS {
-                bail!(
-                    "MCP {} pagination exceeded maximum of {} items",
-                    method,
-                    MCP_LIST_MAX_ITEMS
-                );
-            }
-            items.extend(page_items);
-
-            match page_metadata.nextCursor {
-                Some(cursor) => {
-                    if !seen_cursors.insert(cursor.clone()) {
-                        bail!(
-                            "MCP {} pagination detected cursor cycle at '{}'",
-                            method,
-                            cursor
-                        );
-                    }
-                    next_cursor = Some(cursor);
-                }
-                None => break,
+            if !paginator.absorb_response::<R>(result)? {
+                return Ok(paginator.finish());
             }
         }
-
-        Ok(McpListCatalog { items, metadata })
     }
 
     async fn open_event_stream(&self) -> Result<reqwest::Response> {
@@ -2406,58 +2366,19 @@ impl LegacySseTransport {
 
     async fn list_catalog<T, R>(&self, method: &str) -> Result<McpListCatalog<T>>
     where
-        R: DeserializeOwned + McpListPage<Item = T>,
+        R: serde::de::DeserializeOwned + McpListPage<Item = T>,
     {
-        let mut items = Vec::new();
-        let mut metadata = McpListCatalogMetadata::default();
-        let mut next_cursor = None;
-        let mut seen_cursors = HashSet::new();
-
+        let mut paginator = McpCatalogPaginator::new(method);
         loop {
-            if metadata.pageCount >= MCP_LIST_MAX_PAGES {
-                bail!(
-                    "MCP {} pagination exceeded maximum of {} pages",
-                    method,
-                    MCP_LIST_MAX_PAGES
-                );
-            }
-
-            let params = next_cursor
-                .as_ref()
-                .map(|cursor| serde_json::json!({ "cursor": cursor }));
+            let params = paginator.next_request_params()?;
             let result = self
                 .send_request(method, params)
                 .await
                 .with_context(|| format!("Failed to fetch {}", method))?;
-            let response: R = serde_json::from_value(result)
-                .with_context(|| format!("Failed to parse {} response", method))?;
-            let (page_items, page_metadata) = response.into_parts();
-            metadata.absorb_page(&page_metadata, page_items.len());
-            if metadata.itemCount > MCP_LIST_MAX_ITEMS {
-                bail!(
-                    "MCP {} pagination exceeded maximum of {} items",
-                    method,
-                    MCP_LIST_MAX_ITEMS
-                );
-            }
-            items.extend(page_items);
-
-            match page_metadata.nextCursor {
-                Some(cursor) => {
-                    if !seen_cursors.insert(cursor.clone()) {
-                        bail!(
-                            "MCP {} pagination detected cursor cycle at '{}'",
-                            method,
-                            cursor
-                        );
-                    }
-                    next_cursor = Some(cursor);
-                }
-                None => break,
+            if !paginator.absorb_response::<R>(result)? {
+                return Ok(paginator.finish());
             }
         }
-
-        Ok(McpListCatalog { items, metadata })
     }
 
     async fn run_sse_reader(

--- a/src/adapters/mcp/http_transport.rs
+++ b/src/adapters/mcp/http_transport.rs
@@ -3200,6 +3200,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn modern_tool_call_keeps_mrtr_controls_out_of_arguments() {
+        let mut server = mockito::Server::new_async().await;
+        let list = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"execute","inputSchema":{"type":"object"}}]}}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let call = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "tools/call",
+                "params": {
+                    "name": "execute",
+                    "arguments": {"query": "rust"},
+                    "inputResponses": {
+                        "request-1": {"action": "accept"}
+                    },
+                    "requestState": "opaque-state",
+                    "_meta": {
+                        "io.modelcontextprotocol/clientCapabilities": {
+                            "elicitation": {}
+                        }
+                    }
+                }
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"jsonrpc":"2.0","id":2,"result":{"resultType":"input_required","inputRequests":{"request-2":{"method":"elicitation/create"}},"requestState":"next-opaque"}}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let transport = McpHttpTransport::with_auth_timeout_and_era(
+            server.url(),
+            None,
+            Duration::from_secs(5),
+            McpProtocolEra::Modern,
+        )
+        .unwrap();
+        let result = transport
+            .call_tool_with_options(
+                "execute",
+                Some(json!({"query": "rust"})),
+                &McpExecutionOptions {
+                    capabilities: Some(json!({"elicitation": {}})),
+                    continuation: Some(json!({
+                        "inputResponses": {
+                            "request-1": {"action": "accept"}
+                        },
+                        "requestState": "opaque-state"
+                    })),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.resultType, "input_required");
+        assert_eq!(result.requestState.as_deref(), Some("next-opaque"));
+        list.assert_async().await;
+        call.assert_async().await;
+    }
+
+    #[tokio::test]
     async fn modern_tool_call_sends_validated_custom_header() {
         let mut server = mockito::Server::new_async().await;
         let list = server

--- a/src/adapters/mcp/http_transport.rs
+++ b/src/adapters/mcp/http_transport.rs
@@ -15,8 +15,9 @@ use anyhow::{bail, Context, Result};
 use base64::Engine;
 use reqwest::header::{HeaderName, HeaderValue};
 use reqwest::Client;
+use serde::de::DeserializeOwned;
 use serde_json::Value as JsonValue;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -1411,18 +1412,20 @@ impl McpHttpTransport {
 
     /// List available tools
     pub async fn list_tools(&self) -> Result<Vec<Tool>> {
-        let result = self.send_request("tools/list", None).await?;
+        Ok(self.list_tools_catalog().await?.items)
+    }
 
-        let response: ToolsListResponse =
-            serde_json::from_value(result).context("Failed to parse tools/list response")?;
-
+    pub async fn list_tools_catalog(&self) -> Result<ToolsCatalog> {
+        let mut catalog = self
+            .list_catalog::<Tool, ToolsListResponse>("tools/list")
+            .await?;
         if self.protocol_context.era == McpProtocolEra::Legacy {
-            return Ok(response.tools);
+            return Ok(catalog);
         }
 
         let mut headers_by_tool = HashMap::new();
-        let mut valid_tools = Vec::with_capacity(response.tools.len());
-        for tool in response.tools {
+        let mut valid_tools = Vec::with_capacity(catalog.items.len());
+        for tool in catalog.items {
             match Self::tool_header_mappings(&tool) {
                 Ok(mappings) => {
                     headers_by_tool.insert(tool.name.clone(), mappings);
@@ -1439,7 +1442,9 @@ impl McpHttpTransport {
         }
         *self.tool_headers.lock().await = headers_by_tool;
         *self.tool_catalog_loaded.lock().await = true;
-        Ok(valid_tools)
+        catalog.metadata.itemCount = valid_tools.len();
+        catalog.items = valid_tools;
+        Ok(catalog)
     }
 
     /// Call a tool
@@ -1678,12 +1683,12 @@ impl McpHttpTransport {
 
     /// List available resources
     pub async fn list_resources(&self) -> Result<Vec<Resource>> {
-        let result = self.send_request("resources/list", None).await?;
+        Ok(self.list_resources_catalog().await?.items)
+    }
 
-        let response: ResourcesListResponse =
-            serde_json::from_value(result).context("Failed to parse resources/list response")?;
-
-        Ok(response.resources)
+    pub async fn list_resources_catalog(&self) -> Result<ResourcesCatalog> {
+        self.list_catalog::<Resource, ResourcesListResponse>("resources/list")
+            .await
     }
 
     /// Read a resource
@@ -1746,12 +1751,12 @@ impl McpHttpTransport {
 
     /// List available prompts
     pub async fn list_prompts(&self) -> Result<Vec<Prompt>> {
-        let result = self.send_request("prompts/list", None).await?;
+        Ok(self.list_prompts_catalog().await?.items)
+    }
 
-        let response: PromptsListResponse =
-            serde_json::from_value(result).context("Failed to parse prompts/list response")?;
-
-        Ok(response.prompts)
+    pub async fn list_prompts_catalog(&self) -> Result<PromptsCatalog> {
+        self.list_catalog::<Prompt, PromptsListResponse>("prompts/list")
+            .await
     }
 
     /// Get a prompt
@@ -1801,6 +1806,62 @@ impl McpHttpTransport {
             Self::run_streamable_event_reader(response, notifications, stream_error).await;
         }));
         Ok(())
+    }
+
+    async fn list_catalog<T, R>(&self, method: &str) -> Result<McpListCatalog<T>>
+    where
+        R: DeserializeOwned + McpListPage<Item = T>,
+    {
+        let mut items = Vec::new();
+        let mut metadata = McpListCatalogMetadata::default();
+        let mut next_cursor = None;
+        let mut seen_cursors = HashSet::new();
+
+        loop {
+            if metadata.pageCount >= MCP_LIST_MAX_PAGES {
+                bail!(
+                    "MCP {} pagination exceeded maximum of {} pages",
+                    method,
+                    MCP_LIST_MAX_PAGES
+                );
+            }
+
+            let params = next_cursor
+                .as_ref()
+                .map(|cursor| serde_json::json!({ "cursor": cursor }));
+            let result = self
+                .send_request(method, params)
+                .await
+                .with_context(|| format!("Failed to fetch {}", method))?;
+            let response: R = serde_json::from_value(result)
+                .with_context(|| format!("Failed to parse {} response", method))?;
+            let (page_items, page_metadata) = response.into_parts();
+            metadata.absorb_page(&page_metadata, page_items.len());
+            if metadata.itemCount > MCP_LIST_MAX_ITEMS {
+                bail!(
+                    "MCP {} pagination exceeded maximum of {} items",
+                    method,
+                    MCP_LIST_MAX_ITEMS
+                );
+            }
+            items.extend(page_items);
+
+            match page_metadata.nextCursor {
+                Some(cursor) => {
+                    if !seen_cursors.insert(cursor.clone()) {
+                        bail!(
+                            "MCP {} pagination detected cursor cycle at '{}'",
+                            method,
+                            cursor
+                        );
+                    }
+                    next_cursor = Some(cursor);
+                }
+                None => break,
+            }
+        }
+
+        Ok(McpListCatalog { items, metadata })
     }
 
     async fn open_event_stream(&self) -> Result<reqwest::Response> {
@@ -2264,10 +2325,12 @@ impl LegacySseTransport {
     }
 
     async fn list_tools(&self) -> Result<Vec<Tool>> {
-        let result = self.send_request("tools/list", None).await?;
-        let response: ToolsListResponse =
-            serde_json::from_value(result).context("Failed to parse tools/list response")?;
-        Ok(response.tools)
+        Ok(self.list_tools_catalog().await?.items)
+    }
+
+    async fn list_tools_catalog(&self) -> Result<ToolsCatalog> {
+        self.list_catalog::<Tool, ToolsListResponse>("tools/list")
+            .await
     }
 
     async fn read_resource(&self, uri: &str) -> Result<ResourceContents> {
@@ -2321,6 +2384,80 @@ impl LegacySseTransport {
 
     async fn take_stream_error(&self) -> Option<String> {
         self.event_stream_error.lock().await.take()
+    }
+
+    async fn list_resources(&self) -> Result<Vec<Resource>> {
+        Ok(self.list_resources_catalog().await?.items)
+    }
+
+    async fn list_resources_catalog(&self) -> Result<ResourcesCatalog> {
+        self.list_catalog::<Resource, ResourcesListResponse>("resources/list")
+            .await
+    }
+
+    async fn list_prompts(&self) -> Result<Vec<Prompt>> {
+        Ok(self.list_prompts_catalog().await?.items)
+    }
+
+    async fn list_prompts_catalog(&self) -> Result<PromptsCatalog> {
+        self.list_catalog::<Prompt, PromptsListResponse>("prompts/list")
+            .await
+    }
+
+    async fn list_catalog<T, R>(&self, method: &str) -> Result<McpListCatalog<T>>
+    where
+        R: DeserializeOwned + McpListPage<Item = T>,
+    {
+        let mut items = Vec::new();
+        let mut metadata = McpListCatalogMetadata::default();
+        let mut next_cursor = None;
+        let mut seen_cursors = HashSet::new();
+
+        loop {
+            if metadata.pageCount >= MCP_LIST_MAX_PAGES {
+                bail!(
+                    "MCP {} pagination exceeded maximum of {} pages",
+                    method,
+                    MCP_LIST_MAX_PAGES
+                );
+            }
+
+            let params = next_cursor
+                .as_ref()
+                .map(|cursor| serde_json::json!({ "cursor": cursor }));
+            let result = self
+                .send_request(method, params)
+                .await
+                .with_context(|| format!("Failed to fetch {}", method))?;
+            let response: R = serde_json::from_value(result)
+                .with_context(|| format!("Failed to parse {} response", method))?;
+            let (page_items, page_metadata) = response.into_parts();
+            metadata.absorb_page(&page_metadata, page_items.len());
+            if metadata.itemCount > MCP_LIST_MAX_ITEMS {
+                bail!(
+                    "MCP {} pagination exceeded maximum of {} items",
+                    method,
+                    MCP_LIST_MAX_ITEMS
+                );
+            }
+            items.extend(page_items);
+
+            match page_metadata.nextCursor {
+                Some(cursor) => {
+                    if !seen_cursors.insert(cursor.clone()) {
+                        bail!(
+                            "MCP {} pagination detected cursor cycle at '{}'",
+                            method,
+                            cursor
+                        );
+                    }
+                    next_cursor = Some(cursor);
+                }
+                None => break,
+            }
+        }
+
+        Ok(McpListCatalog { items, metadata })
     }
 
     async fn run_sse_reader(
@@ -2588,6 +2725,13 @@ impl McpRemoteTransport {
         }
     }
 
+    pub async fn list_tools_catalog(&self) -> Result<ToolsCatalog> {
+        match self {
+            Self::Streamable(transport) => transport.list_tools_catalog().await,
+            Self::Legacy(transport) => transport.list_tools_catalog().await,
+        }
+    }
+
     pub async fn call_tool(
         &self,
         name: &str,
@@ -2640,6 +2784,20 @@ impl McpRemoteTransport {
         match self {
             Self::Streamable(transport) => transport.unsubscribe_resource(uri).await,
             Self::Legacy(transport) => transport.unsubscribe_resource(uri).await,
+        }
+    }
+
+    pub async fn list_resources_catalog(&self) -> Result<ResourcesCatalog> {
+        match self {
+            Self::Streamable(transport) => transport.list_resources_catalog().await,
+            Self::Legacy(transport) => transport.list_resources_catalog().await,
+        }
+    }
+
+    pub async fn list_prompts_catalog(&self) -> Result<PromptsCatalog> {
+        match self {
+            Self::Streamable(transport) => transport.list_prompts_catalog().await,
+            Self::Legacy(transport) => transport.list_prompts_catalog().await,
         }
     }
 
@@ -3777,6 +3935,71 @@ data: invalid json
     }
 
     #[tokio::test]
+    async fn list_tools_catalog_paginates_and_aggregates_metadata() {
+        let mut server = mockito::Server::new_async().await;
+
+        let page1 = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "id": 1,
+                "method": "tools/list"
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "jsonrpc":"2.0",
+                "id":1,
+                "result":{
+                    "tools":[{"name":"tool1","description":"First tool","inputSchema":{"type":"object"}}],
+                    "nextCursor":"cursor-2",
+                    "ttlMs":30,
+                    "cacheScope":"public"
+                }
+            }"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "id": 2,
+                "method": "tools/list",
+                "params": { "cursor": "cursor-2" }
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "jsonrpc":"2.0",
+                "id":2,
+                "result":{
+                    "tools":[{"name":"tool2","description":"Second tool","inputSchema":{"type":"object"}}],
+                    "ttlMs":10,
+                    "cacheScope":"private"
+                }
+            }"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let transport = McpHttpTransport::new(server.url()).unwrap();
+
+        let catalog = transport.list_tools_catalog().await.unwrap();
+        assert_eq!(catalog.items.len(), 2);
+        assert_eq!(catalog.items[0].name, "tool1");
+        assert_eq!(catalog.items[1].name, "tool2");
+        assert_eq!(catalog.metadata.ttlMs, Some(10));
+        assert_eq!(catalog.metadata.cacheScope.as_deref(), Some("private"));
+        assert_eq!(catalog.metadata.pageCount, 2);
+        assert_eq!(catalog.metadata.itemCount, 2);
+        page1.assert_async().await;
+        page2.assert_async().await;
+    }
+
+    #[tokio::test]
     async fn list_tools_with_sse_response_succeeds() {
         let mut server = mockito::Server::new_async().await;
 
@@ -3990,6 +4213,62 @@ data: invalid json
     }
 
     #[tokio::test]
+    async fn list_resources_detects_cursor_cycle() {
+        let mut server = mockito::Server::new_async().await;
+
+        let page1 = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "id": 1,
+                "method": "resources/list"
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "jsonrpc":"2.0",
+                "id":1,
+                "result":{
+                    "resources":[{"uri":"file:///r1","name":"r1","description":"R1"}],
+                    "nextCursor":"loop"
+                }
+            }"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "id": 2,
+                "method": "resources/list",
+                "params": { "cursor": "loop" }
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "jsonrpc":"2.0",
+                "id":2,
+                "result":{
+                    "resources":[{"uri":"file:///r2","name":"r2","description":"R2"}],
+                    "nextCursor":"loop"
+                }
+            }"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let transport = McpHttpTransport::new(server.url()).unwrap();
+
+        let err = transport.list_resources().await.unwrap_err();
+        assert!(err.to_string().contains("cursor cycle"));
+        page1.assert_async().await;
+        page2.assert_async().await;
+    }
+
+    #[tokio::test]
     async fn read_resource_succeeds() {
         let mut server = mockito::Server::new_async().await;
 
@@ -4083,6 +4362,69 @@ data: invalid json
         let prompts = result.unwrap();
         assert_eq!(prompts.len(), 1);
         assert_eq!(prompts[0].name, "prompt1");
+    }
+
+    #[tokio::test]
+    async fn list_prompts_enforces_item_limit() {
+        let mut server = mockito::Server::new_async().await;
+        let first_page_prompts: Vec<_> = (0..MCP_LIST_MAX_ITEMS)
+            .map(|idx| {
+                serde_json::json!({
+                    "name": format!("prompt-{idx}"),
+                    "description": "prompt"
+                })
+            })
+            .collect();
+        let first_page_body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "prompts": first_page_prompts,
+                "nextCursor": "cursor-2"
+            }
+        })
+        .to_string();
+
+        let page1 = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "id": 1,
+                "method": "prompts/list"
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(first_page_body)
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "id": 2,
+                "method": "prompts/list",
+                "params": { "cursor": "cursor-2" }
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "jsonrpc":"2.0",
+                "id":2,
+                "result":{
+                    "prompts":[{"name":"overflow","description":"overflow"}]
+                }
+            }"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let transport = McpHttpTransport::new(server.url()).unwrap();
+
+        let err = transport.list_prompts().await.unwrap_err();
+        assert!(err.to_string().contains("maximum of 10000 items"));
+        page1.assert_async().await;
+        page2.assert_async().await;
     }
 
     #[tokio::test]

--- a/src/adapters/mcp/http_transport.rs
+++ b/src/adapters/mcp/http_transport.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 
 use super::types::*;
+use super::McpExecutionOptions;
 use crate::auth::{self, oauth, AuthType, Profile, Profiles};
 use crate::error::UxcError;
 use crate::error::{
@@ -275,9 +276,23 @@ impl McpHttpTransport {
         params: Option<JsonValue>,
         custom_headers: &[(HeaderName, HeaderValue)],
     ) -> Result<JsonValue> {
+        self.send_request_with_custom_headers_and_capabilities(method, params, custom_headers, None)
+            .await
+    }
+
+    async fn send_request_with_custom_headers_and_capabilities(
+        &self,
+        method: &str,
+        params: Option<JsonValue>,
+        custom_headers: &[(HeaderName, HeaderValue)],
+        capabilities: Option<&JsonValue>,
+    ) -> Result<JsonValue> {
         self.maybe_refresh_auth_token().await?;
         let params = match self.protocol_context.era {
-            McpProtocolEra::Modern => Some(self.protocol_context.modern_request_params(params)?),
+            McpProtocolEra::Modern => Some(
+                self.protocol_context
+                    .modern_request_params_with_capabilities(params, capabilities)?,
+            ),
             McpProtocolEra::Legacy => params,
         };
 
@@ -1433,29 +1448,52 @@ impl McpHttpTransport {
         name: &str,
         arguments: Option<JsonValue>,
     ) -> Result<ToolCallResult> {
+        self.call_tool_with_options(name, arguments, &McpExecutionOptions::default())
+            .await
+    }
+
+    pub async fn call_tool_with_options(
+        &self,
+        name: &str,
+        arguments: Option<JsonValue>,
+        options: &McpExecutionOptions,
+    ) -> Result<ToolCallResult> {
         if self.protocol_context.era == McpProtocolEra::Modern
             && !*self.tool_catalog_loaded.lock().await
         {
             let _ = self.list_tools().await?;
         }
 
-        let params = match arguments.clone() {
-            Some(arguments) => serde_json::json!({
-                "name": name,
-                "arguments": arguments
-            }),
-            None => serde_json::json!({
-                "name": name,
-                "arguments": {}
-            }),
-        };
+        let mut params = serde_json::Map::new();
+        params.insert("name".to_string(), JsonValue::String(name.to_string()));
+        params.insert(
+            "arguments".to_string(),
+            arguments.clone().unwrap_or_else(|| serde_json::json!({})),
+        );
+        if let Some(continuation) = &options.continuation {
+            let continuation = continuation
+                .as_object()
+                .context("MCP continuation must be a JSON object")?;
+            for (key, value) in continuation {
+                if matches!(key.as_str(), "name" | "arguments" | "_meta") {
+                    bail!("MCP continuation must not override '{}'", key);
+                }
+                params.insert(key.clone(), value.clone());
+            }
+        }
+        let params = JsonValue::Object(params);
 
         let headers = self
             .custom_tool_headers(name, arguments.as_ref())
             .await
             .with_context(|| format!("Failed to build custom headers for tool '{}'", name))?;
         let result = match self
-            .send_request_with_custom_headers("tools/call", Some(params.clone()), &headers)
+            .send_request_with_custom_headers_and_capabilities(
+                "tools/call",
+                Some(params.clone()),
+                &headers,
+                options.capabilities.as_ref(),
+            )
             .await
         {
             Err(err)
@@ -1469,10 +1507,11 @@ impl McpHttpTransport {
                     .with_context(|| {
                         format!("Failed to rebuild custom headers for tool '{}'", name)
                     })?;
-                self.send_request_with_custom_headers(
+                self.send_request_with_custom_headers_and_capabilities(
                     "tools/call",
                     Some(params),
                     &refreshed_headers,
+                    options.capabilities.as_ref(),
                 )
                 .await?
             }
@@ -2556,6 +2595,22 @@ impl McpRemoteTransport {
     ) -> Result<ToolCallResult> {
         match self {
             Self::Streamable(transport) => transport.call_tool(name, arguments).await,
+            Self::Legacy(transport) => transport.call_tool(name, arguments).await,
+        }
+    }
+
+    pub async fn call_tool_with_options(
+        &self,
+        name: &str,
+        arguments: Option<JsonValue>,
+        options: &McpExecutionOptions,
+    ) -> Result<ToolCallResult> {
+        match self {
+            Self::Streamable(transport) => {
+                transport
+                    .call_tool_with_options(name, arguments, options)
+                    .await
+            }
             Self::Legacy(transport) => transport.call_tool(name, arguments).await,
         }
     }

--- a/src/adapters/mcp/mod.rs
+++ b/src/adapters/mcp/mod.rs
@@ -15,12 +15,22 @@ use async_trait::async_trait;
 pub use client::{LifecycleReapPolicy, McpStdioClient};
 pub use http_transport::{McpHttpTransport, McpRemoteTransport, ResolvedMcpHttpTransport};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tracing::{debug, info};
 pub use transport::StdioSpawnOptions;
+
+pub const MCP_CAPABILITIES_ARG: &str = "__uxc_mcp_capabilities";
+pub const MCP_CONTINUATION_ARG: &str = "__uxc_mcp_continuation";
+
+#[derive(Debug, Clone, Default)]
+pub struct McpExecutionOptions {
+    pub capabilities: Option<Value>,
+    pub continuation: Option<Value>,
+}
 
 pub struct McpAdapter {
     cache: Option<Arc<dyn crate::cache::Cache>>,
@@ -33,6 +43,32 @@ pub struct McpAdapter {
 }
 
 impl McpAdapter {
+    pub fn split_execution_options(
+        mut args: HashMap<String, Value>,
+    ) -> Result<(HashMap<String, Value>, McpExecutionOptions)> {
+        let capabilities = args.remove(MCP_CAPABILITIES_ARG);
+        if capabilities
+            .as_ref()
+            .is_some_and(|value| !value.is_object())
+        {
+            bail!("--mcp-capabilities must resolve to a JSON object");
+        }
+        let continuation = args.remove(MCP_CONTINUATION_ARG);
+        if continuation
+            .as_ref()
+            .is_some_and(|value| !value.is_object())
+        {
+            bail!("--mcp-continuation must resolve to a JSON object");
+        }
+        Ok((
+            args,
+            McpExecutionOptions {
+                capabilities,
+                continuation,
+            },
+        ))
+    }
+
     fn build_tool_arguments(args: HashMap<String, Value>) -> Option<Value> {
         Some(Value::Object(args.into_iter().collect()))
     }
@@ -77,6 +113,18 @@ impl McpAdapter {
     fn request_timeout_or_default(&self) -> Duration {
         self.request_timeout
             .unwrap_or_else(transport::McpStdioTransport::default_request_timeout)
+    }
+
+    fn schema_cache_key(&self, url: &str) -> String {
+        let mut hasher = Sha256::new();
+        if let Some(profile) = &self.auth_profile {
+            if let Ok(serialized) = serde_json::to_vec(profile) {
+                hasher.update(serialized);
+            }
+        } else {
+            hasher.update(b"anonymous");
+        }
+        format!("{}#uxc-mcp-auth={:x}", url, hasher.finalize())
     }
 
     /// Check if a URL/command looks like an MCP stdio command
@@ -162,7 +210,9 @@ impl McpAdapter {
         }
         if !self.force_refresh_schema {
             if let Some(cache) = &self.cache {
-                if let crate::cache::CacheResult::Hit(schema) = cache.get(url)? {
+                if let crate::cache::CacheResult::Hit(schema) =
+                    cache.get(&self.schema_cache_key(url))?
+                {
                     if let Some(resolved) = Self::resolved_transport_from_schema(&schema) {
                         let mut discovered = self.discovered_http_endpoints.write().await;
                         discovered.insert(normalized, resolved.clone());
@@ -329,7 +379,7 @@ impl McpAdapter {
     async fn fetch_schema_internal(&self, url: &str, allow_cache_read: bool) -> Result<Value> {
         if allow_cache_read {
             if let Some(cache) = &self.cache {
-                match cache.get(url)? {
+                match cache.get(&self.schema_cache_key(url))? {
                     crate::cache::CacheResult::Hit(schema) => {
                         debug!("MCP cache hit for: {}", url);
                         return Ok(schema);
@@ -390,7 +440,7 @@ impl McpAdapter {
 
             // Store in cache if available
             if let Some(cache) = &self.cache {
-                if let Err(e) = cache.put(url, &schema) {
+                if let Err(e) = cache.put(&self.schema_cache_key(url), &schema) {
                     debug!("Failed to cache MCP schema: {}", e);
                 } else {
                     info!("Cached MCP schema for: {}", url);
@@ -444,7 +494,7 @@ impl McpAdapter {
 
             // Store in cache if available
             if let Some(cache) = &self.cache {
-                if let Err(e) = cache.put(url, &schema) {
+                if let Err(e) = cache.put(&self.schema_cache_key(url), &schema) {
                     debug!("Failed to cache MCP schema: {}", e);
                 } else {
                     info!("Cached MCP schema for: {}", url);
@@ -547,6 +597,7 @@ impl Adapter for McpAdapter {
         args: HashMap<String, Value>,
     ) -> Result<ExecutionResult> {
         let start = std::time::Instant::now();
+        let (args, execution_options) = Self::split_execution_options(args)?;
         self.validate_tool_call(url, operation, &args).await?;
 
         if Self::is_stdio_command(url) {
@@ -562,7 +613,12 @@ impl Adapter for McpAdapter {
             let arguments = Self::build_tool_arguments(args);
 
             let result = client
-                .call_tool_with_timeout(operation, arguments, self.request_timeout_or_default())
+                .call_tool_with_options_and_timeout(
+                    operation,
+                    arguments,
+                    &execution_options,
+                    self.request_timeout_or_default(),
+                )
                 .await?;
 
             let output = convert_tool_result_to_value(&result);
@@ -594,7 +650,9 @@ impl Adapter for McpAdapter {
 
             let arguments = Self::build_tool_arguments(args);
 
-            let result = transport.call_tool(operation, arguments).await?;
+            let result = transport
+                .call_tool_with_options(operation, arguments, &execution_options)
+                .await?;
 
             let output = convert_tool_result_to_value(&result);
 
@@ -772,6 +830,35 @@ mod tests {
         assert_eq!(output["isError"], true);
         assert_eq!(output["structuredContent"]["message"], "hello");
         assert_eq!(output["structuredContent"]["count"], 1);
+    }
+
+    #[test]
+    fn split_execution_options_keeps_control_fields_out_of_tool_arguments() {
+        let (args, options) = McpAdapter::split_execution_options(StdHashMap::from([
+            ("message".to_string(), json!("hello")),
+            (MCP_CAPABILITIES_ARG.to_string(), json!({"elicitation": {}})),
+            (
+                MCP_CONTINUATION_ARG.to_string(),
+                json!({
+                    "inputResponses": {"request-1": {"action": "accept"}},
+                    "requestState": "opaque"
+                }),
+            ),
+        ]))
+        .unwrap();
+
+        assert_eq!(
+            args,
+            StdHashMap::from([("message".to_string(), json!("hello"))])
+        );
+        assert_eq!(options.capabilities, Some(json!({"elicitation": {}})));
+        assert_eq!(
+            options.continuation,
+            Some(json!({
+                "inputResponses": {"request-1": {"action": "accept"}},
+                "requestState": "opaque"
+            }))
+        );
     }
 
     #[test]

--- a/src/adapters/mcp/mod.rs
+++ b/src/adapters/mcp/mod.rs
@@ -118,8 +118,12 @@ impl McpAdapter {
     pub(crate) fn schema_cache_key_for(url: &str, auth_profile: Option<&Profile>) -> String {
         let mut hasher = Sha256::new();
         if let Some(profile) = auth_profile {
-            if let Ok(serialized) = serde_json::to_vec(profile) {
-                hasher.update(serialized);
+            match serde_json::to_value(profile) {
+                Ok(value) => hash_canonical_json(&mut hasher, &value),
+                Err(err) => {
+                    debug!(error = %err, "Failed to serialize auth profile for MCP cache key");
+                    hasher.update(b"serialization-error");
+                }
             }
         } else {
             hasher.update(b"anonymous");
@@ -773,6 +777,43 @@ fn convert_tool_content_to_json(content: &[types::ToolContent]) -> Value {
     Value::Array(content.iter().map(|item| item.as_value().clone()).collect())
 }
 
+fn hash_canonical_json(hasher: &mut Sha256, value: &Value) {
+    match value {
+        Value::Null => hasher.update(b"null"),
+        Value::Bool(value) => hasher.update(if *value {
+            b"true".as_slice()
+        } else {
+            b"false".as_slice()
+        }),
+        Value::Number(value) => hasher.update(value.to_string().as_bytes()),
+        Value::String(value) => {
+            hasher.update(b"\"");
+            hasher.update(value.as_bytes());
+            hasher.update(b"\"");
+        }
+        Value::Array(values) => {
+            hasher.update(b"[");
+            for value in values {
+                hash_canonical_json(hasher, value);
+                hasher.update(b",");
+            }
+            hasher.update(b"]");
+        }
+        Value::Object(values) => {
+            hasher.update(b"{");
+            let mut keys = values.keys().collect::<Vec<_>>();
+            keys.sort_unstable();
+            for key in keys {
+                hasher.update(key.as_bytes());
+                hasher.update(b":");
+                hash_canonical_json(hasher, &values[key]);
+                hasher.update(b",");
+            }
+            hasher.update(b"}");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -889,6 +930,44 @@ mod tests {
                 "inputResponses": {"request-1": {"action": "accept"}},
                 "requestState": "opaque"
             }))
+        );
+    }
+
+    #[test]
+    fn schema_cache_key_is_stable_across_auth_field_insertion_order() {
+        use crate::auth::{AuthType, SecretSource};
+
+        let mut first = Profile::new("secret".to_string(), AuthType::Bearer);
+        first.fields.insert(
+            "alpha".to_string(),
+            SecretSource::Literal {
+                value: "one".to_string(),
+            },
+        );
+        first.fields.insert(
+            "beta".to_string(),
+            SecretSource::Literal {
+                value: "two".to_string(),
+            },
+        );
+
+        let mut second = Profile::new("secret".to_string(), AuthType::Bearer);
+        second.fields.insert(
+            "beta".to_string(),
+            SecretSource::Literal {
+                value: "two".to_string(),
+            },
+        );
+        second.fields.insert(
+            "alpha".to_string(),
+            SecretSource::Literal {
+                value: "one".to_string(),
+            },
+        );
+
+        assert_eq!(
+            McpAdapter::schema_cache_key_for("https://example.com/mcp", Some(&first)),
+            McpAdapter::schema_cache_key_for("https://example.com/mcp", Some(&second))
         );
     }
 

--- a/src/adapters/mcp/mod.rs
+++ b/src/adapters/mcp/mod.rs
@@ -124,7 +124,38 @@ impl McpAdapter {
         } else {
             hasher.update(b"anonymous");
         }
-        format!("{}#uxc-mcp-auth={:x}", url, hasher.finalize())
+        format!(
+            "{}#uxc-mcp-schema=dual-era-2026&auth={:x}",
+            url,
+            hasher.finalize()
+        )
+    }
+
+    fn catalog_ttl_seconds(metadata: &types::McpListCatalogMetadata) -> Option<u64> {
+        metadata
+            .ttlMs
+            .map(|ttl_ms| ttl_ms.saturating_add(999) / 1000)
+    }
+
+    fn cache_schema(
+        &self,
+        url: &str,
+        schema: &Value,
+        metadata: Option<&types::McpListCatalogMetadata>,
+    ) {
+        let Some(cache) = &self.cache else {
+            return;
+        };
+        let cache_key = self.schema_cache_key(url);
+        let result = match metadata.and_then(Self::catalog_ttl_seconds) {
+            Some(ttl_seconds) => cache.put_with_ttl(&cache_key, schema, ttl_seconds),
+            None => cache.put(&cache_key, schema),
+        };
+        if let Err(err) = result {
+            debug!("Failed to cache MCP schema: {}", err);
+        } else {
+            info!("Cached MCP schema for: {}", url);
+        }
     }
 
     /// Check if a URL/command looks like an MCP stdio command
@@ -409,10 +440,10 @@ impl McpAdapter {
             let server_info = client.server_info().cloned();
             let instructions = client.instructions().map(ToString::to_string);
             let tools = match client
-                .list_tools_with_timeout(self.request_timeout_or_default())
+                .list_tools_catalog_with_timeout(self.request_timeout_or_default())
                 .await
             {
-                Ok(tools) => Some(tools),
+                Ok(catalog) => Some(catalog),
                 Err(err) => {
                     debug!("MCP stdio list_tools failed while building schema: {}", err);
                     None
@@ -434,18 +465,16 @@ impl McpAdapter {
                     "prompts": client.supports_prompts(),
                 }
             });
-            if let Some(tools) = tools {
-                schema["tools"] = serde_json::json!(tools);
+            if let Some(catalog) = &tools {
+                schema["tools"] = serde_json::json!(catalog.items);
+                schema["cacheMetadata"] = serde_json::to_value(&catalog.metadata)?;
             }
 
-            // Store in cache if available
-            if let Some(cache) = &self.cache {
-                if let Err(e) = cache.put(&self.schema_cache_key(url), &schema) {
-                    debug!("Failed to cache MCP schema: {}", e);
-                } else {
-                    info!("Cached MCP schema for: {}", url);
-                }
-            }
+            self.cache_schema(
+                url,
+                &schema,
+                tools.as_ref().map(|catalog| &catalog.metadata),
+            );
 
             return Ok(schema);
         }
@@ -466,8 +495,8 @@ impl McpAdapter {
             // subsequent requests on the session. Spec-compliant servers
             // (e.g., rmcp 0.15) otherwise hang on follow-up requests.
             transport.initialized().await?;
-            let tools = match transport.list_tools().await {
-                Ok(tools) => Some(tools),
+            let tools = match transport.list_tools_catalog().await {
+                Ok(catalog) => Some(catalog),
                 Err(err) => {
                     debug!("MCP HTTP list_tools failed while building schema: {}", err);
                     None
@@ -488,18 +517,16 @@ impl McpAdapter {
                 "instructions": init_result.instructions,
                 "capabilities": init_result.capabilities
             });
-            if let Some(tools) = tools {
-                schema["tools"] = serde_json::json!(tools);
+            if let Some(catalog) = &tools {
+                schema["tools"] = serde_json::json!(catalog.items);
+                schema["cacheMetadata"] = serde_json::to_value(&catalog.metadata)?;
             }
 
-            // Store in cache if available
-            if let Some(cache) = &self.cache {
-                if let Err(e) = cache.put(&self.schema_cache_key(url), &schema) {
-                    debug!("Failed to cache MCP schema: {}", e);
-                } else {
-                    info!("Cached MCP schema for: {}", url);
-                }
-            }
+            self.cache_schema(
+                url,
+                &schema,
+                tools.as_ref().map(|catalog| &catalog.metadata),
+            );
 
             return Ok(schema);
         }
@@ -942,9 +969,10 @@ mod tests {
     async fn resolve_http_transport_reuses_cached_resolved_transport() {
         let cache = Arc::new(TestCache::default());
         let url = "https://example.com";
+        let adapter = McpAdapter::new().with_cache(cache.clone());
         cache
             .put(
-                url,
+                &adapter.schema_cache_key(url),
                 &json!({
                     "protocol": "MCP",
                     "transport": "http",
@@ -956,7 +984,6 @@ mod tests {
             )
             .unwrap();
 
-        let adapter = McpAdapter::new().with_cache(cache);
         let resolved = adapter.resolve_http_transport(url).await.unwrap().unwrap();
 
         assert_eq!(resolved.mode, http_transport::McpHttpMode::LegacySse);

--- a/src/adapters/mcp/mod.rs
+++ b/src/adapters/mcp/mod.rs
@@ -115,9 +115,9 @@ impl McpAdapter {
             .unwrap_or_else(transport::McpStdioTransport::default_request_timeout)
     }
 
-    fn schema_cache_key(&self, url: &str) -> String {
+    pub(crate) fn schema_cache_key_for(url: &str, auth_profile: Option<&Profile>) -> String {
         let mut hasher = Sha256::new();
-        if let Some(profile) = &self.auth_profile {
+        if let Some(profile) = auth_profile {
             if let Ok(serialized) = serde_json::to_vec(profile) {
                 hasher.update(serialized);
             }
@@ -129,6 +129,10 @@ impl McpAdapter {
             url,
             hasher.finalize()
         )
+    }
+
+    fn schema_cache_key(&self, url: &str) -> String {
+        Self::schema_cache_key_for(url, self.auth_profile.as_ref())
     }
 
     fn catalog_ttl_seconds(metadata: &types::McpListCatalogMetadata) -> Option<u64> {

--- a/src/adapters/mcp/types.rs
+++ b/src/adapters/mcp/types.rs
@@ -7,6 +7,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 
+pub const MCP_LIST_MAX_PAGES: usize = 100;
+pub const MCP_LIST_MAX_ITEMS: usize = 10_000;
+
 /// JSON-RPC 2.0 Request
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonRpcRequest {
@@ -412,6 +415,14 @@ pub struct GetPromptResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolsListResponse {
     pub tools: Vec<Tool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nextCursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttlMs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cacheScope: Option<String>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
 }
 
 /// Tool call result (alias for CallToolResult)
@@ -421,12 +432,147 @@ pub type ToolCallResult = CallToolResult;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResourcesListResponse {
     pub resources: Vec<Resource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nextCursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttlMs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cacheScope: Option<String>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
 }
 
 /// Prompts list response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PromptsListResponse {
     pub prompts: Vec<Prompt>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nextCursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttlMs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cacheScope: Option<String>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct McpListPageMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nextCursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttlMs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cacheScope: Option<String>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct McpListCatalogMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttlMs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cacheScope: Option<String>,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
+    pub pageCount: usize,
+    pub itemCount: usize,
+}
+
+impl McpListCatalogMetadata {
+    pub fn absorb_page(&mut self, page: &McpListPageMetadata, item_count: usize) {
+        self.pageCount += 1;
+        self.itemCount += item_count;
+        self.ttlMs = match (self.ttlMs, page.ttlMs) {
+            (Some(current), Some(next)) => Some(current.min(next)),
+            (None, Some(next)) => Some(next),
+            (current, None) => current,
+        };
+        self.cacheScope = merge_cache_scope(self.cacheScope.take(), page.cacheScope.clone());
+        if self.meta.is_none() {
+            self.meta = page.meta.clone();
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct McpListCatalog<T> {
+    pub items: Vec<T>,
+    pub metadata: McpListCatalogMetadata,
+}
+
+pub type ToolsCatalog = McpListCatalog<Tool>;
+pub type ResourcesCatalog = McpListCatalog<Resource>;
+pub type PromptsCatalog = McpListCatalog<Prompt>;
+
+pub trait McpListPage {
+    type Item;
+
+    fn into_parts(self) -> (Vec<Self::Item>, McpListPageMetadata);
+}
+
+fn merge_cache_scope(current: Option<String>, next: Option<String>) -> Option<String> {
+    match (current, next) {
+        (Some(current), Some(_next)) if is_private_cache_scope(&current) => Some(current),
+        (_, Some(next)) if is_private_cache_scope(&next) => Some(next),
+        (Some(current), Some(_)) => Some(current),
+        (None, Some(next)) => Some(next),
+        (Some(current), None) => Some(current),
+        (None, None) => None,
+    }
+}
+
+fn is_private_cache_scope(scope: &str) -> bool {
+    scope.eq_ignore_ascii_case("private")
+}
+
+impl McpListPage for ToolsListResponse {
+    type Item = Tool;
+
+    fn into_parts(self) -> (Vec<Self::Item>, McpListPageMetadata) {
+        (
+            self.tools,
+            McpListPageMetadata {
+                nextCursor: self.nextCursor,
+                ttlMs: self.ttlMs,
+                cacheScope: self.cacheScope,
+                meta: self.meta,
+            },
+        )
+    }
+}
+
+impl McpListPage for ResourcesListResponse {
+    type Item = Resource;
+
+    fn into_parts(self) -> (Vec<Self::Item>, McpListPageMetadata) {
+        (
+            self.resources,
+            McpListPageMetadata {
+                nextCursor: self.nextCursor,
+                ttlMs: self.ttlMs,
+                cacheScope: self.cacheScope,
+                meta: self.meta,
+            },
+        )
+    }
+}
+
+impl McpListPage for PromptsListResponse {
+    type Item = Prompt;
+
+    fn into_parts(self) -> (Vec<Self::Item>, McpListPageMetadata) {
+        (
+            self.prompts,
+            McpListPageMetadata {
+                nextCursor: self.nextCursor,
+                ttlMs: self.ttlMs,
+                cacheScope: self.cacheScope,
+                meta: self.meta,
+            },
+        )
+    }
 }
 
 #[cfg(test)]
@@ -510,5 +656,50 @@ mod tests {
         assert_eq!(result.resultType, "complete");
         assert_eq!(result.content[0].content_type(), Some("future-content"));
         assert_eq!(result.content[0].as_value()["nested"]["value"], 1);
+    }
+
+    #[test]
+    fn list_catalog_metadata_aggregates_min_ttl_and_private_cache_scope() {
+        let mut metadata = McpListCatalogMetadata::default();
+        metadata.absorb_page(
+            &McpListPageMetadata {
+                ttlMs: Some(30),
+                cacheScope: Some("public".to_string()),
+                ..Default::default()
+            },
+            2,
+        );
+        metadata.absorb_page(
+            &McpListPageMetadata {
+                ttlMs: Some(10),
+                cacheScope: Some("private".to_string()),
+                ..Default::default()
+            },
+            3,
+        );
+
+        assert_eq!(metadata.ttlMs, Some(10));
+        assert_eq!(metadata.cacheScope.as_deref(), Some("private"));
+        assert_eq!(metadata.pageCount, 2);
+        assert_eq!(metadata.itemCount, 5);
+    }
+
+    #[test]
+    fn list_responses_parse_cursor_and_metadata() {
+        let response: ToolsListResponse = serde_json::from_value(json!({
+            "tools": [{"name": "ping"}],
+            "nextCursor": "cursor-2",
+            "ttlMs": 50,
+            "cacheScope": "public",
+            "_meta": {"page": 1}
+        }))
+        .unwrap();
+
+        let (tools, metadata) = response.into_parts();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(metadata.nextCursor.as_deref(), Some("cursor-2"));
+        assert_eq!(metadata.ttlMs, Some(50));
+        assert_eq!(metadata.cacheScope.as_deref(), Some("public"));
+        assert_eq!(metadata.meta, Some(json!({"page": 1})));
     }
 }

--- a/src/adapters/mcp/types.rs
+++ b/src/adapters/mcp/types.rs
@@ -2,10 +2,11 @@
 
 #![allow(non_snake_case)]
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 pub const MCP_LIST_MAX_PAGES: usize = 100;
 pub const MCP_LIST_MAX_ITEMS: usize = 10_000;
@@ -510,6 +511,80 @@ pub trait McpListPage {
     type Item;
 
     fn into_parts(self) -> (Vec<Self::Item>, McpListPageMetadata);
+}
+
+pub struct McpCatalogPaginator<T> {
+    method: String,
+    items: Vec<T>,
+    metadata: McpListCatalogMetadata,
+    next_cursor: Option<String>,
+    seen_cursors: HashSet<String>,
+}
+
+impl<T> McpCatalogPaginator<T> {
+    pub fn new(method: &str) -> Self {
+        Self {
+            method: method.to_string(),
+            items: Vec::new(),
+            metadata: McpListCatalogMetadata::default(),
+            next_cursor: None,
+            seen_cursors: HashSet::new(),
+        }
+    }
+
+    pub fn next_request_params(&self) -> Result<Option<JsonValue>> {
+        if self.metadata.pageCount >= MCP_LIST_MAX_PAGES {
+            bail!(
+                "MCP {} pagination exceeded maximum of {} pages",
+                self.method,
+                MCP_LIST_MAX_PAGES
+            );
+        }
+        Ok(self
+            .next_cursor
+            .as_ref()
+            .map(|cursor| serde_json::json!({ "cursor": cursor })))
+    }
+
+    pub fn absorb_response<R>(&mut self, result: JsonValue) -> Result<bool>
+    where
+        R: DeserializeOwned + McpListPage<Item = T>,
+    {
+        let response: R = serde_json::from_value(result)
+            .with_context(|| format!("Failed to parse {} response", self.method))?;
+        let (page_items, page_metadata) = response.into_parts();
+        self.metadata.absorb_page(&page_metadata, page_items.len());
+        if self.metadata.itemCount > MCP_LIST_MAX_ITEMS {
+            bail!(
+                "MCP {} pagination exceeded maximum of {} items",
+                self.method,
+                MCP_LIST_MAX_ITEMS
+            );
+        }
+        self.items.extend(page_items);
+
+        match page_metadata.nextCursor {
+            Some(cursor) => {
+                if !self.seen_cursors.insert(cursor.clone()) {
+                    bail!(
+                        "MCP {} pagination detected cursor cycle at '{}'",
+                        self.method,
+                        cursor
+                    );
+                }
+                self.next_cursor = Some(cursor);
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    pub fn finish(self) -> McpListCatalog<T> {
+        McpListCatalog {
+            items: self.items,
+            metadata: self.metadata,
+        }
+    }
 }
 
 fn merge_cache_scope(current: Option<String>, next: Option<String>) -> Option<String> {

--- a/src/adapters/mcp/types.rs
+++ b/src/adapters/mcp/types.rs
@@ -79,6 +79,14 @@ pub struct McpProtocolContext {
 
 impl McpProtocolContext {
     pub fn modern_request_params(&self, params: Option<JsonValue>) -> Result<JsonValue> {
+        self.modern_request_params_with_capabilities(params, None)
+    }
+
+    pub fn modern_request_params_with_capabilities(
+        &self,
+        params: Option<JsonValue>,
+        client_capabilities: Option<&JsonValue>,
+    ) -> Result<JsonValue> {
         let mut params = match params {
             Some(JsonValue::Object(params)) => params,
             Some(_) => return Err(anyhow!("MCP request params must be a JSON object")),
@@ -99,7 +107,11 @@ impl McpProtocolContext {
         );
         meta.insert(
             "io.modelcontextprotocol/clientCapabilities".to_string(),
-            serde_json::to_value(&self.client_capabilities)?,
+            match client_capabilities {
+                Some(JsonValue::Object(_)) => client_capabilities.cloned().unwrap(),
+                Some(_) => return Err(anyhow!("MCP client capabilities must be a JSON object")),
+                None => serde_json::to_value(&self.client_capabilities)?,
+            },
         );
         params.insert("_meta".to_string(), JsonValue::Object(meta));
         Ok(JsonValue::Object(params))
@@ -276,14 +288,6 @@ impl Tool {
             })
             .unwrap_or(&self.name)
     }
-}
-
-/// Tool call parameters
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CallToolParams {
-    pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub arguments: Option<JsonValue>,
 }
 
 /// Tool call result
@@ -474,6 +478,22 @@ mod tests {
         assert_eq!(
             params["_meta"]["io.modelcontextprotocol/clientInfo"]["name"],
             "uxc"
+        );
+    }
+
+    #[test]
+    fn modern_request_params_accept_explicit_client_capabilities() {
+        let capabilities = json!({
+            "elicitation": {},
+            "sampling": {}
+        });
+        let params = modern_context()
+            .modern_request_params_with_capabilities(None, Some(&capabilities))
+            .unwrap();
+
+        assert_eq!(
+            params["_meta"]["io.modelcontextprotocol/clientCapabilities"],
+            capabilities
         );
     }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -103,6 +103,12 @@ pub trait Cache: Send + Sync {
     /// If caching is disabled, this is a no-op.
     fn put(&self, url: &str, schema: &Value) -> Result<()>;
 
+    /// Put a schema into cache with an explicit TTL in seconds.
+    fn put_with_ttl(&self, url: &str, schema: &Value, ttl_seconds: u64) -> Result<()> {
+        let _ = ttl_seconds;
+        self.put(url, schema)
+    }
+
     /// Invalidate a specific cache entry
     fn invalidate(&self, url: &str) -> Result<()>;
 

--- a/src/cache/storage.rs
+++ b/src/cache/storage.rs
@@ -356,14 +356,17 @@ impl Cache for SchemaCache {
             return Ok(());
         }
 
+        self.put_with_ttl(url, schema, self.storage.config.ttl)
+    }
+
+    fn put_with_ttl(&self, url: &str, schema: &Value, ttl_seconds: u64) -> Result<()> {
+        if !self.storage.config.enabled {
+            return Ok(());
+        }
+
         let key = self.storage.generate_cache_key(url);
         let protocol = self.detect_protocol(url);
-        let entry = CacheEntry::new(
-            url.to_string(),
-            schema.clone(),
-            self.storage.config.ttl,
-            protocol,
-        );
+        let entry = CacheEntry::new(url.to_string(), schema.clone(), ttl_seconds, protocol);
 
         self.storage.save_entry(&key, &entry)?;
         info!("Cached schema for: {}", url);
@@ -474,6 +477,8 @@ impl Cache for SchemaCache {
 mod tests {
     use super::*;
     use std::fs;
+    use std::thread::sleep;
+    use std::time::Duration;
     use tempfile::TempDir;
 
     fn create_test_cache() -> (SchemaCache, TempDir) {
@@ -535,6 +540,28 @@ mod tests {
             }
             _ => panic!("Expected cache hit"),
         }
+    }
+
+    #[test]
+    fn test_cache_put_with_short_ttl_expires_after_delay() {
+        let (cache, _temp) = create_test_cache();
+        let url = "https://api.example.com/openapi.json";
+        let schema = serde_json::json!({"openapi": "3.0"});
+
+        cache.put_with_ttl(url, &schema, 1).unwrap();
+        assert!(matches!(cache.get(url).unwrap(), CacheResult::Hit(_)));
+        sleep(Duration::from_secs(2));
+        assert!(matches!(cache.get(url).unwrap(), CacheResult::Miss));
+    }
+
+    #[test]
+    fn test_cache_put_with_zero_ttl_expires_immediately() {
+        let (cache, _temp) = create_test_cache();
+        let url = "https://api.example.com/openapi.json";
+        let schema = serde_json::json!({"openapi": "3.0"});
+
+        cache.put_with_ttl(url, &schema, 0).unwrap();
+        assert!(matches!(cache.get(url).unwrap(), CacheResult::Miss));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8562,7 +8562,7 @@ fn lookup_schema_cache(
     policy: cache::CacheReadPolicy,
 ) -> Result<Option<(cache::CacheHit, String)>> {
     let mcp_cache_key = adapters::mcp::McpAdapter::schema_cache_key_for(url, auth_profile);
-    for cache_key in [url.to_string(), mcp_cache_key] {
+    for cache_key in [mcp_cache_key, url.to_string()] {
         if let cache::CacheLookup::Hit(hit) = cache.get_with_policy(&cache_key, policy)? {
             return Ok(Some((hit, cache_key)));
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4587,6 +4587,8 @@ impl DaemonRuntime {
             .operation_id
             .as_ref()
             .ok_or_else(|| anyhow!("operation_id is required"))?;
+        let (raw_args, execution_options) =
+            adapters::mcp::McpAdapter::split_execution_options(raw_args)?;
 
         if adapters::mcp::McpAdapter::is_stdio_command(endpoint) {
             let (cmd, cmd_args) = adapters::mcp::McpAdapter::parse_stdio_command(endpoint)?;
@@ -4638,7 +4640,7 @@ impl DaemonRuntime {
             let arguments = Some(Value::Object(args.into_iter().collect()));
             let result = guard
                 .client
-                .call_tool_with_timeout(op, arguments, timeout)
+                .call_tool_with_options_and_timeout(op, arguments, &execution_options, timeout)
                 .await;
             let _ = guard
                 .mark_tools_dirty_from_notifications(endpoint, &cache)
@@ -4692,7 +4694,10 @@ impl DaemonRuntime {
             };
             session.mark_used().await;
             let arguments = Some(Value::Object(raw_args.into_iter().collect()));
-            let result = session.transport.call_tool(op, arguments).await?;
+            let result = session
+                .transport
+                .call_tool_with_options(op, arguments, &execution_options)
+                .await?;
             let _ = session.collect_pending_notifications().await;
             Ok((
                 "call_result".to_string(),
@@ -8777,13 +8782,33 @@ async fn prepare_runtime_execute_args(
         .as_ref()
         .ok_or_else(|| anyhow!("operation_id is required"))?;
 
-    prepare_execute_args(
-        adapter,
-        &request.endpoint,
-        op,
-        request.args.clone().unwrap_or_default(),
-    )
-    .await
+    let mut raw_args = request.args.clone().unwrap_or_default();
+    let mcp_options = if matches!(adapter.protocol_type(), ProtocolType::Mcp) {
+        let capabilities = raw_args.remove(adapters::mcp::MCP_CAPABILITIES_ARG);
+        let continuation = raw_args.remove(adapters::mcp::MCP_CONTINUATION_ARG);
+        let (_, options) = adapters::mcp::McpAdapter::split_execution_options(HashMap::from_iter(
+            capabilities
+                .map(|value| (adapters::mcp::MCP_CAPABILITIES_ARG.to_string(), value))
+                .into_iter()
+                .chain(
+                    continuation
+                        .map(|value| (adapters::mcp::MCP_CONTINUATION_ARG.to_string(), value)),
+                ),
+        ))?;
+        Some(options)
+    } else {
+        None
+    };
+    let mut args = prepare_execute_args(adapter, &request.endpoint, op, raw_args).await?;
+    if let Some(options) = mcp_options {
+        if let Some(value) = options.capabilities {
+            args.insert(adapters::mcp::MCP_CAPABILITIES_ARG.to_string(), value);
+        }
+        if let Some(value) = options.continuation {
+            args.insert(adapters::mcp::MCP_CONTINUATION_ARG.to_string(), value);
+        }
+    }
+    Ok(args)
 }
 
 async fn host_help_service_summary(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1021,7 +1021,7 @@ impl McpStdioSession {
             if notification.method == "notifications/tools/list_changed" {
                 self.tools_dirty = true;
                 if let Some(cache) = cache {
-                    let _ = cache.invalidate(&self.schema_cache_key);
+                    invalidate_mcp_schema_cache(cache.as_ref(), &self.schema_cache_key, endpoint);
                 }
             }
             public_notifications.push(notification);
@@ -8822,22 +8822,10 @@ async fn prepare_runtime_execute_args(
         .ok_or_else(|| anyhow!("operation_id is required"))?;
 
     let mut raw_args = request.args.clone().unwrap_or_default();
-    let mcp_options = if matches!(adapter.protocol_type(), ProtocolType::Mcp) {
-        let capabilities = raw_args.remove(adapters::mcp::MCP_CAPABILITIES_ARG);
-        let continuation = raw_args.remove(adapters::mcp::MCP_CONTINUATION_ARG);
-        let (_, options) = adapters::mcp::McpAdapter::split_execution_options(HashMap::from_iter(
-            capabilities
-                .map(|value| (adapters::mcp::MCP_CAPABILITIES_ARG.to_string(), value))
-                .into_iter()
-                .chain(
-                    continuation
-                        .map(|value| (adapters::mcp::MCP_CONTINUATION_ARG.to_string(), value)),
-                ),
-        ))?;
-        Some(options)
-    } else {
-        None
-    };
+    let mcp_options = split_runtime_mcp_controls(
+        &mut raw_args,
+        matches!(adapter.protocol_type(), ProtocolType::Mcp),
+    )?;
     let mut args = prepare_execute_args(adapter, &request.endpoint, op, raw_args).await?;
     if let Some(options) = mcp_options {
         if let Some(value) = options.capabilities {
@@ -8848,6 +8836,35 @@ async fn prepare_runtime_execute_args(
         }
     }
     Ok(args)
+}
+
+fn split_runtime_mcp_controls(
+    raw_args: &mut HashMap<String, Value>,
+    is_mcp: bool,
+) -> Result<Option<adapters::mcp::McpExecutionOptions>> {
+    let capabilities = raw_args.remove(adapters::mcp::MCP_CAPABILITIES_ARG);
+    let continuation = raw_args.remove(adapters::mcp::MCP_CONTINUATION_ARG);
+    if is_mcp {
+        let (_, options) = adapters::mcp::McpAdapter::split_execution_options(HashMap::from_iter(
+            capabilities
+                .map(|value| (adapters::mcp::MCP_CAPABILITIES_ARG.to_string(), value))
+                .into_iter()
+                .chain(
+                    continuation
+                        .map(|value| (adapters::mcp::MCP_CONTINUATION_ARG.to_string(), value)),
+                ),
+        ))?;
+        Ok(Some(options))
+    } else {
+        Ok(None)
+    }
+}
+
+fn invalidate_mcp_schema_cache(cache: &dyn Cache, scoped_key: &str, endpoint: &str) {
+    let _ = cache.invalidate(scoped_key);
+    if scoped_key != endpoint {
+        let _ = cache.invalidate(endpoint);
+    }
 }
 
 async fn host_help_service_summary(
@@ -9155,17 +9172,104 @@ impl Default for DaemonRuntime {
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
+    use crate::cache::{CacheLookup, CacheReadPolicy, CacheResult, CacheStats};
     use futures::SinkExt;
     use rusqlite::Connection;
     use std::collections::VecDeque;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc as StdArc;
+    use std::sync::Mutex as StdMutex;
     use std::time::Duration as StdDuration;
     use tempfile::tempdir;
     use tokio::net::TcpListener;
     use tokio_tungstenite::accept_hdr_async;
     use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
     use tokio_tungstenite::tungstenite::Message;
+
+    #[derive(Default)]
+    struct RecordingCache {
+        invalidated: StdMutex<Vec<String>>,
+    }
+
+    impl Cache for RecordingCache {
+        fn get(&self, _url: &str) -> Result<CacheResult> {
+            Ok(CacheResult::Miss)
+        }
+
+        fn get_with_policy(&self, _url: &str, _policy: CacheReadPolicy) -> Result<CacheLookup> {
+            Ok(CacheLookup::Miss)
+        }
+
+        fn put(&self, _url: &str, _schema: &Value) -> Result<()> {
+            Ok(())
+        }
+
+        fn invalidate(&self, url: &str) -> Result<()> {
+            self.invalidated.lock().unwrap().push(url.to_string());
+            Ok(())
+        }
+
+        fn invalidate_by_key(&self, _key: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn clear(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn list_entries(&self) -> Result<Vec<crate::cache::CacheListEntry>> {
+            Ok(Vec::new())
+        }
+
+        fn stats(&self) -> Result<CacheStats> {
+            Ok(CacheStats::default())
+        }
+
+        fn is_enabled(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn list_change_invalidates_scoped_and_legacy_mcp_schema_cache_keys() {
+        let cache = RecordingCache::default();
+        invalidate_mcp_schema_cache(
+            &cache,
+            "https://example.com/mcp#uxc-mcp-schema=scoped",
+            "https://example.com/mcp",
+        );
+
+        assert_eq!(
+            *cache.invalidated.lock().unwrap(),
+            vec![
+                "https://example.com/mcp#uxc-mcp-schema=scoped".to_string(),
+                "https://example.com/mcp".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn non_mcp_runtime_args_strip_mcp_control_fields() {
+        let mut args = HashMap::from([
+            ("message".to_string(), json!("hello")),
+            (
+                adapters::mcp::MCP_CAPABILITIES_ARG.to_string(),
+                json!({"elicitation": {}}),
+            ),
+            (
+                adapters::mcp::MCP_CONTINUATION_ARG.to_string(),
+                json!({"requestState": "opaque"}),
+            ),
+        ]);
+
+        assert!(split_runtime_mcp_controls(&mut args, false)
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            args,
+            HashMap::from([("message".to_string(), json!("hello"))])
+        );
+    }
 
     #[test]
     fn managed_source_poll_jitter_preserves_interval_cadence() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -803,6 +803,7 @@ struct InitLockEntry {
 
 struct McpStdioSession {
     client: adapters::mcp::McpStdioClient,
+    schema_cache_key: String,
     tools: Option<Vec<adapters::mcp::types::Tool>>,
     tools_dirty: bool,
     notifications: SessionNotificationFanout,
@@ -870,6 +871,7 @@ struct SessionNotificationFanout {
 }
 
 struct StdioSessionRequestMetadata<'a> {
+    schema_cache_key: String,
     idle_ttl_secs: Option<u64>,
     link_name: Option<&'a str>,
     link_skill: Option<&'a str>,
@@ -1019,7 +1021,7 @@ impl McpStdioSession {
             if notification.method == "notifications/tools/list_changed" {
                 self.tools_dirty = true;
                 if let Some(cache) = cache {
-                    let _ = cache.invalidate(endpoint);
+                    let _ = cache.invalidate(&self.schema_cache_key);
                 }
             }
             public_notifications.push(notification);
@@ -1527,6 +1529,7 @@ impl McpSessionManager {
     ) -> Result<(Arc<Mutex<McpStdioSession>>, bool)> {
         let exclusive_keys = normalize_exclusive_keys(metadata.exclusive_keys);
         let metadata = StdioSessionRequestMetadata {
+            schema_cache_key: metadata.schema_cache_key,
             idle_ttl_secs: metadata.idle_ttl_secs,
             link_name: metadata.link_name,
             link_skill: metadata.link_skill,
@@ -1639,6 +1642,7 @@ impl McpSessionManager {
         let session = Arc::new(Mutex::new(McpStdioSession {
             child_pid,
             client,
+            schema_cache_key: metadata.schema_cache_key.clone(),
             tools: None,
             tools_dirty: false,
             notifications: SessionNotificationFanout::default(),
@@ -4249,13 +4253,16 @@ impl DaemonRuntime {
         // succeeded without network access. This keeps `-h` flows resilient when the cached
         // schema is expired but still useful.
         if result.is_err() && !request.options.no_cache && !request.options.refresh_schema {
-            if let cache::CacheLookup::Hit(hit) = cache_for_fallback
-                .get_with_policy(&request.endpoint, cache::CacheReadPolicy::AllowStale)?
-            {
+            if let Some((hit, cache_key)) = lookup_schema_cache(
+                cache_for_fallback.as_ref(),
+                &request.endpoint,
+                root_auth_profile.as_ref(),
+                cache::CacheReadPolicy::AllowStale,
+            )? {
                 if hit.stale {
                     if let Some(fallback_protocol) = protocol_from_cached_schema(&hit.schema) {
                         // Refresh TTL so adapters using normal cache reads can consume this schema.
-                        let _ = cache_for_fallback.put(&request.endpoint, &hit.schema);
+                        let _ = cache_for_fallback.put(&cache_key, &hit.schema);
                         let mut adapter =
                             adapter_from_protocol(fallback_protocol, &detection_options);
                         adapter = inject_cache_if_supported(adapter, cache_for_fallback.clone());
@@ -4616,6 +4623,10 @@ impl DaemonRuntime {
                     &spawn_options,
                     request_timeout_duration(request.options.timeout_ms),
                     StdioSessionRequestMetadata {
+                        schema_cache_key: adapters::mcp::McpAdapter::schema_cache_key_for(
+                            endpoint,
+                            auth_profile.as_ref(),
+                        ),
                         idle_ttl_secs: request.options.daemon_idle_ttl,
                         link_name: request.options.link_name.as_deref(),
                         link_skill: request.options.link_skill.as_deref(),
@@ -6381,6 +6392,10 @@ async fn run_mcp_subscription_job(
             &spawn_options,
             request_timeout_duration(request.options.timeout_ms),
             StdioSessionRequestMetadata {
+                schema_cache_key: adapters::mcp::McpAdapter::schema_cache_key_for(
+                    &request.endpoint,
+                    auth_profile.as_ref(),
+                ),
                 idle_ttl_secs: request.options.daemon_idle_ttl,
                 link_name: request.options.link_name.as_deref(),
                 link_skill: request.options.link_skill.as_deref(),
@@ -8473,24 +8488,26 @@ async fn resolve_adapter_with_schema_cache(
     refresh_schema: bool,
 ) -> Result<ResolveAdapterResult> {
     if !no_cache && !refresh_schema {
-        match cache.get_with_policy(url, cache::CacheReadPolicy::NormalTtl)? {
-            cache::CacheLookup::Hit(hit) => {
-                if let Some(protocol) = protocol_from_cached_schema(&hit.schema) {
-                    let mut adapter = adapter_from_protocol(protocol, detection_options);
-                    adapter = inject_cache_if_supported(adapter, cache.clone());
-                    adapter = inject_auth_if_supported(adapter, auth_profile.clone());
-                    adapter = inject_refresh_if_supported(adapter, refresh_schema);
-                    return Ok(ResolveAdapterResult {
-                        adapter,
-                        cache_meta: Some(SchemaCacheMeta {
-                            age_ms: cache_age_ms(hit.fetched_at),
-                            stale: hit.stale,
-                            fallback: false,
-                        }),
-                    });
-                }
+        if let Some((hit, _)) = lookup_schema_cache(
+            cache.as_ref(),
+            url,
+            auth_profile.as_ref(),
+            cache::CacheReadPolicy::NormalTtl,
+        )? {
+            if let Some(protocol) = protocol_from_cached_schema(&hit.schema) {
+                let mut adapter = adapter_from_protocol(protocol, detection_options);
+                adapter = inject_cache_if_supported(adapter, cache.clone());
+                adapter = inject_auth_if_supported(adapter, auth_profile.clone());
+                adapter = inject_refresh_if_supported(adapter, refresh_schema);
+                return Ok(ResolveAdapterResult {
+                    adapter,
+                    cache_meta: Some(SchemaCacheMeta {
+                        age_ms: cache_age_ms(hit.fetched_at),
+                        stale: hit.stale,
+                        fallback: false,
+                    }),
+                });
             }
-            cache::CacheLookup::Miss | cache::CacheLookup::Bypassed => {}
         }
     }
 
@@ -8510,11 +8527,14 @@ async fn resolve_adapter_with_schema_cache(
         }
         Err(err) => {
             if !no_cache && !refresh_schema {
-                if let cache::CacheLookup::Hit(hit) =
-                    cache.get_with_policy(url, cache::CacheReadPolicy::AllowStale)?
-                {
+                if let Some((hit, cache_key)) = lookup_schema_cache(
+                    cache.as_ref(),
+                    url,
+                    auth_profile.as_ref(),
+                    cache::CacheReadPolicy::AllowStale,
+                )? {
                     if let Some(protocol) = protocol_from_cached_schema(&hit.schema) {
-                        let _ = cache.put(url, &hit.schema);
+                        let _ = cache.put(&cache_key, &hit.schema);
                         let mut adapter = adapter_from_protocol(protocol, detection_options);
                         adapter = inject_cache_if_supported(adapter, cache.clone());
                         adapter = inject_auth_if_supported(adapter, auth_profile.clone());
@@ -8533,6 +8553,21 @@ async fn resolve_adapter_with_schema_cache(
             Err(err)
         }
     }
+}
+
+fn lookup_schema_cache(
+    cache: &dyn cache::Cache,
+    url: &str,
+    auth_profile: Option<&Profile>,
+    policy: cache::CacheReadPolicy,
+) -> Result<Option<(cache::CacheHit, String)>> {
+    let mcp_cache_key = adapters::mcp::McpAdapter::schema_cache_key_for(url, auth_profile);
+    for cache_key in [url.to_string(), mcp_cache_key] {
+        if let cache::CacheLookup::Hit(hit) = cache.get_with_policy(&cache_key, policy)? {
+            return Ok(Some((hit, cache_key)));
+        }
+    }
+    Ok(None)
 }
 
 async fn invoke_with_adapter(
@@ -8659,6 +8694,10 @@ async fn invoke_live_stdio_mcp_help(
     runtime.mcp.mark_stdio_request_started(&session_key).await;
     let mut guard = session.lock().await;
     guard.apply_request_metadata(&StdioSessionRequestMetadata {
+        schema_cache_key: adapters::mcp::McpAdapter::schema_cache_key_for(
+            &request.endpoint,
+            auth_profile,
+        ),
         idle_ttl_secs: request.options.daemon_idle_ttl,
         link_name: request.options.link_name.as_deref(),
         link_skill: request.options.link_skill.as_deref(),
@@ -9373,6 +9412,10 @@ mod tests {
         with_mcp_idle_ttl_env(None, || {
             let resolved = resolve_stdio_request_metadata(
                 &StdioSessionRequestMetadata {
+                    schema_cache_key: adapters::mcp::McpAdapter::schema_cache_key_for(
+                        "https://new.example.com",
+                        None,
+                    ),
                     idle_ttl_secs: None,
                     link_name: None,
                     link_skill: None,
@@ -9398,6 +9441,10 @@ mod tests {
     fn resolve_stdio_request_metadata_accepts_zero_ttl_override() {
         let resolved = resolve_stdio_request_metadata(
             &StdioSessionRequestMetadata {
+                schema_cache_key: adapters::mcp::McpAdapter::schema_cache_key_for(
+                    "https://new.example.com",
+                    None,
+                ),
                 idle_ttl_secs: Some(0),
                 link_name: Some("board-link"),
                 link_skill: Some("board-webmcp"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use clap::{error::ErrorKind, Parser, Subcommand, ValueEnum};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -127,6 +127,14 @@ struct Cli {
     /// Force online schema discovery and refresh cache.
     #[arg(long, global = true, conflicts_with = "no_cache")]
     refresh_schema: bool,
+
+    /// MCP client capabilities JSON, @FILE, or - for stdin
+    #[arg(long, global = true, value_name = "JSON|@FILE|-")]
+    mcp_capabilities: Option<String>,
+
+    /// MCP MRTR continuation JSON, @FILE, or - for stdin
+    #[arg(long, global = true, value_name = "JSON|@FILE|-")]
+    mcp_continuation: Option<String>,
 
     /// Explicit OpenAPI schema URL (for schema-discovery separated services)
     #[arg(long, global = true)]
@@ -1404,6 +1412,8 @@ fn normalize_global_args(raw_args: Vec<String>) -> Vec<String> {
                 | "--daemon-exclusive"
                 | "--daemon-idle-ttl"
                 | "--inject-env"
+                | "--mcp-capabilities"
+                | "--mcp-continuation"
         );
         let is_global_inline = arg.starts_with("--format=")
             || arg.starts_with("--auth=")
@@ -1411,7 +1421,9 @@ fn normalize_global_args(raw_args: Vec<String>) -> Vec<String> {
             || arg.starts_with("--schema-url=")
             || arg.starts_with("--daemon-exclusive=")
             || arg.starts_with("--daemon-idle-ttl=")
-            || arg.starts_with("--inject-env=");
+            || arg.starts_with("--inject-env=")
+            || arg.starts_with("--mcp-capabilities=")
+            || arg.starts_with("--mcp-continuation=");
 
         if is_global_bool || is_global_inline {
             global_args.push(arg.clone());
@@ -1460,6 +1472,8 @@ fn is_global_kv_arg(arg: &str) -> bool {
             | "--daemon-exclusive"
             | "--daemon-idle-ttl"
             | "--inject-env"
+            | "--mcp-capabilities"
+            | "--mcp-continuation"
     )
 }
 
@@ -2004,7 +2018,7 @@ async fn execute_endpoint_via_daemon(
     let daemon_restarted_for_version_mismatch = daemon_ensure
         .as_ref()
         .map(|outcome| outcome.restarted_for_version_mismatch);
-    let (action, operation_id, args_map) = match endpoint_command {
+    let (action, operation_id, mut args_map) = match endpoint_command {
         EndpointCommand::HostHelp => (daemon::RuntimeAction::HostHelp, None, None),
         EndpointCommand::CodegenSchema => (daemon::RuntimeAction::CodegenSchema, None, None),
         EndpointCommand::Describe { operation_id } => (
@@ -2022,6 +2036,21 @@ async fn execute_endpoint_via_daemon(
             Some(parse_arguments(args.clone(), input_json.clone())?),
         ),
     };
+    if matches!(action, daemon::RuntimeAction::Execute) {
+        let args = args_map.get_or_insert_with(HashMap::new);
+        if let Some(input) = cli.mcp_capabilities.as_deref() {
+            args.insert(
+                adapters::mcp::MCP_CAPABILITIES_ARG.to_string(),
+                parse_json_control_input("--mcp-capabilities", input)?,
+            );
+        }
+        if let Some(input) = cli.mcp_continuation.as_deref() {
+            args.insert(
+                adapters::mcp::MCP_CONTINUATION_ARG.to_string(),
+                parse_json_control_input("--mcp-continuation", input)?,
+            );
+        }
+    }
 
     let request = daemon::RuntimeInvokeRequest {
         request_id: format!(
@@ -3607,6 +3636,27 @@ fn parse_arguments(
     input_json: Option<String>,
 ) -> Result<HashMap<String, Value>> {
     crate::cli::ArgumentParser::parse_arguments(args, input_json)
+}
+
+fn parse_json_control_input(flag: &str, input: &str) -> Result<Value> {
+    let raw = if let Some(path) = input.strip_prefix('@') {
+        std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {} file '{}'", flag, path))?
+    } else if input == "-" {
+        let mut raw = String::new();
+        std::io::stdin()
+            .read_to_string(&mut raw)
+            .with_context(|| format!("Failed to read {} from stdin", flag))?;
+        raw
+    } else {
+        input.to_string()
+    };
+    let value: Value =
+        serde_json::from_str(&raw).with_context(|| format!("Invalid JSON for {}", flag))?;
+    if !value.is_object() {
+        bail!("{} must resolve to a JSON object", flag);
+    }
+    Ok(value)
 }
 
 fn enrich_operation_detail_payload(data: Value, command_head: &str, operation_id: &str) -> Value {
@@ -7564,9 +7614,9 @@ fn parse_oauth_flow(value: &str) -> Result<OAuthFlow> {
 mod tests {
     use super::{
         build_link_launcher, collect_daemon_idle_ttl, enrich_operation_detail_payload,
-        infer_scheme_for_endpoint, link_target_path, normalize_endpoint_url, parse_arguments,
-        resolve_home_dir, resolve_link_dir, shell_single_quote, validate_link_name, Cli,
-        LinkLauncherConfig,
+        infer_scheme_for_endpoint, link_target_path, normalize_endpoint_url, normalize_global_args,
+        parse_arguments, parse_json_control_input, resolve_home_dir, resolve_link_dir,
+        shell_single_quote, validate_link_name, Cli, LinkLauncherConfig,
     };
     use clap::Parser;
     use serde_json::json;
@@ -7770,6 +7820,31 @@ mod tests {
         assert_eq!(parsed["filter"]["status"], "active");
         assert_eq!(parsed["tags"][0], "rust");
         assert_eq!(parsed["tags"][1], "cli");
+    }
+
+    #[test]
+    fn normalize_global_args_moves_mcp_control_flags_before_endpoint() {
+        let normalized = normalize_global_args(vec![
+            "uxc".to_string(),
+            "https://example.com/mcp".to_string(),
+            "search".to_string(),
+            "--mcp-capabilities".to_string(),
+            r#"{"elicitation":{}}"#.to_string(),
+            "--mcp-continuation=@continuation.json".to_string(),
+        ]);
+
+        assert_eq!(normalized[1], "--mcp-capabilities");
+        assert_eq!(normalized[2], r#"{"elicitation":{}}"#);
+        assert_eq!(normalized[3], "--mcp-continuation=@continuation.json");
+    }
+
+    #[test]
+    fn parse_json_control_input_requires_object() {
+        assert_eq!(
+            parse_json_control_input("--mcp-capabilities", r#"{"sampling":{}}"#).unwrap(),
+            json!({"sampling": {}})
+        );
+        assert!(parse_json_control_input("--mcp-continuation", "[]").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What

Add MCP result normalization, complete list pagination, scoped schema caching, and Multi Round-Trip Request (MRTR) continuation support for the modern protocol while preserving legacy behavior.

## Why

This is PR 3 of the ordered MCP 2026-07-28 compatibility series. Modern MCP responses introduce typed result variants and continuation flows, while catalog discovery must handle pagination and cache isolation across protocol/auth scopes.

## How

- Normalize modern and legacy MCP results behind a stable `resultType` output contract.
- Follow cursors across tools, prompts, resources, and resource-template catalog requests.
- Scope schema cache metadata by endpoint, protocol era, and authorization identity.
- Invalidate matching memory and disk schema caches on list-change notifications.
- Add explicit MRTR pending-result output and continuation controls across stdio, HTTP, and daemon reuse paths.

## Changes

- [x] Add MRTR execution and continuation controls.
- [x] Paginate MCP list catalogs.
- [x] Scope schema cache metadata and notification invalidation.
- [x] Extend regression and integration coverage for modern/legacy behavior.

## Testing

### Unit Tests
- [x] All existing tests pass
- [x] New tests added
- [x] `cargo test` passes

### Manual Testing
- [x] Tested transport continuation paths
- [x] Tested pagination and cache edge cases
- [x] Tested error and stale-cache fallback conditions

### Test Results

```bash
cargo +1.91.1 test --locked -- --test-threads=1
cargo +1.91.1 clippy --locked --lib --bins -- -D warnings
```

## Checklist

- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings for library and binary targets
- [x] All tests pass
- [ ] Documentation updated (planned for PR 5)
- [x] Commit messages follow convention
- [x] PR title follows convention

## Breaking Changes

None. Legacy MCP behavior remains supported; modern result details are exposed through additive output fields and explicit continuation controls.

## Additional Notes

This PR depends on the protocol foundation and modern Streamable HTTP support merged in PRs #428 and #429. Subscriptions/daemon listening and OAuth/conformance documentation remain scoped to PRs 4 and 5.
