### PR TITLE
docs(email): document email source and attachments

### DIFF
--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -34,6 +34,7 @@ uxc petstore3.swagger.io/api/v3 get:/pet/{petId} petId=1
 - [Protocols](./protocols/)
 - [Auth](./auth/)
 - [Daemon](./daemon/)
+- [Sources](./sources/)
 - [Ecosystem](./ecosystem/)
 - [Reference](./reference/)
 - [Skills Directory](./skills/)
@@ -86,6 +87,9 @@ single-page overview.
   <!-- mdorigin:index kind=directory -->
 
 - [Skills](./skills/)
+  <!-- mdorigin:index kind=directory -->
+
+- [Sources](./sources/)
   <!-- mdorigin:index kind=directory -->
 
 <!-- INDEX:END -->

--- a/docs/site/sources/email-attachments.md
+++ b/docs/site/sources/email-attachments.md
@@ -1,0 +1,145 @@
+# Email Attachments
+
+`email_event` messages expose provider-neutral attachment metadata plus an
+opaque retrieval handle. Events never inline attachment bytes; use
+`uxc email attachment get` to download content on demand.
+
+## Attachment Metadata
+
+Each entry under `message.attachments` carries:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | Provider part/attachment id (IMAP section number, Gmail/Graph attachment id, JMAP part id) |
+| `filename` | string \| null | Decoded from RFC 2047 / RFC 2231 forms; `null` when absent |
+| `content_type` | string \| null | MIME type of the part |
+| `size` | number \| null | Decoded byte size when known |
+| `disposition` | string \| null | `attachment`, `inline`, or `null` |
+| `content_id` | string \| null | Content-ID for inline HTML resources |
+| `handle` | object | Opaque retrieval handle for lazy download |
+
+A part counts as an attachment when:
+
+- it carries `Content-Disposition: attachment`, or
+- it is `inline` with a filename or Content-ID, or
+- it is a non-text part (for example unnamed `application/octet-stream`)
+  outside the `multipart/alternative` body.
+
+Plain `text/plain` and `text/html` alternatives of the message body are never
+attachments.
+
+## Provider Notes
+
+| Provider | Mapping |
+| --- | --- |
+| IMAP | Parsed from the raw MIME tree; `id` is the RFC 3501 section number |
+| Gmail | Recursed over `payload.parts`; `id` is the `body.attachmentId` |
+| Microsoft Graph | Mapped from `attachments[]`; requires `$expand=attachments` on the poll endpoint |
+| JMAP | Mapped from `attachments[]` (`partId`, `blobId`, `type`, `size`) |
+
+Fields a provider does not report stay `null`; the original provider JSON is
+preserved verbatim under `raw.provider_payload`.
+
+### Microsoft Graph Without Expansion
+
+Graph list endpoints do not return attachment metadata by default. When the
+poll endpoint lacks `$expand=attachments` but the message reports
+`hasAttachments: true`, the event keeps the provider's signal without
+inventing metadata:
+
+```json
+{
+  "attachments": [],
+  "has_attachments": true,
+  "attachment_count": null
+}
+```
+
+`attachment_count: null` means "the provider says attachments exist but their
+metadata was not expanded", as opposed to `0` for a message without
+attachments. Consumers that need per-attachment entries should subscribe with
+`$expand=attachments`.
+
+## Retrieval Handles
+
+`handle` objects are credential-free. They reference an auth profile by name,
+and that profile is re-resolved from the local auth store at download time:
+
+```json
+{
+  "type": "email_attachment",
+  "provider": "gmail",
+  "endpoint": "https://gmail.googleapis.com/gmail/v1/users/me/messages",
+  "account": "user@example.com",
+  "mailbox": "INBOX",
+  "message_id": "<msg@example.com>",
+  "uid": "18c2f4a9e3b1d000",
+  "auth_profile": "gmail-primary",
+  "part": { "attachment_id": "ANGjdJ_..." }
+}
+```
+
+The `part` field is provider-specific: IMAP uses `{"section": "2.1"}` (plus
+`uidvalidity` guarding against stale UIDs), Gmail and Graph use
+`{"attachment_id": "..."}`, and JMAP uses `{"blob_id": "..."}`.
+
+Treat handles as opaque values: copy them from the event and pass them back
+to UXC. Do not parse or construct them by hand; the fields above are
+documented for transparency only.
+
+## Lazy Download
+
+```bash
+uxc email attachment get --handle '{"type":"email_attachment", ...}'
+uxc email attachment get --handle @handle.json --output ./report.pdf
+```
+
+| Option | Description |
+| --- | --- |
+| `--handle <json\|@file>` | The `attachments[].handle` object from an `email_event`, or a file containing it |
+| `--profile <name>` | Auth profile override; takes precedence over the handle reference |
+| `--output <path>` | Explicit output path; defaults to a cache path under `~/.uxc/email-attachments/` |
+| `--max-bytes <n>` | Reject larger attachments; defaults to 25 MiB, `0` disables the limit |
+
+Successful downloads return a `kind=email_attachment_get_result` envelope:
+
+```json
+{
+  "ok": true,
+  "kind": "email_attachment_get_result",
+  "data": {
+    "provider": "gmail",
+    "account": "user@example.com",
+    "message_id": "<msg@example.com>",
+    "attachment_id": "ANGjdJ_...",
+    "filename": "report.pdf",
+    "content_type": "application/pdf",
+    "size_bytes": 102400,
+    "sha256": "9f2b...",
+    "saved_path": "/home/user/.uxc/email-attachments/report.pdf"
+  }
+}
+```
+
+Content is always written to a file; it is never inlined into the JSON
+envelope. The response includes `sha256` and `size_bytes` so callers can
+verify the download.
+
+## Errors
+
+| Code | Meaning |
+| --- | --- |
+| `invalid_attachment_handle` | The handle is not valid JSON, has the wrong `type`, or misses required provider fields |
+| `attachment_not_found` | The provider no longer has the referenced attachment |
+| `message_not_found` | The referenced message no longer exists |
+| `uid_invalid` | IMAP mailbox `UIDVALIDITY` changed since the event; re-fetch the message |
+| `auth_profile_missing` | The referenced auth profile is absent from the local store |
+| `auth_failed` | The provider rejected the re-resolved credentials |
+| `size_limit_exceeded` | The attachment exceeds `--max-bytes` |
+| `provider_request_failed` | The provider request itself failed |
+
+## Compatibility
+
+Messages without attachments keep `attachments: []`,
+`has_attachments: false`, and `attachment_count: 0`, so existing
+`email_event` consumers are unaffected by attachment support.

