### PR TITLE
feat(mcp): add subscriptions and daemon support

### DIFF
--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -1,7 +1,8 @@
 //! MCP stdio client implementation
 
 use super::transport::{
-    DefaultStdioProcessExecutor, McpStdioTransport, StdioProcessExecutor, StdioSpawnOptions,
+    DefaultStdioProcessExecutor, McpStdioTransport, StdioLongLivedRequest, StdioProcessExecutor,
+    StdioSpawnOptions,
 };
 use super::types::*;
 use super::McpExecutionOptions;
@@ -32,6 +33,7 @@ pub struct McpStdioClient {
     server_capabilities: Option<ServerCapabilities>,
     server_info: Option<ServerInfo>,
     instructions: Option<String>,
+    subscription: Option<StdioLongLivedRequest>,
 }
 
 impl McpStdioClient {
@@ -156,6 +158,7 @@ impl McpStdioClient {
                         server_capabilities: Some(discover.capabilities),
                         server_info,
                         instructions: discover.instructions,
+                        subscription: None,
                     });
                 }
                 Err(err) => tracing::debug!(
@@ -211,6 +214,7 @@ impl McpStdioClient {
             server_capabilities: Some(init_result.capabilities),
             server_info: init_result.serverInfo,
             instructions: init_result.instructions,
+            subscription: None,
         })
     }
 
