### PR TITLE
docs: update install version to v0.17.0 and sync README/docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ bash install-uxc.sh
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.15.3
+curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.17.0
 ```
 
 Windows note: native Windows is no longer supported; run UXC through WSL.
@@ -317,6 +317,7 @@ See [the daemon API docs](https://uxc.holon.run/daemon/api/) for the daemon cont
 ## Docs Map
 
 - getting started: [https://uxc.holon.run/getting-started/](https://uxc.holon.run/getting-started/)
+- MCP protocol support: [https://uxc.holon.run/protocols/mcp/](https://uxc.holon.run/protocols/mcp/)
 - public no-key endpoints: [https://uxc.holon.run/reference/public-endpoints/](https://uxc.holon.run/reference/public-endpoints/)
 - auth secret sources: [https://uxc.holon.run/auth/secret-sources/](https://uxc.holon.run/auth/secret-sources/)
 - MCP HTTP OAuth: [https://uxc.holon.run/auth/oauth-mcp-http/](https://uxc.holon.run/auth/oauth-mcp-http/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,6 +108,7 @@ MCP-only workflow。
 - 默认返回稳定的 JSON 输出，文本输出为可选模式
 - 可复用的认证凭证和 endpoint binding
 - 面向常用 host 的快捷 link
+- 面向常见编辑器/客户端的 MCP 配置导入
 - daemon 驱动的会话复用和后台订阅
 - 用于本地集成的 TypeScript daemon client
 
@@ -208,7 +209,7 @@ bash install-uxc.sh
 安装指定版本：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.15.3
+curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.17.0
 ```
 
 Windows 说明：不再支持原生 Windows，请通过 WSL 运行 UXC。
