### PR TITLE
chore(release): bump version to 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-09-08
+
+### Added
+- Email support: MIME attachment metadata parsing for IMAP events with RFC 2047/2231 filename decoding (#437).
+- Email support: provider-neutral attachment metadata mapping for Gmail, Microsoft Graph, and JMAP sources (#439).
+- Email support: `uxc email attachment get` for lazy attachment retrieval with a 25 MiB default size guardrail (#440).
+- Email documentation covering email sources and attachments (#441).
+
 ## [0.17.0] - 2026-08-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3227,7 +3227,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uxc"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxc"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 authors = ["UXC Contributors"]
 description = "A unified CLI for discovering and invoking tools across OpenAPI, MCP, GraphQL, gRPC, and JSON-RPC"

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ bash install-uxc.sh
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.17.0
+curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.18.0
 ```
 
 Windows note: native Windows is no longer supported; run UXC through WSL.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -209,7 +209,7 @@ bash install-uxc.sh
 安装指定版本：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.17.0
+curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.18.0
 ```
 
 Windows 说明：不再支持原生 Windows，请通过 WSL 运行 UXC。

--- a/docs/site/getting-started/install.md
+++ b/docs/site/getting-started/install.md
@@ -16,7 +16,7 @@ curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.17.0
+curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.18.0
 ```
 
 ## Cargo

--- a/packages/uxc-daemon-client/package.json
+++ b/packages/uxc-daemon-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holon-run/uxc-daemon-client",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Thin Node.js client for UXC daemon-backed operations",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

Release UXC v0.18.0:

- Bump crate version to `0.18.0` (`Cargo.toml`, `Cargo.lock`)
- Bump `@holon-run/uxc-daemon-client` to `0.18.0` (`packages/uxc-daemon-client/package.json`)
- Roll `CHANGELOG.md` Unreleased entries into `## [0.18.0] - 2026-02-16`
- Update install examples to `v0.18.0` (`README.md`, `README.zh-CN.md`, `docs/site/getting-started/install.md`)

## Why

main contains 4 feature PRs since v0.17.0 (email attachment metadata + retrieval: #437, #439, #440, #441), which warrants a minor version bump. Install docs version is folded into this release PR to avoid a follow-up docs PR.

## How

Standard release bump following the v0.17.0 process: version fields, CHANGELOG section roll-up, install example version references.

## Testing

- `./scripts/release-check.sh v0.18.0 --allow-dirty` — all checks passed (fmt, clippy, tests, build, daemon-client build+test)
