### PR TITLE
chore(release): bump version to 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-08-08
+
+### Added
+- MCP 2026-07-28 dual-era compatibility: protocol negotiation for stdio (#428), modern Streamable HTTP transport (#429), results pagination and cache with MRTR execution controls (#431), subscriptions/listen and daemon integration (#432), OAuth issuer (RFC 9207) hardening and conformance test harness (#433).
+- MCP documentation page covering protocol lifecycle, transport modes, and auth flows.
+
+### Fixed
+- Aligned Holon CI trigger configuration to match upstream workflow expectations (#430).
+
 ## [0.16.0] - 2026-07-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3227,7 +3227,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uxc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxc"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 authors = ["UXC Contributors"]
 description = "A unified CLI for discovering and invoking tools across OpenAPI, MCP, GraphQL, gRPC, and JSON-RPC"

--- a/packages/uxc-daemon-client/package.json
+++ b/packages/uxc-daemon-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holon-run/uxc-daemon-client",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Thin Node.js client for UXC daemon-backed operations",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

Version bump to 0.17.0 with CHANGELOG update for release.

## Why

v0.16.0 发布后，main 合并了 7 个 commit，核心变更为 MCP 2026-07-28 双时代兼容支持（新功能），属于 minor bump。

### Release Highlights

- **MCP 2026-07-28 dual-era compatibility**: protocol negotiation for stdio (#428), modern Streamable HTTP transport (#429), results pagination and cache with MRTR execution controls (#431), subscriptions/listen and daemon integration (#432), OAuth issuer (RFC 9207) hardening and conformance test harness (#433)
- **CI fix**: aligned Holon CI trigger configuration (#430)
- MCP documentation page covering protocol lifecycle, transport modes, and auth flows

## How

- Bump `Cargo.toml` and `Cargo.lock` to 0.17.0
- Bump `packages/uxc-daemon-client/package.json` to 0.17.0
- Add CHANGELOG entry for 0.17.0

## Testing

- `scripts/release-check.sh v0.17.0` passed: 548 Rust tests + 18 TypeScript tests all green
- `cargo clippy` clean
- `cargo build` clean
- `npm run build` (tsup) and `npm run test` (vitest) passed