@@ -283,6 +287,57 @@ impl McpStdioClient {
 
     pub async fn drain_notifications(&mut self) -> Vec<JsonRpcNotification> {
         self.transport.drain_notifications().await
+    }
+
+    pub async fn start_subscription(&mut self, filter: SubscriptionFilter) -> Result<RequestId> {
+        if self.protocol_context.era != McpProtocolEra::Modern {
+            bail!("subscriptions/listen requires modern MCP");
+        }
+        if filter.is_empty() {
+            bail!("subscriptions/listen requires at least one notification filter");
+        }
+        self.cancel_subscription("subscription filter replaced")
+            .await?;
+        let params = self
+            .protocol_context
+            .modern_request_params(Some(json!({ "notifications": filter })))?;
+        let request = self
+            .transport
+            .start_long_lived_request("subscriptions/listen", Some(params))
+            .await?;
+        let request_id = request.request_id().clone();
+        self.subscription = Some(request);
+        Ok(request_id)
+    }
+
+    pub fn poll_subscription_closed(&mut self) -> Result<Option<JsonValue>> {
+        let Some(request) = self.subscription.as_mut() else {
+            return Ok(None);
+        };
+        match McpStdioTransport::poll_long_lived_request(request) {
+            Ok(Some(result)) => {
+                self.subscription = None;
+                Ok(Some(result))
+            }
+            Ok(None) => Ok(None),
+            Err(err) => {
+                self.subscription = None;
+                Err(err)
+            }
+        }
+    }
+
+    pub async fn cancel_subscription(&mut self, reason: &str) -> Result<()> {
+        let Some(request) = self.subscription.take() else {
+            return Ok(());
+        };
+        let request_id = request.request_id().clone();
+        let cancel_result = self
+            .transport
+            .cancel_request(&request_id, Some(reason))
+            .await;
+        self.transport.forget_request(&request_id).await;
+        cancel_result
     }
 
     pub async fn lifecycle_contract(&mut self, timeout: Duration) -> Result<LifecycleContract> {

--- a/src/adapters/mcp/client.rs
+++ b/src/adapters/mcp/client.rs
@@ -337,7 +337,14 @@ impl McpStdioClient {
             .cancel_request(&request_id, Some(reason))
             .await;
         self.transport.forget_request(&request_id).await;
-        cancel_result
+        if let Err(err) = cancel_result {
+            tracing::debug!(
+                reason,
+                error = %err,
+                "Failed to send MCP subscription cancellation after local cleanup"
+            );
+        }
+        Ok(())
     }
 
     pub async fn lifecycle_contract(&mut self, timeout: Duration) -> Result<LifecycleContract> {

--- a/src/adapters/mcp/http_transport.rs
+++ b/src/adapters/mcp/http_transport.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, Context, Result};
 use base64::Engine;
 use reqwest::header::{HeaderName, HeaderValue};
 use reqwest::Client;
-use serde_json::Value as JsonValue;
+use serde_json::{json, Value as JsonValue};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
@@ -118,6 +118,8 @@ pub struct McpHttpTransport {
     event_stream_task: Arc<Mutex<Option<JoinHandle<()>>>>,
     /// Terminal error from the current event stream reader, if any.
     event_stream_error: Arc<Mutex<Option<String>>>,
+    /// JSON-RPC id of the active modern subscriptions/listen request.
+    subscription_id: Arc<Mutex<Option<RequestId>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -261,6 +263,7 @@ impl McpHttpTransport {
             notifications: Arc::new(Mutex::new(VecDeque::new())),
             event_stream_task: Arc::new(Mutex::new(None)),
             event_stream_error: Arc::new(Mutex::new(None)),
+            subscription_id: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -1746,6 +1749,67 @@ impl McpHttpTransport {
         if let Some(task) = self.event_stream_task.lock().await.take() {
             task.abort();
         }
+        *self.subscription_id.lock().await = None;
+    }
+
+    pub async fn start_subscription(&self, filter: SubscriptionFilter) -> Result<RequestId> {
+        if self.protocol_context.era != McpProtocolEra::Modern {
+            bail!("subscriptions/listen requires modern MCP");
+        }
+        if filter.is_empty() {
+            bail!("subscriptions/listen requires at least one notification filter");
+        }
+        self.shutdown_event_stream().await;
+        self.maybe_refresh_auth_token().await?;
+
+        let id = {
+            let mut next_id = self.next_id.lock().await;
+            let id = RequestId::Number(*next_id);
+            *next_id += 1;
+            id
+        };
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: id.clone(),
+            method: "subscriptions/listen".to_string(),
+            params: Some(
+                self.protocol_context
+                    .modern_request_params(Some(json!({ "notifications": filter })))?,
+            ),
+        };
+        let mut response = self.send_jsonrpc_request(&request, &[]).await?;
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED
+            && self.is_refreshable_profile().await
+        {
+            self.force_refresh_auth_token().await?;
+            response = self.send_jsonrpc_request(&request, &[]).await?;
+        }
+        let status = response.status();
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unable to read response body".to_string());
+            Self::map_http_error(status, &body, None)?;
+            unreachable!("map_http_error should always return an error");
+        }
+        let is_sse = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.to_ascii_lowercase().contains("text/event-stream"));
+        if !is_sse {
+            bail!("subscriptions/listen HTTP response must use text/event-stream");
+        }
+
+        *self.event_stream_error.lock().await = None;
+        *self.subscription_id.lock().await = Some(id.clone());
+        let notifications = self.notifications.clone();
+        let stream_error = self.event_stream_error.clone();
+        *self.event_stream_task.lock().await = Some(tokio::spawn(async move {
+            Self::run_streamable_event_reader(response, notifications, stream_error).await;
+        }));
+        Ok(id)
     }
 
     /// List available prompts
@@ -2587,6 +2651,13 @@ impl Drop for LegacySseTransport {
 }
 
 impl McpRemoteTransport {
+    pub fn protocol_era(&self) -> McpProtocolEra {
+        match self {
+            Self::Streamable(transport) => transport.protocol_context.era,
+            Self::Legacy(_) => McpProtocolEra::Legacy,
+        }
+    }
+
     pub fn with_auth(
         resolved: ResolvedMcpHttpTransport,
         auth_profile: Option<Profile>,
@@ -2691,6 +2762,13 @@ impl McpRemoteTransport {
         match self {
             Self::Streamable(transport) => transport.subscribe_resource(uri).await,
             Self::Legacy(transport) => transport.subscribe_resource(uri).await,
+        }
+    }
+
+    pub async fn start_subscription(&self, filter: SubscriptionFilter) -> Result<RequestId> {
+        match self {
+            Self::Streamable(transport) => transport.start_subscription(filter).await,
+            Self::Legacy(_) => bail!("subscriptions/listen requires modern MCP"),
         }
     }
 
@@ -3117,6 +3195,55 @@ mod tests {
             .read_resource("file:///tmp/example")
             .await
             .unwrap();
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn modern_subscription_listen_uses_request_scoped_sse() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .match_header("mcp-protocol-version", MCP_MODERN_PROTOCOL_VERSION)
+            .match_header("mcp-method", "subscriptions/listen")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "id": 1,
+                "method": "subscriptions/listen",
+                "params": {
+                    "notifications": {
+                        "toolsListChanged": true,
+                        "resourceSubscriptions": ["file:///tmp/example"]
+                    },
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": MCP_MODERN_PROTOCOL_VERSION
+                    }
+                }
+            })))
+            .with_status(200)
+            .with_header("content-type", "text/event-stream")
+            .with_body(
+                "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/subscriptions/acknowledged\",\"params\":{\"notifications\":{\"toolsListChanged\":true,\"resourceSubscriptions\":[\"file:///tmp/example\"]},\"_meta\":{\"io.modelcontextprotocol/subscriptionId\":1}}}\n\n",
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let transport = McpHttpTransport::with_auth_timeout_and_era(
+            server.url(),
+            None,
+            Duration::from_secs(5),
+            McpProtocolEra::Modern,
+        )
+        .unwrap();
+        let request_id = transport
+            .start_subscription(SubscriptionFilter {
+                toolsListChanged: Some(true),
+                resourceSubscriptions: Some(vec!["file:///tmp/example".to_string()]),
+                ..SubscriptionFilter::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(request_id, RequestId::Number(1));
         mock.assert_async().await;
     }
 

--- a/src/adapters/mcp/transport.rs
+++ b/src/adapters/mcp/transport.rs
@@ -268,6 +268,17 @@ struct OutboundMessage {
     message: String,
 }
 
+pub struct StdioLongLivedRequest {
+    request_id: RequestId,
+    response_rx: tokio::sync::oneshot::Receiver<JsonRpcResponse>,
+}
+
+impl StdioLongLivedRequest {
+    pub fn request_id(&self) -> &RequestId {
+        &self.request_id
+    }
+}
+
 impl McpStdioTransport {
     pub fn default_request_timeout() -> Duration {
         Duration::from_millis(DEFAULT_STDIO_REQUEST_TIMEOUT_MS)
@@ -507,55 +518,13 @@ impl McpStdioTransport {
         params: Option<JsonValue>,
         timeout: Duration,
     ) -> Result<JsonValue> {
-        // Get the next ID
-        let id = {
-            let mut id_guard = self.next_id.lock().await;
-            let id = *id_guard;
-            *id_guard += 1;
-            RequestId::Number(id)
-        };
-
-        let request = JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
-            id: id.clone(),
-            method: method.to_string(),
-            params,
-        };
-
-        let request_json = serde_json::to_string(&request)?;
-        tracing::debug!("Sending request: {}", request_json);
-
-        let request_tx = self
-            .request_tx
-            .as_ref()
-            .cloned()
-            .ok_or_else(|| anyhow!("Request channel closed"))?;
-
-        // Create a response channel
-        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
-
-        // Register request id -> response channel before sending the request
-        {
-            let mut channels = self.response_channels.lock().await;
-            channels.insert(id.clone(), response_tx);
-        }
-
-        // Send the request
-        if request_tx
-            .send(OutboundMessage {
-                request_id: Some(id.clone()),
-                message: request_json,
-            })
-            .is_err()
-        {
-            let mut channels = self.response_channels.lock().await;
-            channels.remove(&id);
-            return Err(anyhow!("Request channel closed"));
-        }
+        let StdioLongLivedRequest {
+            request_id: id,
+            mut response_rx,
+        } = self.start_long_lived_request(method, params).await?;
 
         // Wait for the response with timeout so a stuck MCP server/tool call
         // does not block the caller indefinitely.
-        let mut response_rx = response_rx;
         let response = match tokio::select! {
             biased;
             response = &mut response_rx => StdioRequestOutcome::Response(response),
@@ -602,6 +571,85 @@ impl McpStdioTransport {
             }
         };
 
+        Self::response_result(response)
+    }
+
+    pub async fn start_long_lived_request(
+        &mut self,
+        method: &str,
+        params: Option<JsonValue>,
+    ) -> Result<StdioLongLivedRequest> {
+        let id = {
+            let mut id_guard = self.next_id.lock().await;
+            let id = *id_guard;
+            *id_guard += 1;
+            RequestId::Number(id)
+        };
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: id.clone(),
+            method: method.to_string(),
+            params,
+        };
+        let request_json = serde_json::to_string(&request)?;
+        tracing::debug!("Sending request: {}", request_json);
+        let request_tx = self
+            .request_tx
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| anyhow!("Request channel closed"))?;
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        self.response_channels
+            .lock()
+            .await
+            .insert(id.clone(), response_tx);
+        if request_tx
+            .send(OutboundMessage {
+                request_id: Some(id.clone()),
+                message: request_json,
+            })
+            .is_err()
+        {
+            self.response_channels.lock().await.remove(&id);
+            return Err(anyhow!("Request channel closed"));
+        }
+        Ok(StdioLongLivedRequest {
+            request_id: id,
+            response_rx,
+        })
+    }
+
+    pub fn poll_long_lived_request(
+        request: &mut StdioLongLivedRequest,
+    ) -> Result<Option<JsonValue>> {
+        match request.response_rx.try_recv() {
+            Ok(response) => Self::response_result(response).map(Some),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => Ok(None),
+            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                Err(anyhow!("Response channel closed"))
+            }
+        }
+    }
+
+    pub async fn cancel_request(
+        &mut self,
+        request_id: &RequestId,
+        reason: Option<&str>,
+    ) -> Result<()> {
+        let mut params = serde_json::Map::new();
+        params.insert("requestId".to_string(), serde_json::to_value(request_id)?);
+        if let Some(reason) = reason {
+            params.insert("reason".to_string(), JsonValue::String(reason.to_string()));
+        }
+        self.send_notification("notifications/cancelled", Some(JsonValue::Object(params)))
+            .await
+    }
+
+    pub async fn forget_request(&self, request_id: &RequestId) {
+        self.response_channels.lock().await.remove(request_id);
+    }
+
+    fn response_result(response: JsonRpcResponse) -> Result<JsonValue> {
         if let Some(error) = response.error {
             return Err(structured_error_from_jsonrpc_error(
                 error.code,
@@ -611,7 +659,6 @@ impl McpStdioTransport {
             )
             .into());
         }
-
         response.result.context("No result in response")
     }
 

--- a/src/adapters/mcp/types.rs
+++ b/src/adapters/mcp/types.rs
@@ -49,6 +49,45 @@ pub enum RequestId {
     String(String),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct SubscriptionFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub toolsListChanged: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub promptsListChanged: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resourcesListChanged: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resourceSubscriptions: Option<Vec<String>>,
+}
+
+impl SubscriptionFilter {
+    pub fn is_empty(&self) -> bool {
+        !self.toolsListChanged.unwrap_or(false)
+            && !self.promptsListChanged.unwrap_or(false)
+            && !self.resourcesListChanged.unwrap_or(false)
+            && self
+                .resourceSubscriptions
+                .as_ref()
+                .is_none_or(Vec::is_empty)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SubscriptionsAcknowledgedParams {
+    pub notifications: SubscriptionFilter,
+    #[serde(rename = "_meta")]
+    pub meta: JsonValue,
+}
+
+impl SubscriptionsAcknowledgedParams {
+    pub fn subscription_id(&self) -> Option<RequestId> {
+        self.meta
+            .get("io.modelcontextprotocol/subscriptionId")
+            .and_then(|value| serde_json::from_value(value.clone()).ok())
+    }
+}
+
 /// JSON-RPC Error
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonRpcError {
@@ -715,6 +754,27 @@ mod tests {
         assert_eq!(
             params["_meta"]["io.modelcontextprotocol/clientCapabilities"],
             capabilities
+        );
+    }
+
+    #[test]
+    fn subscription_acknowledgement_parses_subscription_id_and_filter() {
+        let params: SubscriptionsAcknowledgedParams = serde_json::from_value(json!({
+            "notifications": {
+                "toolsListChanged": true,
+                "resourceSubscriptions": ["file:///tmp/example"]
+            },
+            "_meta": {
+                "io.modelcontextprotocol/subscriptionId": 7
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(params.subscription_id(), Some(RequestId::Number(7)));
+        assert_eq!(params.notifications.toolsListChanged, Some(true));
+        assert_eq!(
+            params.notifications.resourceSubscriptions,
+            Some(vec!["file:///tmp/example".to_string()])
         );
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -527,6 +527,57 @@ fn should_read_mcp_resource_snapshot(notification: &JsonRpcNotification) -> bool
     notification.method == "notifications/resources/updated"
 }
 
+fn desired_mcp_subscription_filter(
+    resource_subscriptions: &HashMap<String, usize>,
+) -> adapters::mcp::types::SubscriptionFilter {
+    let mut resource_uris = resource_subscriptions.keys().cloned().collect::<Vec<_>>();
+    resource_uris.sort();
+    adapters::mcp::types::SubscriptionFilter {
+        toolsListChanged: Some(true),
+        promptsListChanged: None,
+        resourcesListChanged: None,
+        resourceSubscriptions: (!resource_uris.is_empty()).then_some(resource_uris),
+    }
+}
+
+fn notification_subscription_id(
+    notification: &JsonRpcNotification,
+) -> Option<adapters::mcp::types::RequestId> {
+    notification
+        .params
+        .as_ref()?
+        .get("_meta")?
+        .get("io.modelcontextprotocol/subscriptionId")
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+}
+
+fn accept_subscription_notification(
+    notification: &JsonRpcNotification,
+    active_subscription_id: Option<&adapters::mcp::types::RequestId>,
+    acknowledged: &mut bool,
+) -> bool {
+    let Some(subscription_id) = notification_subscription_id(notification) else {
+        return true;
+    };
+    if active_subscription_id != Some(&subscription_id) {
+        return false;
+    }
+    if notification.method == "notifications/subscriptions/acknowledged" {
+        if serde_json::from_value::<adapters::mcp::types::SubscriptionsAcknowledgedParams>(
+            notification.params.clone().unwrap_or_default(),
+        )
+        .ok()
+        .and_then(|params| params.subscription_id())
+        .as_ref()
+            == active_subscription_id
+        {
+            *acknowledged = true;
+        }
+        return false;
+    }
+    *acknowledged
+}
+
 async fn append_mcp_resource_snapshot(
     recorder: &mut impl SubscriptionEventRecorder,
     reason: &str,
@@ -808,6 +859,8 @@ struct McpStdioSession {
     tools_dirty: bool,
     notifications: SessionNotificationFanout,
     resource_subscriptions: HashMap<String, usize>,
+    subscription_id: Option<adapters::mcp::types::RequestId>,
+    subscription_acknowledged: bool,
     last_used: Instant,
     last_used_at_unix: u64,
     idle_ttl_secs: u64,
@@ -853,6 +906,8 @@ struct McpHttpSession {
     notifications: Mutex<SessionNotificationFanout>,
     resource_subscriptions: Mutex<HashMap<String, usize>>,
     resource_subscription_ops: Mutex<()>,
+    subscription_id: Mutex<Option<adapters::mcp::types::RequestId>>,
+    subscription_acknowledged: Mutex<bool>,
     lookup_key: String,
     last_used: Mutex<Instant>,
 }
@@ -955,6 +1010,42 @@ struct ManagedSourceRuntimeStateSnapshot {
 }
 
 impl McpStdioSession {
+    fn desired_subscription_filter(&self) -> adapters::mcp::types::SubscriptionFilter {
+        desired_mcp_subscription_filter(&self.resource_subscriptions)
+    }
+
+    async fn restart_modern_subscription(&mut self) -> Result<()> {
+        if self.client.protocol_era() != adapters::mcp::types::McpProtocolEra::Modern {
+            return Ok(());
+        }
+        let request_id = self
+            .client
+            .start_subscription(self.desired_subscription_filter())
+            .await?;
+        self.subscription_id = Some(request_id);
+        self.subscription_acknowledged = false;
+        Ok(())
+    }
+
+    async fn ensure_modern_subscription(&mut self) -> Result<()> {
+        if self.client.protocol_era() != adapters::mcp::types::McpProtocolEra::Modern {
+            return Ok(());
+        }
+        match self.client.poll_subscription_closed() {
+            Ok(Some(_)) => self.restart_modern_subscription().await,
+            Ok(None) if self.subscription_id.is_some() => Ok(()),
+            Ok(None) => self.restart_modern_subscription().await,
+            Err(err) => {
+                tracing::warn!(
+                    endpoint = %self.endpoint,
+                    error = %err,
+                    "Modern MCP stdio subscription ended; reopening"
+                );
+                self.restart_modern_subscription().await
+            }
+        }
+    }
+
     fn apply_lifecycle_notification(&mut self, notification: &JsonRpcNotification) -> Result<bool> {
         if notification.method != "notifications/uxc.lifecycle_changed" {
             return Ok(false);
@@ -1011,6 +1102,13 @@ impl McpStdioSession {
     ) -> Vec<JsonRpcNotification> {
         let mut public_notifications = Vec::new();
         for notification in notifications {
+            if !accept_subscription_notification(
+                &notification,
+                self.subscription_id.as_ref(),
+                &mut self.subscription_acknowledged,
+            ) {
+                continue;
+            }
             if let Err(err) = self.apply_lifecycle_notification(&notification) {
                 tracing::warn!(endpoint = %endpoint, error = %err, "Failed to apply MCP lifecycle notification");
                 continue;
@@ -1035,6 +1133,13 @@ impl McpStdioSession {
         endpoint: &str,
         cache: Option<&Arc<dyn Cache>>,
     ) -> Vec<JsonRpcNotification> {
+        if let Err(err) = self.ensure_modern_subscription().await {
+            tracing::warn!(
+                endpoint = %endpoint,
+                error = %err,
+                "Failed to maintain modern MCP stdio subscription"
+            );
+        }
         let notifications = self.client.drain_notifications().await;
         self.record_notifications(notifications, endpoint, cache)
     }
@@ -1059,6 +1164,15 @@ impl McpStdioSession {
             *count = count.saturating_add(1);
             return Ok(());
         }
+        if self.client.protocol_era() == adapters::mcp::types::McpProtocolEra::Modern {
+            self.resource_subscriptions.insert(uri.to_string(), 1);
+            if let Err(err) = self.restart_modern_subscription().await {
+                self.resource_subscriptions.remove(uri);
+                return Err(err);
+            }
+            let _ = self.sync_notifications(endpoint, cache).await;
+            return Ok(());
+        }
         self.client.subscribe_resource(uri).await?;
         self.resource_subscriptions.insert(uri.to_string(), 1);
         let _ = self.sync_notifications(endpoint, cache).await;
@@ -1079,6 +1193,11 @@ impl McpStdioSession {
             return Ok(());
         }
         self.resource_subscriptions.remove(uri);
+        if self.client.protocol_era() == adapters::mcp::types::McpProtocolEra::Modern {
+            self.restart_modern_subscription().await?;
+            let _ = self.sync_notifications(endpoint, cache).await;
+            return Ok(());
+        }
         self.client.unsubscribe_resource(uri).await?;
         let _ = self.sync_notifications(endpoint, cache).await;
         Ok(())
@@ -1136,8 +1255,53 @@ impl SessionNotificationFanout {
 }
 
 impl McpHttpSession {
+    async fn desired_subscription_filter(&self) -> adapters::mcp::types::SubscriptionFilter {
+        let subscriptions = self.resource_subscriptions.lock().await;
+        desired_mcp_subscription_filter(&subscriptions)
+    }
+
+    async fn restart_modern_subscription(&self) -> Result<()> {
+        if self.transport.protocol_era() != adapters::mcp::types::McpProtocolEra::Modern {
+            return Ok(());
+        }
+        let request_id = self
+            .transport
+            .start_subscription(self.desired_subscription_filter().await)
+            .await?;
+        *self.subscription_id.lock().await = Some(request_id);
+        *self.subscription_acknowledged.lock().await = false;
+        self.notifications.lock().await.clear_stream_error();
+        Ok(())
+    }
+
+    async fn ensure_modern_subscription(&self) -> Result<()> {
+        if self.transport.protocol_era() != adapters::mcp::types::McpProtocolEra::Modern {
+            return Ok(());
+        }
+        let stream_error = self.transport.take_stream_error().await;
+        let needs_start = self.subscription_id.lock().await.is_none();
+        if stream_error.is_none() && !needs_start {
+            return Ok(());
+        }
+        let _op_guard = self.resource_subscription_ops.lock().await;
+        if let Some(err) = stream_error {
+            tracing::warn!(
+                endpoint = %self.lookup_key,
+                error = %err,
+                "Modern MCP HTTP subscription ended; reopening"
+            );
+        }
+        self.restart_modern_subscription().await
+    }
+
     async fn drain_pending_notifications(&self) -> Vec<JsonRpcNotification> {
-        if let Err(err) = self.transport.ensure_notification_stream().await {
+        let stream_result =
+            if self.transport.protocol_era() == adapters::mcp::types::McpProtocolEra::Modern {
+                self.ensure_modern_subscription().await
+            } else {
+                self.transport.ensure_notification_stream().await
+            };
+        if let Err(err) = stream_result {
             self.notifications
                 .lock()
                 .await
@@ -1149,9 +1313,30 @@ impl McpHttpSession {
 
     async fn collect_pending_notifications(&self) -> Vec<JsonRpcNotification> {
         if let Some(error) = self.transport.take_stream_error().await {
-            self.notifications.lock().await.set_stream_error(error);
+            if self.transport.protocol_era() == adapters::mcp::types::McpProtocolEra::Modern {
+                if let Err(restart_error) = self.restart_modern_subscription().await {
+                    self.notifications.lock().await.set_stream_error(format!(
+                        "{}; failed to reopen subscription: {}",
+                        error, restart_error
+                    ));
+                }
+            } else {
+                self.notifications.lock().await.set_stream_error(error);
+            }
         }
         let notifications = self.transport.drain_notifications().await;
+        let active_subscription_id = self.subscription_id.lock().await.clone();
+        let mut acknowledged = self.subscription_acknowledged.lock().await;
+        let notifications = notifications
+            .into_iter()
+            .filter(|notification| {
+                accept_subscription_notification(
+                    notification,
+                    active_subscription_id.as_ref(),
+                    &mut acknowledged,
+                )
+            })
+            .collect::<Vec<_>>();
         self.notifications
             .lock()
             .await
@@ -1174,6 +1359,16 @@ impl McpHttpSession {
         let mut subscriptions = self.resource_subscriptions.lock().await;
         if let Some(count) = subscriptions.get_mut(uri) {
             *count = count.saturating_add(1);
+            return Ok(());
+        }
+        if self.transport.protocol_era() == adapters::mcp::types::McpProtocolEra::Modern {
+            subscriptions.insert(uri.to_string(), 1);
+            drop(subscriptions);
+            if let Err(err) = self.restart_modern_subscription().await {
+                self.resource_subscriptions.lock().await.remove(uri);
+                return Err(err);
+            }
+            let _ = self.collect_pending_notifications().await;
             return Ok(());
         }
         drop(subscriptions);
@@ -1200,6 +1395,11 @@ impl McpHttpSession {
         subscriptions.remove(uri);
         let no_more_subscriptions = subscriptions.is_empty();
         drop(subscriptions);
+        if self.transport.protocol_era() == adapters::mcp::types::McpProtocolEra::Modern {
+            self.restart_modern_subscription().await?;
+            let _ = self.collect_pending_notifications().await;
+            return Ok(());
+        }
         let unsubscribe_result = self.transport.unsubscribe_resource(uri).await;
         if no_more_subscriptions {
             self.transport.shutdown_notification_stream().await;
@@ -1639,7 +1839,7 @@ impl McpSessionManager {
         let created_at_unix = now_unix_secs();
         let command_summary = command_summary_from_endpoint(metadata.endpoint);
         let child_pid = client.child_id();
-        let session = Arc::new(Mutex::new(McpStdioSession {
+        let mut session = McpStdioSession {
             child_pid,
             client,
             schema_cache_key: metadata.schema_cache_key.clone(),
@@ -1647,6 +1847,8 @@ impl McpSessionManager {
             tools_dirty: false,
             notifications: SessionNotificationFanout::default(),
             resource_subscriptions: HashMap::new(),
+            subscription_id: None,
+            subscription_acknowledged: false,
             last_used: Instant::now(),
             last_used_at_unix: created_at_unix,
             idle_ttl_secs: metadata
@@ -1663,7 +1865,9 @@ impl McpSessionManager {
             lifecycle_contract_fetch_state,
             last_lifecycle_update_at_unix: None,
             last_lifecycle_snapshot: None,
-        }));
+        };
+        session.restart_modern_subscription().await?;
+        let session = Arc::new(Mutex::new(session));
 
         {
             let mut map = self.stdio.lock().await;
@@ -2096,9 +2300,12 @@ impl McpSessionManager {
             notifications: Mutex::new(SessionNotificationFanout::default()),
             resource_subscriptions: Mutex::new(HashMap::new()),
             resource_subscription_ops: Mutex::new(()),
+            subscription_id: Mutex::new(None),
+            subscription_acknowledged: Mutex::new(false),
             lookup_key: lookup_key.to_string(),
             last_used: Mutex::new(Instant::now()),
         });
+        session.restart_modern_subscription().await?;
 
         {
             let mut map = self.http.lock().await;
@@ -6408,7 +6615,9 @@ async fn run_mcp_subscription_job(
         .await?;
     {
         let mut guard = session.lock().await;
-        if !guard.client.supports_resource_subscribe() {
+        if guard.client.protocol_era() == adapters::mcp::types::McpProtocolEra::Legacy
+            && !guard.client.supports_resource_subscribe()
+        {
             bail!("MCP server does not support resources.subscribe");
         }
         guard
@@ -9246,6 +9455,80 @@ mod tests {
                 "https://example.com/mcp".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn modern_mcp_subscription_filter_tracks_sorted_resource_uris() {
+        let subscriptions = HashMap::from([
+            ("file:///tmp/z".to_string(), 1),
+            ("file:///tmp/a".to_string(), 2),
+        ]);
+
+        let filter = desired_mcp_subscription_filter(&subscriptions);
+
+        assert_eq!(filter.toolsListChanged, Some(true));
+        assert_eq!(
+            filter.resourceSubscriptions,
+            Some(vec![
+                "file:///tmp/a".to_string(),
+                "file:///tmp/z".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn modern_mcp_subscription_notifications_wait_for_matching_ack() {
+        let active_id = adapters::mcp::types::RequestId::Number(7);
+        let notification = |method: &str, subscription_id: i64| JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: method.to_string(),
+            params: Some(json!({
+                "_meta": {
+                    "io.modelcontextprotocol/subscriptionId": subscription_id
+                }
+            })),
+        };
+        let acknowledgement = |subscription_id: i64| JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: "notifications/subscriptions/acknowledged".to_string(),
+            params: Some(json!({
+                "notifications": {
+                    "toolsListChanged": true
+                },
+                "_meta": {
+                    "io.modelcontextprotocol/subscriptionId": subscription_id
+                }
+            })),
+        };
+        let mut acknowledged = false;
+
+        assert!(!accept_subscription_notification(
+            &notification("notifications/tools/list_changed", 7),
+            Some(&active_id),
+            &mut acknowledged,
+        ));
+        assert!(!accept_subscription_notification(
+            &acknowledgement(8),
+            Some(&active_id),
+            &mut acknowledged,
+        ));
+        assert!(!acknowledged);
+        assert!(!accept_subscription_notification(
+            &acknowledgement(7),
+            Some(&active_id),
+            &mut acknowledged,
+        ));
+        assert!(acknowledged);
+        assert!(accept_subscription_notification(
+            &notification("notifications/tools/list_changed", 7),
+            Some(&active_id),
+            &mut acknowledged,
+        ));
+        assert!(!accept_subscription_notification(
+            &notification("notifications/tools/list_changed", 8),
+            Some(&active_id),
+            &mut acknowledged,
+        ));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1866,7 +1866,13 @@ impl McpSessionManager {
             last_lifecycle_update_at_unix: None,
             last_lifecycle_snapshot: None,
         };
-        session.restart_modern_subscription().await?;
+        if let Err(err) = session.restart_modern_subscription().await {
+            tracing::warn!(
+                endpoint = %session.endpoint,
+                error = %err,
+                "Initial modern MCP stdio subscription failed; will retry"
+            );
+        }
         let session = Arc::new(Mutex::new(session));
 
         {
@@ -2305,7 +2311,13 @@ impl McpSessionManager {
             lookup_key: lookup_key.to_string(),
             last_used: Mutex::new(Instant::now()),
         });
-        session.restart_modern_subscription().await?;
+        if let Err(err) = session.restart_modern_subscription().await {
+            tracing::warn!(
+                endpoint = %session.lookup_key,
+                error = %err,
+                "Initial modern MCP HTTP subscription failed; will retry"
+            );
+        }
 
         {
             let mut map = self.http.lock().await;


### PR DESCRIPTION
## What
Add MCP `2026-07-28` `subscriptions/listen` support across stdio, Streamable HTTP, and daemon-backed execution while preserving legacy subscription behavior.

## Why
Modern MCP replaces legacy resource subscribe/unsubscribe flows with a unified long-lived `subscriptions/listen` request. UXC needs transport-level streaming and daemon routing so modern and legacy servers remain usable through the same CLI contract.

## How
- model modern subscription filters, acknowledgement results, and subscription IDs
- keep stdio requests open while matching subscription notifications are received
- support request-scoped SSE responses for HTTP `subscriptions/listen`
- route daemon subscriptions through modern or legacy paths based on detected protocol era
- maintain desired filters across reconnects and acknowledge notifications on the correct protocol path

## Changes

- [x] Add modern MCP subscription request/result types
- [x] Add stdio and HTTP long-lived subscription transport support
- [x] Add daemon modern/legacy subscription routing, acknowledgements, and reconnect handling
- [x] Add targeted regression tests for transport and daemon behavior

## Testing

### Unit Tests
- [x] All existing tests pass
- [x] New tests added
- [x] `cargo test` passes

### Test Results
```bash
cargo fmt --all
cargo test --locked modern_mcp_subscription_ -- --nocapture
cargo test --locked modern_subscription_listen_uses_request_scoped_sse -- --exact --nocapture
cargo +1.91.1 clippy --locked --lib --bins -- -D warnings
target/debug/uxc daemon stop >/dev/null 2>&1 || true
cargo test --locked -- --test-threads=1
# 545 unit tests plus all integration and doc tests passed
```

## Checklist

- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings
- [x] All tests pass
- [x] Documentation not required for this implementation-only PR; MCP docs are planned for PR 5
- [x] Commit messages follow convention
- [x] PR title follows convention

## Breaking Changes

None. Legacy MCP subscriptions remain supported.

## Additional Notes

This is PR 4 of the ordered MCP `2026-07-28` compatibility series, following #428, #429, and #431.
