### PR TITLE
feat(daemon): expose email.send and email.reply RPC

### DIFF
--- a/packages/uxc-daemon-client/src/index.ts
+++ b/packages/uxc-daemon-client/src/index.ts
@@ -104,6 +104,8 @@ export interface ManagedSourceSpec {
     | "discord_gateway"
     | "slack_socket_mode"
     | "feishu_long_connection"
+    | "email_imap_idle"
+    | "email_provider_poll"
     | null;
   subprotocols?: string[];
   initial_text_frames?: string[];
@@ -120,6 +122,49 @@ export interface ManagedSourceEnsureResponse {
   status: string;
   reused: boolean;
   replaced_previous: boolean;
+}
+
+export interface EmailSendResult {
+  smtp_url: string;
+  from: string;
+  to: string[];
+  cc?: string[];
+  bcc?: string[];
+  subject: string;
+  message_id: string;
+  in_reply_to?: string | null;
+  references?: string[];
+  dry_run: boolean;
+  accepted_recipients: number;
+}
+
+export interface EmailReplyHandle {
+  message_id?: string;
+  account?: string;
+  mailbox?: string;
+  uid?: number;
+}
+
+export interface EmailSendArgs {
+  smtpUrl: string;
+  from: string;
+  to: string[];
+  cc?: string[];
+  bcc?: string[];
+  subject: string;
+  text?: string;
+  html?: string;
+  inReplyTo?: string;
+  references?: string[];
+  auth?: string;
+  /** Caller-supplied Message-ID used for outbound idempotency. */
+  messageId?: string;
+  allowInsecureAuth?: boolean;
+  dryRun?: boolean;
+}
+
+export interface EmailReplyArgs extends EmailSendArgs {
+  replyHandle?: EmailReplyHandle | null;
 }
 
 export interface ManagedSourceView {
@@ -343,6 +388,18 @@ export class UxcDaemonClient {
       options: args.options,
     });
     return generateTypeScriptClient(schema, args.emitter);
+  }
+
+  async emailSend(args: EmailSendArgs): Promise<EmailSendResult> {
+    return this.request("email.send", emailSendParams(args));
+  }
+
+  async emailReply(args: EmailReplyArgs): Promise<EmailSendResult> {
+    const { replyHandle, ...send } = args;
+    return this.request("email.reply", {
+      ...emailSendParams(send),
+      ...(replyHandle ? { reply_handle: emailReplyHandleParams(replyHandle) } : {}),
+    });
   }
 
   async sourceEnsure(args: {
@@ -946,6 +1003,37 @@ function defaultSocketPath(env: NodeJS.ProcessEnv | undefined): string {
   }
   const label = bestEffortUserLabel(env);
   return join(tmpdir(), `uxc-${label}`, "daemon", "uxc.sock");
+}
+
+function emailSendParams(args: EmailSendArgs): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    smtp_url: args.smtpUrl,
+    from: args.from,
+    to: args.to,
+    subject: args.subject,
+  };
+  if (args.cc?.length) params.cc = args.cc;
+  if (args.bcc?.length) params.bcc = args.bcc;
+  if (args.text != null) params.text = args.text;
+  if (args.html != null) params.html = args.html;
+  if (args.inReplyTo != null) params.in_reply_to = args.inReplyTo;
+  if (args.references?.length) params.references = args.references;
+  if (args.auth != null) params.auth = args.auth;
+  if (args.messageId != null) params.message_id = args.messageId;
+  if (args.allowInsecureAuth != null) params.allow_insecure_auth = args.allowInsecureAuth;
+  if (args.dryRun != null) params.dry_run = args.dryRun;
+  return params;
+}
+
+function emailReplyHandleParams(replyHandle: EmailReplyHandle): Record<string, unknown> {
+  if (replyHandle.messageId == null) {
+    throw new Error("emailReply replyHandle requires messageId");
+  }
+  const params: Record<string, unknown> = { message_id: replyHandle.messageId };
+  if (replyHandle.account != null) params.account = replyHandle.account;
+  if (replyHandle.mailbox != null) params.mailbox = replyHandle.mailbox;
+  if (replyHandle.uid != null) params.uid = replyHandle.uid;
+  return params;
 }
 
 function bestEffortUserLabel(env: NodeJS.ProcessEnv | undefined): string {

--- a/packages/uxc-daemon-client/src/index.ts
+++ b/packages/uxc-daemon-client/src/index.ts
@@ -139,7 +139,7 @@ export interface EmailSendResult {
 }
 
 export interface EmailReplyHandle {
-  message_id?: string;
+  messageId?: string;
   account?: string;
   mailbox?: string;
   uid?: number;

--- a/packages/uxc-daemon-client/test/client.test.ts
+++ b/packages/uxc-daemon-client/test/client.test.ts
@@ -154,6 +154,85 @@ describe("UxcDaemonClient", () => {
     ]);
   });
 