--- a/docs/site/sources/email.md
+++ b/docs/site/sources/email.md
@@ -1,0 +1,133 @@
+# Email
+
+UXC exposes email as an event source plus direct outbound commands. Inbound
+messages stream into daemon-backed subscriptions as normalized `email_event`
+envelopes; replies and new mail go out through `uxc email send` and
+`uxc email reply` over SMTP.
+
+## Inbound Subscriptions
+
+Two transports cover self-hosted IMAP mailboxes and hosted providers:
+
+| Transport | Mode | Target | Example endpoint |
+| --- | --- | --- | --- |
+| `email-imap-idle` | `stream` | Any IMAP server with IDLE | `imaps://imap.example.com:993` |
+| `email-provider-poll` | `poll` | Gmail, Microsoft Graph, or JMAP HTTP APIs | `https://gmail.googleapis.com/gmail/v1/users/me/messages` |
+
+### IMAP IDLE
+
+```bash
+uxc source ensure agentinbox email:primary imaps://imap.example.com:993 \
+  --transport email-imap-idle \
+  --auth email-primary mailbox=INBOX
+```
+
+The subscription holds the connection open with IMAP IDLE and emits one
+`email_event` per newly seen message. Credentials come from the referenced
+auth profile (`--auth email-primary`); store the IMAP username and password in
+that profile with your preferred auth mechanism.
+
+### Provider Polling
+
+```bash
+uxc source ensure agentinbox gmail:primary \
+  https://gmail.googleapis.com/gmail/v1/users/me/messages \
+  --transport email-provider-poll --mode poll \
+  --auth gmail-primary provider=gmail
+```
+
+`provider=gmail|graph|jmap` selects the normalization path. The endpoint must
+return the provider's message-list JSON, so UXC can map it onto the same
+`email_event` envelope:
+
+| Provider | Endpoint example | Response shape |
+| --- | --- | --- |
+| Gmail | `https://gmail.googleapis.com/gmail/v1/users/me/messages` | `messages` array |
+| Microsoft Graph | `https://graph.microsoft.com/v1.0/me/messages?$expand=attachments` | `value` array |
+| JMAP | JMAP API endpoint returning `Email/get` results | `list` array |
+
+Microsoft Graph only returns attachment metadata when the endpoint includes
+`$expand=attachments`; see [Email Attachments](./email-attachments.md) for the
+partial-metadata semantics.
+
+## Event Envelope
+
+Every transport emits the same envelope shape:
+
+```json
+{
+  "type": "email_event",
+  "version": "v1",
+  "provider": "imap",
+  "account": "user@example.com",
+  "mailbox": "INBOX",
+  "event_kind": "message_received",
+  "message": {
+    "uid": "42",
+    "message_id": "<msg@example.com>",
+    "thread_id": null,
+    "from": "sender@example.com",
+    "to": ["user@example.com"],
+    "subject": "Quarterly report",
+    "date": "Mon, 07 Sep 2026 12:00:00 +0000",
+    "snippet": "Please review the attached report...",
+    "attachments": [],
+    "has_attachments": false,
+    "attachment_count": 0,
+    "flags": []
+  },
+  "raw": {
+    "mime_inline": null,
+    "mime_truncated": true,
+    "size_bytes": 204800
+  },
+  "reply_handle": {
+    "type": "email_imap",
+    "provider": "imap",
+    "account": "user@example.com",
+    "mailbox": "INBOX",
+    "message_id": "<msg@example.com>",
+    "uid": "42"
+  }
+}
+```
+
+Provider-polled events use `provider: "gmail" | "graph" | "jmap"`, keep the
+provider's original JSON under `raw.provider_payload`, and stamp a
+`reply_handle` of type `email_provider`.
+
+| Field | Notes |
+| --- | --- |
+| `message.attachments` | Neutral attachment metadata plus retrieval handles; see [Email Attachments](./email-attachments.md) |
+| `message.has_attachments` | `true` when the message has (or the provider reports) attachments |
+| `raw.mime_inline` | Raw MIME text inlined when the message is small enough; `null` otherwise |
+| `raw.provider_payload` | Original provider JSON for polled sources |
+| `reply_handle` | Opaque handle consumed by `uxc email reply --reply-handle` |
+
+## Outbound Mail
+
+Send a new message:
+
+```bash
+uxc email send --smtp smtp://localhost:2525 \
+  --from bot@example.com --to user@example.com \
+  --subject 'Hello' --text-body 'Hi'
+```
+
+Reply to a received event using its `reply_handle`:
+
+```bash
+uxc email reply --smtp smtp://localhost:2525 \
+  --reply-handle '{"message_id":"<msg@example.com>"}' \
+  --from bot@example.com --to user@example.com \
+  --subject 'Re: Quarterly report' --text-body 'Thanks'
+```
+
+Notes:
+
+- Use `--auth` with credentials containing `username`/`user`/`account` and
+  `password`/`secret` fields when SMTP AUTH is required.
+- SMTP AUTH over cleartext `smtp://` requires explicit
+  `--allow-insecure-auth`; prefer a trusted local relay until
+  STARTTLS/TLS is supported.
+- Add `--dry-run` to preview a message without delivering it.