@@ -310,6 +311,7 @@ daemon 合约见 [站点中的 daemon API 文档](https://uxc.holon.run/daemon/a
 ## 文档导航
 
 - 入门： [https://uxc.holon.run/getting-started/](https://uxc.holon.run/getting-started/)
+- MCP 协议支持： [https://uxc.holon.run/protocols/mcp/](https://uxc.holon.run/protocols/mcp/)
 - 免 API key 的公开 endpoint： [https://uxc.holon.run/reference/public-endpoints/](https://uxc.holon.run/reference/public-endpoints/)
 - auth secret 来源： [https://uxc.holon.run/auth/secret-sources/](https://uxc.holon.run/auth/secret-sources/)
 - MCP HTTP OAuth： [https://uxc.holon.run/auth/oauth-mcp-http/](https://uxc.holon.run/auth/oauth-mcp-http/)

--- a/docs/site/auth/index.md
+++ b/docs/site/auth/index.md
@@ -28,8 +28,10 @@ individual command.
 
 - [MCP HTTP OAuth](./oauth-mcp-http.md)
   This page summarizes OAuth support for MCP HTTP in UXC.
+  <!-- mdorigin:index kind=article -->
 
 - [Secret Sources](./secret-sources.md)
   UXC supports two layers of non-OAuth auth values:
+  <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/site/daemon/index.md
+++ b/docs/site/daemon/index.md
@@ -33,11 +33,14 @@ background subscriptions should stay outside one-off CLI processes.
 
 - [Daemon API](./api.md)
   UXC exposes a stable local daemon control plane over a Unix socket using `Content-Length` framed JSON-RPC 2.0.
+  <!-- mdorigin:index kind=article -->
 
 - [Logging and Troubleshooting](./logging.md)
   UXC uses structured logging through `tracing`. Logs go to `stderr` so JSON output on `stdout` remains machine-parseable.
+  <!-- mdorigin:index kind=article -->
 
 - [Run as a Managed Service](./service.md)
   Run `uxc` daemon under a service manager when runtime auth environment must stay stable across requests.
+  <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/site/getting-started/install.md
+++ b/docs/site/getting-started/install.md
@@ -16,7 +16,7 @@ curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.15.3
+curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.17.0
 ```
 
 ## Cargo

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -68,11 +68,24 @@ single-page overview.
 <!-- INDEX:START -->
 
 - [Auth](./auth/)
+  <!-- mdorigin:index kind=directory -->
+
 - [Daemon](./daemon/)
+  <!-- mdorigin:index kind=directory -->
+
 - [Ecosystem](./ecosystem/)
+  <!-- mdorigin:index kind=directory -->
+
 - [Getting Started](./getting-started/)
+  <!-- mdorigin:index kind=directory -->
+
 - [Protocols](./protocols/)
+  <!-- mdorigin:index kind=directory -->
+
 - [Reference](./reference/)
+  <!-- mdorigin:index kind=directory -->
+
 - [Skills](./skills/)
+  <!-- mdorigin:index kind=directory -->
 
 <!-- INDEX:END -->

--- a/docs/site/protocols/index.md
+++ b/docs/site/protocols/index.md
@@ -37,5 +37,6 @@ feel consistent across them.
 
 - [MCP](./mcp.md)
   UXC supports MCP servers over Streamable HTTP and stdio while preserving compatibility across the stateful and stateless protocol eras.
+  <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/site/reference/index.md
+++ b/docs/site/reference/index.md
@@ -24,8 +24,10 @@ These remain repository docs rather than public site pages:
 
 - [Public Endpoints](./public-endpoints.md)
   These endpoints are useful for protocol availability checks without API keys.
+  <!-- mdorigin:index kind=article -->
 
 - [Schema Mapping](./schema-mapping.md)
   Some services expose runtime APIs and OpenAPI schemas at different URLs.
+  <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/skills/README.md
+++ b/skills/README.md
@@ -98,188 +98,250 @@ notes, and maintenance logs.
 
 - [alchemy-openapi-skill](./alchemy-openapi-skill/)
   Operate Alchemy Prices API reads through UXC with a curated OpenAPI schema, path-templated API-key auth, and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [binance-spot-openapi-skill](./binance-spot-openapi-skill/)
   Operate Binance Spot market, account, and order APIs through UXC with a curated OpenAPI schema, Binance query signing, and separate mainnet/testnet link flows.
+  <!-- mdorigin:index kind=article -->
 
 - [binance-spot-websocket-skill](./binance-spot-websocket-skill/)
   Subscribe to Binance Spot public market streams through UXC raw WebSocket support for trades, book ticker, depth, and ticker events with stream-specific guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [binance-web3-openapi-skill](./binance-web3-openapi-skill/)
   Operate Binance Web3 public market and research APIs through UXC with a curated OpenAPI schema. Use when tasks need token search, token metadata/market snapshots, address holdings, rankings, token audit, or smart money signals on Binance Web3.
+  <!-- mdorigin:index kind=article -->
 
 - [birdeye-mcp-skill](./birdeye-mcp-skill/)
   Use Birdeye MCP through UXC for token market data, trending and discovery workflows, price monitoring, and DEX-related reads with help-first live tool discovery and API-key auth.
+  <!-- mdorigin:index kind=article -->
 
 - [bitget-openapi-skill](./bitget-openapi-skill/)
   Operate Bitget public exchange market APIs through UXC with a curated OpenAPI schema, market-first discovery, and explicit private-auth boundary notes.
+  <!-- mdorigin:index kind=article -->
 
 - [bitquery-graphql-skill](./bitquery-graphql-skill/)
   Use Bitquery GraphQL through UXC for onchain trades, transfers, token holder analysis, balances, and market structure queries across supported networks, with OAuth client_credentials authentication and query-first execution.
+  <!-- mdorigin:index kind=article -->
 
 - [blocknative-openapi-skill](./blocknative-openapi-skill/)
   Operate Blocknative gas intelligence APIs through UXC with a curated OpenAPI schema, API-key auth, and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [blockscout-openapi-skill](./blockscout-openapi-skill/)
   Operate Blockscout explorer reads through UXC with a curated OpenAPI schema, instance-specific host selection, and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [bybit-openapi-skill](./bybit-openapi-skill/)
   Operate Bybit V5 public market APIs through UXC with a curated OpenAPI schema, market-first discovery, and explicit private-auth boundary notes.
+  <!-- mdorigin:index kind=article -->
 
 - [chainbase-openapi-skill](./chainbase-openapi-skill/)
   Operate Chainbase indexed wallet and token reads through UXC with a curated OpenAPI schema, API-key auth, and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [chrome-devtools-mcp-skill](./chrome-devtools-mcp-skill/)
   Use Chrome DevTools MCP through UXC over local stdio for page navigation, DOM/a11y snapshots, network inspection, console inspection, and performance tooling, with a live-browser autoConnect default and optional browserUrl or isolated fallback modes.
+  <!-- mdorigin:index kind=article -->
 
 - [coinapi-openapi-skill](./coinapi-openapi-skill/)
   Operate CoinAPI market data reads through UXC with a curated OpenAPI schema, API-key auth, and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [coinbase-openapi-skill](./coinbase-openapi-skill/)
   Operate Coinbase Advanced Trade REST APIs through UXC with a curated OpenAPI schema, products-first discovery, and explicit JWT bearer auth guidance.
+  <!-- mdorigin:index kind=article -->
 
 - [coingecko-openapi-skill](./coingecko-openapi-skill/)
   Operate CoinGecko and GeckoTerminal market data APIs through UXC with a curated OpenAPI schema, API-key auth, and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [coinmarketcap-mcp-skill](./coinmarketcap-mcp-skill/)
   Use CoinMarketCap MCP through UXC for crypto market quotes, technical analysis, on-chain metrics, global market overview, narratives, macro events, news, and semantic search with help-first schema inspection and API-key auth.
+  <!-- mdorigin:index kind=article -->
 
 - [context7-mcp-skill](./context7-mcp-skill/)
   Query up-to-date library documentation and code examples using Context7 MCP. Use when you need current, version-specific documentation for npm packages, Python libraries, or other programming languages.
+  <!-- mdorigin:index kind=article -->
 
 - [crypto-com-mcp-skill](./crypto-com-mcp-skill/)
   Use Crypto.com MCP through UXC for exchange market data workflows with help-first discovery and read-only guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [deepwiki-mcp-skill](./deepwiki-mcp-skill/)
   Ask questions and read documentation about any GitHub repository using DeepWiki MCP. Use when you need to understand a codebase, find specific APIs, or get context about a repository.
+  <!-- mdorigin:index kind=article -->
 
 - [defillama-openapi-skill](./defillama-openapi-skill/)
   Operate DefiLlama public analytics APIs through UXC with a curated OpenAPI schema and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [defillama-prices-openapi-skill](./defillama-prices-openapi-skill/)
   Operate DefiLlama public price APIs through UXC with a curated OpenAPI schema and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [defillama-pro-openapi-skill](./defillama-pro-openapi-skill/)
   Operate DefiLlama Pro analytics APIs through UXC with a curated OpenAPI schema, path-templated API-key auth, and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [defillama-yields-openapi-skill](./defillama-yields-openapi-skill/)
   Operate DefiLlama public yield APIs through UXC with a curated OpenAPI schema and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [dexscreener-openapi-skill](./dexscreener-openapi-skill/)
   Operate DexScreener public market data APIs through UXC with a curated OpenAPI schema, no-auth setup, and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [dingtalk-openapi-skill](./dingtalk-openapi-skill/)
   Operate DingTalk messaging APIs through UXC with a curated OpenAPI schema, app-token bearer auth, and robot/service-group guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [discord-openapi-skill](./discord-openapi-skill/)
   Operate Discord HTTP API through UXC with Discord OpenAPI schema. Bot token recommended for full API access including messages and server management. OAuth2 user authentication available for limited profile operations only.
-
-- [github-openapi-skill](./github-openapi-skill/)
-  Operate GitHub REST API through UXC with the official OpenAPI schema, explicit gh-to-uxc auth import, and read-first guardrails for repo, issue, pull request, and event workflows.
+  <!-- mdorigin:index kind=article -->
 
 - [dune-mcp-skill](./dune-mcp-skill/)
   Use Dune MCP through UXC for blockchain table discovery, SQL query creation/execution, execution result retrieval, and visualization with help-first schema inspection, explicit auth binding, and guarded credit-consuming operations.
+  <!-- mdorigin:index kind=article -->
 
 - [ethereum-jsonrpc-skill](./ethereum-jsonrpc-skill/)
   Operate Ethereum execution JSON-RPC through UXC with the official execution OpenRPC schema, public EVM read methods, and eth_subscribe pubsub guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [etherscan-mcp-skill](./etherscan-mcp-skill/)
   Use Etherscan MCP through UXC for address balance checks, token holder analysis, transaction inspection, and contract lookup tasks. Use when tasks need Etherscan MCP tools for onchain investigation with help-first schema inspection, bearer-key auth, and tier-aware read-first handling.
+  <!-- mdorigin:index kind=article -->
 
 - [feishu-openapi-skill](./feishu-openapi-skill/)
   Operate Feishu or Lark IM APIs through UXC with a curated OpenAPI schema, tenant-token bearer auth, and chat/message guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [gate-mcp-skill](./gate-mcp-skill/)
   Use Gate MCP through UXC for public spot and futures market data workflows with a fixed streamable-http endpoint and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
+
+- [github-openapi-skill](./github-openapi-skill/)
+  Operate GitHub REST API through UXC with the official OpenAPI schema, explicit gh-to-uxc auth import, and read-first guardrails for repo, issue, pull request, and event workflows.
+  <!-- mdorigin:index kind=article -->
 
 - [goldrush-mcp-skill](./goldrush-mcp-skill/)
   Use GoldRush MCP through UXC for multichain wallet balances, transfers, portfolio history, NFT ownership, token approvals, prices, and chain metadata via stdio MCP with injected API-key auth.
+  <!-- mdorigin:index kind=article -->
 
 - [helius-openapi-skill](./helius-openapi-skill/)
   Operate Helius Wallet API reads through UXC with a curated OpenAPI schema, API-key auth, and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [hive-mcp-skill](./hive-mcp-skill/)
   Use Hive Intelligence MCP through UXC for broad crypto market, onchain, portfolio, and risk workflows with help-first discovery and convenience-layer guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [kraken-openapi-skill](./kraken-openapi-skill/)
   Operate Kraken public market APIs through UXC with a curated OpenAPI schema, market-first discovery, and explicit private-auth boundary notes.
+  <!-- mdorigin:index kind=article -->
 
 - [kucoin-openapi-skill](./kucoin-openapi-skill/)
   Operate KuCoin public exchange market APIs through UXC with a curated OpenAPI schema, market-first discovery, and explicit private-auth boundary notes.
+  <!-- mdorigin:index kind=article -->
 
 - [lifi-mcp-skill](./lifi-mcp-skill/)
   Use the LI.FI MCP server through UXC for cross-chain route discovery, bridge/DEX availability checks, token and chain lookup, gas/balance/allowance checks, quote generation, and transfer status tracking. Use when tasks involve planning or monitoring cross-chain swaps and bridges without signing or broadcasting transactions.
+  <!-- mdorigin:index kind=article -->
 
 - [line-openapi-skill](./line-openapi-skill/)
   Operate LINE Messaging API through UXC with a curated OpenAPI schema, bearer-token auth, and messaging-core guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [linear-graphql-skill](./linear-graphql-skill/)
   Operate Linear workspace issues, projects, and teams through Linear GraphQL API using UXC. Use when tasks require querying or creating issues, managing projects, or interacting with Linear workflow. Supports both Personal API Key and OAuth authentication.
+  <!-- mdorigin:index kind=article -->
 
 - [matrix-openapi-skill](./matrix-openapi-skill/)
   Operate Matrix Client-Server API through UXC with a curated OpenAPI schema, bearer-token auth, and homeserver-aware messaging guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [mempool-space-openapi-skill](./mempool-space-openapi-skill/)
   Operate mempool.space public Bitcoin and Lightning explorer APIs through UXC with a curated OpenAPI schema, no-auth setup, and read-first guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [mexc-openapi-skill](./mexc-openapi-skill/)
   Operate MEXC Spot REST APIs through UXC with a curated OpenAPI schema, HMAC query signing, and separate public/signed workflow guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [moralis-openapi-skill](./moralis-openapi-skill/)
   Operate Moralis EVM wallet and token reads through UXC with a curated OpenAPI schema, API-key auth, and wallet-intelligence guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [near-jsonrpc-skill](./near-jsonrpc-skill/)
   Operate NEAR JSON-RPC reads through UXC with a public provider default, provider-override guidance, and read-only guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [nodit-openapi-skill](./nodit-openapi-skill/)
   Operate Nodit Web3 Data API reads through UXC with a curated OpenAPI schema, API-key auth, and overlap-aware guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [notion-mcp-skill](./notion-mcp-skill/)
   Operate Notion workspace content through Notion MCP using the UXC CLI, including search, fetch, users/teams lookup, page/database creation and updates, and comments. Use when tasks require calling Notion tools over MCP with OAuth (authorization_code + PKCE), especially when safe write controls and JSON-envelope parsing are required.
+  <!-- mdorigin:index kind=article -->
 
 - [notion-openapi-skill](./notion-openapi-skill/)
   Operate Notion Public API through UXC with a curated OpenAPI schema for search, block traversal, page reads, content writes, and data source/database inspection. Use when tasks need recursive reads or structured writes that Notion MCP does not expose directly.
+  <!-- mdorigin:index kind=article -->
 
 - [okx-exchange-websocket-skill](./okx-exchange-websocket-skill/)
   Subscribe to OKX public exchange WebSocket channels through UXC raw WebSocket mode for ticker, trade, book, and candle events with explicit subscribe frames.
+  <!-- mdorigin:index kind=article -->
 
 - [okx-mcp-skill](./okx-mcp-skill/)
   Use OKX OnchainOS MCP through UXC for token discovery, market data, wallet balance, and swap execution planning. Use when tasks need OKX MCP tools such as token search/ranking/holder, price/trades/candlesticks/index, balance queries, and DEX quote/swap flows with help-first schema inspection and safe auth handling.
+  <!-- mdorigin:index kind=article -->
 
 - [playwright-mcp-skill](./playwright-mcp-skill/)
   Run browser automation through @playwright/mcp over UXC stdio MCP, with daemon-friendly session reuse and safe action guardrails. Use when tasks need deterministic page navigation, DOM snapshots, and scripted browser interaction from CLI.
+  <!-- mdorigin:index kind=article -->
 
 - [qmd-mcp-skill](./qmd-mcp-skill/)
   Use a local QMD knowledge base through UXC over MCP stdio, with daemon-backed session reuse and typed retrieval flows that avoid repeated model warmup and unnecessary query-expansion latency.
+  <!-- mdorigin:index kind=article -->
 
 - [slack-openapi-skill](./slack-openapi-skill/)
   Operate Slack Web API through UXC with a curated OpenAPI schema, bearer-token auth, and messaging-core guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [sui-jsonrpc-skill](./sui-jsonrpc-skill/)
   Operate Sui public JSON-RPC through UXC with OpenRPC-driven discovery, mainnet fullnode defaults, and read-only query plus pubsub subscription guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [telegram-openapi-skill](./telegram-openapi-skill/)
   Operate Telegram Bot API through UXC with a curated OpenAPI schema, bot-token path auth, polling-based reads, and webhook management guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [thegraph-mcp-skill](./thegraph-mcp-skill/)
   Use The Graph Subgraph MCP through UXC via native SSE with a fixed linked command for subgraph discovery, schema retrieval, deployment selection, and GraphQL query execution with help-first inspection and explicit auth handling.
+  <!-- mdorigin:index kind=article -->
 
 - [thegraph-token-mcp-skill](./thegraph-token-mcp-skill/)
   Use The Graph Token API MCP through UXC for token metadata, wallet balances, transfers, holders, pools, and market data with help-first inspection and Token API specific JWT bearer auth binding.
+  <!-- mdorigin:index kind=article -->
 
 - [upbit-openapi-skill](./upbit-openapi-skill/)
   Operate Upbit public exchange market APIs through UXC with a curated OpenAPI schema, market-first discovery, and explicit private-auth boundary notes.
+  <!-- mdorigin:index kind=article -->
 
 - [uxc](./uxc/)
   Discover and call remote schema-exposed interfaces with UXC. Use when an agent or skill needs to list operations, inspect operation schemas, and execute OpenAPI, GraphQL, gRPC, MCP, or JSON-RPC calls via one CLI contract.
+  <!-- mdorigin:index kind=article -->
 
 - [uxc-skill-creator](./uxc-skill-creator/)
   Create wrapper skills that call remote tools through UXC. Use when defining a new provider skill and you need reusable templates, validation rules, and anti-pattern guidance based on proven UXC skill practices.
+  <!-- mdorigin:index kind=article -->
 
 - [whatsapp-openapi-skill](./whatsapp-openapi-skill/)
   Operate WhatsApp Business Platform Cloud API through UXC with a curated OpenAPI schema, bearer-token auth, and message/profile guardrails.
+  <!-- mdorigin:index kind=article -->
 
 - [x-openapi-skill](./x-openapi-skill/)
   Operate X API v2 through UXC with the official OpenAPI schema, OAuth2 PKCE user-context auth, app-only bearer guidance, and read-first guardrails for timeline/bookmark/post workflows.
+  <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->


### PR DESCRIPTION
## What

Post-release documentation cleanup for v0.17.0.

## Why

After the v0.17.0 release, several documentation files still referenced the old version number (v0.15.3) and had minor content gaps between the English and Chinese README.

## How

- Updated install/version references from v0.15.3 → v0.17.0 in `README.md`, `README.zh-CN.md`, and `docs/site/getting-started/install.md`
- Added the missing "MCP config import for common editors/clients" line in `README.zh-CN.md` (already present in English version)
- Added MCP protocol page link to the Docs Map in both `README.md` and `README.zh-CN.md`
- Ran `npm run docs:index` to regenerate section indexes and `skills/README.md`

## Testing

Documentation-only changes (Markdown). No Rust code affected.

## Closes

N/A