+  test("emailSend maps args onto email.send params", async () => {
+    const stub = new UxcDaemonClient({ autoStart: false });
+    const calls: Array<{ method: string; params: unknown }> = [];
+    (stub as unknown as { request: (method: string, params?: unknown) => Promise<unknown> }).request = async (
+      method,
+      params,
+    ) => {
+      calls.push({ method, params });
+      return { message_id: "<agentinbox-1@localhost>", accepted_recipients: 1 };
+    };
+
+    const response = await stub.emailSend({
+      smtpUrl: "smtp://localhost:2525",
+      from: "bot@example.com",
+      to: ["alice@example.org"],
+      cc: ["carol@example.net"],
+      subject: "Ping",
+      text: "Hello",
+      auth: "email-primary",
+      messageId: "<agentinbox-1@localhost>",
+      dryRun: true,
+    });
+    expect(response.message_id).toBe("<agentinbox-1@localhost>");
+    expect(calls).toEqual([
+      {
+        method: "email.send",
+        params: {
+          smtp_url: "smtp://localhost:2525",
+          from: "bot@example.com",
+          to: ["alice@example.org"],
+          cc: ["carol@example.net"],
+          subject: "Ping",
+          text: "Hello",
+          auth: "email-primary",
+          message_id: "<agentinbox-1@localhost>",
+          dry_run: true,
+        },
+      },
+    ]);
+  });
+
+  test("emailReply includes reply_handle on email.reply params", async () => {
+    const stub = new UxcDaemonClient({ autoStart: false });
+    const calls: Array<{ method: string; params: unknown }> = [];
+    (stub as unknown as { request: (method: string, params?: unknown) => Promise<unknown> }).request = async (
+      method,
+      params,
+    ) => {
+      calls.push({ method, params });
+      return { message_id: "<agentinbox-2@localhost>", accepted_recipients: 1 };
+    };
+
+    await stub.emailReply({
+      smtpUrl: "smtp://localhost:2525",
+      from: "bot@example.com",
+      to: ["alice@example.org"],
+      subject: "Re: Quarterly report",
+      text: "Thanks",
+      replyHandle: { messageId: "<m1@example.com>", account: "user@example.com", uid: 42 },
+    });
+    expect(calls).toEqual([
+      {
+        method: "email.reply",
+        params: {
+          smtp_url: "smtp://localhost:2525",
+          from: "bot@example.com",
+          to: ["alice@example.org"],
+          subject: "Re: Quarterly report",
+          text: "Thanks",
+          reply_handle: {
+            message_id: "<m1@example.com>",
+            account: "user@example.com",
+            uid: 42,
+          },
+        },
+      },
+    ]);
+  });
+
   test("call executes OpenAPI operations without CLI envelope parsing", async () => {
     const server = createOpenApiServer();
     await server.start();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7487,13 +7487,20 @@ async fn handle_connection(mut stream: UnixStream, runtime: Arc<DaemonRuntime>) 
         }
         "email.send" => {
             let Some(params) = req.params else {
-                write_jsonrpc_error(&mut stream, req.id, -32602, "Missing params".to_string()).await?;
+                write_jsonrpc_error(&mut stream, req.id, -32602, "Missing params".to_string())
+                    .await?;
                 return Ok(());
             };
             let request: DaemonEmailSendRequest = match serde_json::from_value(params) {
                 Ok(value) => value,
                 Err(err) => {
-                    write_jsonrpc_error(&mut stream, req.id, -32602, format!("Invalid params: {err}")).await?;
+                    write_jsonrpc_error(
+                        &mut stream,
+                        req.id,
+                        -32602,
+                        format!("Invalid params: {err}"),
+                    )
+                    .await?;
                     return Ok(());
                 }
             };
@@ -7514,13 +7521,20 @@ async fn handle_connection(mut stream: UnixStream, runtime: Arc<DaemonRuntime>) 
         }
         "email.reply" => {
             let Some(params) = req.params else {
-                write_jsonrpc_error(&mut stream, req.id, -32602, "Missing params".to_string()).await?;
+                write_jsonrpc_error(&mut stream, req.id, -32602, "Missing params".to_string())
+                    .await?;
                 return Ok(());
             };
             let request: DaemonEmailReplyRequest = match serde_json::from_value(params) {
                 Ok(value) => value,
                 Err(err) => {
-                    write_jsonrpc_error(&mut stream, req.id, -32602, format!("Invalid params: {err}")).await?;
+                    write_jsonrpc_error(
+                        &mut stream,
+                        req.id,
+                        -32602,
+                        format!("Invalid params: {err}"),
+                    )
+                    .await?;
                     return Ok(());
                 }
             };

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9,6 +9,7 @@ use crate::cache::{self, Cache, CacheConfig};
 use crate::codegen::build_codegen_host_schema;
 use crate::daemon_log::{redact_endpoint, redact_sensitive};
 use crate::daemon_log::{DaemonEventType, DaemonLogEntry, DaemonLogger};
+use crate::email::{self, EmailSendRequest};
 use crate::error::{
     structured_error_from_anyhow, structured_error_from_jsonrpc_error, StructuredError,
     StructuredErrorPayload, UxcError,
@@ -328,6 +329,63 @@ pub struct ManagedSourceEnsureRequest {
     pub namespace: String,
     pub source_key: String,
     pub spec: ManagedSourceSpec,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonEmailSendRequest {
+    pub smtp_url: String,
+    pub from: String,
+    #[serde(default)]
+    pub to: Vec<String>,
+    #[serde(default)]
+    pub cc: Vec<String>,
+    #[serde(default)]
+    pub bcc: Vec<String>,
+    #[serde(default)]
+    pub subject: String,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub html: Option<String>,
+    #[serde(default)]
+    pub in_reply_to: Option<String>,
+    #[serde(default)]
+    pub references: Vec<String>,
+    #[serde(default)]
+    pub auth: Option<String>,
+    #[serde(default)]
+    pub message_id: Option<String>,
+    #[serde(default)]
+    pub allow_insecure_auth: bool,
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonEmailReplyRequest {
+    #[serde(flatten)]
+    pub send: DaemonEmailSendRequest,
+    #[serde(default)]
+    pub reply_handle: Option<email::EmailReplyHandle>,
+}
+
+pub fn daemon_email_send_request_to_email(request: DaemonEmailSendRequest) -> EmailSendRequest {
+    EmailSendRequest {
+        smtp_url: request.smtp_url,
+        from: request.from,
+        to: request.to,
+        cc: request.cc,
+        bcc: request.bcc,
+        subject: request.subject,
+        text: request.text,
+        html: request.html,
+        in_reply_to: request.in_reply_to,
+        references: request.references,
+        auth: request.auth,
+        message_id: request.message_id,
+        allow_insecure_auth: request.allow_insecure_auth,
+        dry_run: request.dry_run,
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -7427,6 +7485,68 @@ async fn handle_connection(mut stream: UnixStream, runtime: Arc<DaemonRuntime>) 
                 error: None,
             }
         }
+        "email.send" => {
+            let Some(params) = req.params else {
+                write_jsonrpc_error(&mut stream, req.id, -32602, "Missing params".to_string()).await?;
+                return Ok(());
+            };
+            let request: DaemonEmailSendRequest = match serde_json::from_value(params) {
+                Ok(value) => value,
+                Err(err) => {
+                    write_jsonrpc_error(&mut stream, req.id, -32602, format!("Invalid params: {err}")).await?;
+                    return Ok(());
+                }
+            };
+            match email::send_email(daemon_email_send_request_to_email(request)).await {
+                Ok(result) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: Some(serde_json::to_value(result)?),
+                    error: None,
+                },
+                Err(err) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: None,
+                    error: Some(jsonrpc_error_from_anyhow(&err)),
+                },
+            }
+        }
+        "email.reply" => {
+            let Some(params) = req.params else {
+                write_jsonrpc_error(&mut stream, req.id, -32602, "Missing params".to_string()).await?;
+                return Ok(());
+            };
+            let request: DaemonEmailReplyRequest = match serde_json::from_value(params) {
+                Ok(value) => value,
+                Err(err) => {
+                    write_jsonrpc_error(&mut stream, req.id, -32602, format!("Invalid params: {err}")).await?;
+                    return Ok(());
+                }
+            };
+            let mut send = daemon_email_send_request_to_email(request.send);
+            let (in_reply_to, references) = email::references_with_reply_handle(
+                request.reply_handle.as_ref(),
+                send.in_reply_to,
+                std::mem::take(&mut send.references),
+            );
+            send.in_reply_to = in_reply_to;
+            send.references = references;
+            match email::send_email(send).await {
+                Ok(result) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: Some(serde_json::to_value(result)?),
+                    error: None,
+                },
+                Err(err) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: None,
+                    error: Some(jsonrpc_error_from_anyhow(&err)),
+                },
+            }
+        }
         "runtime.invoke" => {
             let Some(params) = req.params else {
                 let resp = JsonRpcResponse {
@@ -9406,6 +9526,62 @@ mod tests {
     use tokio_tungstenite::accept_hdr_async;
     use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
     use tokio_tungstenite::tungstenite::Message;
+
+    #[test]
+    fn daemon_email_reply_request_parses_flattened_params_and_reply_handle() {
+        let params = serde_json::json!({
+            "smtp_url": "smtp://localhost:2525",
+            "from": "bot@example.com",
+            "to": ["alice@example.org"],
+            "subject": "Re: Quarterly report",
+            "text": "Thanks",
+            "auth": "email-primary",
+            "message_id": "<agentinbox-reply-42@localhost>",
+            "reply_handle": {
+                "message_id": "<m1@example.com>",
+                "account": "user@example.com",
+                "mailbox": "INBOX",
+                "uid": 42
+            }
+        });
+        let request: DaemonEmailReplyRequest = serde_json::from_value(params).unwrap();
+        assert_eq!(request.send.smtp_url, "smtp://localhost:2525");
+        assert_eq!(request.send.to, vec!["alice@example.org".to_string()]);
+        assert_eq!(
+            request.send.message_id.as_deref(),
+            Some("<agentinbox-reply-42@localhost>")
+        );
+        let reply_handle = request.reply_handle.clone().expect("reply_handle parsed");
+        assert_eq!(reply_handle.message_id.as_deref(), Some("<m1@example.com>"));
+        assert_eq!(reply_handle.uid, Some(42));
+
+        let mut send = daemon_email_send_request_to_email(request.send);
+        let (in_reply_to, references) = email::references_with_reply_handle(
+            request.reply_handle.as_ref(),
+            send.in_reply_to,
+            std::mem::take(&mut send.references),
+        );
+        assert_eq!(in_reply_to.as_deref(), Some("<m1@example.com>"));
+        assert_eq!(references, vec!["<m1@example.com>".to_string()]);
+    }
+
+    #[test]
+    fn daemon_email_send_request_defaults_collections() {
+        let request: DaemonEmailSendRequest = serde_json::from_value(serde_json::json!({
+            "smtp_url": "smtp://localhost:2525",
+            "from": "bot@example.com",
+            "subject": "hello",
+            "text": "body"
+        }))
+        .unwrap();
+        assert!(request.to.is_empty());
+        assert!(request.cc.is_empty());
+        assert!(!request.dry_run);
+        assert!(!request.allow_insecure_auth);
+        let converted = daemon_email_send_request_to_email(request);
+        assert_eq!(converted.from, "bot@example.com");
+        assert_eq!(converted.message_id, None);
+    }
 
     #[derive(Default)]
     struct RecordingCache {

--- a/src/email.rs
+++ b/src/email.rs
@@ -32,6 +32,9 @@ pub struct EmailSendRequest {
     pub in_reply_to: Option<String>,
     pub references: Vec<String>,
     pub auth: Option<String>,
+    /// Optional caller-supplied Message-ID. Used for outbound idempotency:
+    /// retries with the same correlation key produce the same Message-ID.
+    pub message_id: Option<String>,
     pub allow_insecure_auth: bool,
     pub dry_run: bool,
 }
@@ -64,14 +67,22 @@ struct SmtpAuth {
 pub async fn send_email(request: EmailSendRequest) -> Result<EmailSendResult> {
     validate_request(&request)?;
     let smtp_url = parse_smtp_url(&request.smtp_url)?;
-    let message_id = format!(
-        "<uxc-{}-{}@localhost>",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-    );
+    let message_id = request
+        .message_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            format!(
+                "<uxc-{}-{}@localhost>",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos()
+            )
+        });
     let body = build_message(&request, &message_id)?;
     let accepted_recipients = request.to.len() + request.cc.len() + request.bcc.len();
 
@@ -411,10 +422,34 @@ mod tests {
             in_reply_to: None,
             references: vec![],
             auth: None,
+            message_id: None,
             allow_insecure_auth: false,
             dry_run: true,
         };
         assert!(build_message(&request, "<id@example.com>").is_err());
+    }
+
+    #[tokio::test]
+    async fn send_email_honors_caller_message_id_in_dry_run() {
+        let result = send_email(EmailSendRequest {
+            smtp_url: "smtp://localhost:25".to_string(),
+            from: "sender@example.com".to_string(),
+            to: vec!["recipient@example.com".to_string()],
+            cc: vec![],
+            bcc: vec![],
+            subject: "hello".to_string(),
+            text: Some("body".to_string()),
+            html: None,
+            in_reply_to: None,
+            references: vec![],
+            auth: None,
+            message_id: Some("<agentinbox-correlation-1@localhost>".to_string()),
+            allow_insecure_auth: false,
+            dry_run: true,
+        })
+        .await
+        .unwrap();
+        assert_eq!(result.message_id, "<agentinbox-correlation-1@localhost>");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6239,6 +6239,7 @@ async fn handle_email_command(command: &EmailCommands, cli: &Cli) -> Result<Outp
             in_reply_to: None,
             references: vec![],
             auth: cli.auth.clone(),
+            message_id: None,
             allow_insecure_auth: args.allow_insecure_auth,
             dry_run: args.dry_run,
         },
@@ -6265,6 +6266,7 @@ async fn handle_email_command(command: &EmailCommands, cli: &Cli) -> Result<Outp
                 in_reply_to,
                 references,
                 auth: cli.auth.clone(),
+                message_id: None,
                 allow_insecure_auth: args.allow_insecure_auth,
                 dry_run: args.dry_run,
             }


### PR DESCRIPTION
## Summary

Adds two daemon JSON-RPC methods for outbound email, so mailbox-consuming runtimes (AgentInbox `email_mailbox` source, holon-run/agentinbox#215) can deliver replies without wrapping the CLI:

- **`email.send` / `email.reply`** — same semantics as `uxc email send/reply` with snake_case params. `email.reply` accepts the `email_event` `reply_handle` object (flattened request) and reuses `references_with_reply_handle` to build `In-Reply-To` / `References` thread headers.
- **`EmailSendRequest.message_id`** — optional caller-supplied Message-ID used verbatim, enabling outbound idempotency (retry with the same correlation key produces the same Message-ID). Still sanitized through the existing header-injection guards.
- **`uxc-daemon-client`** — typed `emailSend()` / `emailReply()` methods plus the `email_imap_idle` / `email_provider_poll` `transport_hint` types (the daemon serde already accepted both; this closes the TS type gap).

Protocol/MIME/SMTP handling stays entirely in `email.rs`; the daemon layer is a thin JSON-RPC surface, keeping connector details at the edge.

## Testing

- `cargo test daemon::tests::daemon_email` — request parsing (flattened params + reply_handle), collection defaults, reply header derivation: 2 new tests
- `cargo test email::` — 18 passing (incl. new dry-run custom `message_id` test)
- `packages/uxc-daemon-client`: vitest 20/20 (2 new param-mapping tests; integration suite runs against the freshly built daemon)

Companion AgentInbox PR consumes this via the generic `UxcDaemonClient.request()` surface and degrades gracefully (clear upgrade-hint error) when the connected uxc daemon predates these methods.