--- a/docs/site/sources/index.md
+++ b/docs/site/sources/index.md
@@ -1,0 +1,22 @@
+# Sources
+
+Inbound event sources turn external systems into daemon-backed subscription
+streams. UXC normalizes each provider into a typed event envelope so agents
+and scripts consume one stable shape per system.
+
+## Available Sources
+
+- [Email](./email.md) — IMAP IDLE and Gmail, Microsoft Graph, and JMAP provider polling, plus SMTP send and reply
+- [Email Attachments](./email-attachments.md) — provider-neutral attachment metadata and lazy downloads
+
+<!-- INDEX:START -->
+
+- [Email](./email.md)
+  UXC exposes email as an event source plus direct outbound commands. Inbound messages stream into daemon-backed subscriptions as normalized `email_event` envelopes; replies and new mail go out through `uxc email send` and `uxc email reply` over SMTP.
+  <!-- mdorigin:index kind=article -->
+
+- [Email Attachments](./email-attachments.md)
+  `email_event` messages expose provider-neutral attachment metadata plus an opaque retrieval handle. Events never inline attachment bytes; use `uxc email attachment get` to download content on demand.
+  <!-- mdorigin:index kind=article -->
+
+<!-- INDEX:END -->


### PR DESCRIPTION
## What

Adds the first `docs/site/sources/` section covering the email source:

- `docs/site/sources/email.md` — inbound subscriptions (`email-imap-idle` stream + `email-provider-poll` with Gmail/Graph/JMAP), the normalized `email_event` v1 envelope, and outbound `uxc email send` / `uxc email reply`.
- `docs/site/sources/email-attachments.md` — provider-neutral attachment metadata fields and detection rules, provider mapping notes (including the Microsoft Graph `$expand=attachments` requirement and the `has_attachments: true` + `attachment_count: null` unexpanded semantics), credential-free retrieval handles, `uxc email attachment get` usage with the result envelope, error codes, and backward compatibility.
- `docs/site/sources/index.md` plus a Sources link from the docs homepage; indexes regenerated with `npm run docs:index`.

## Why

Issue #436 delivered email attachment metadata and lazy retrieval across PRs #437, #439, and #440, but `docs/site` had no email documentation at all. This closes the delivery plan's final step and gives users an accurate reference for both the event contract and the new attachment CLI.

## How

- Documents the real CLI contract from source (`email attachment get --handle <json|@file> [--profile] [--output] [--max-bytes]`, default 25 MiB guard, `~/.uxc/email-attachments/` cache path, `kind=email_attachment_get_result` envelope with `sha256`/`size_bytes`).
- Documents handle opacity: no credentials, auth profile re-resolved at retrieval time.
- Tables follow existing docs-site style; no code changes.

## Testing

- `npm run docs:index` — updated 9 index files, generated `sources/` entries.
- `npm run docs:build` — passes (local search build skips the native addon as before; CI builds it).

Closes #436