### PR TITLE
chore(release): bump version to 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-09-08
+
+### Added
+- Daemon JSON-RPC methods `email.send` and `email.reply` for outbound email, with typed `emailSend`/`emailReply` methods in `uxc-daemon-client` and caller-supplied `message_id` support for outbound idempotency (#443).
+
 ## [0.18.0] - 2026-09-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3227,7 +3227,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uxc"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxc"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 authors = ["UXC Contributors"]
 description = "A unified CLI for discovering and invoking tools across OpenAPI, MCP, GraphQL, gRPC, and JSON-RPC"

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ bash install-uxc.sh
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.18.0
+curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.19.0
 ```
 
 Windows note: native Windows is no longer supported; run UXC through WSL.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -209,7 +209,7 @@ bash install-uxc.sh
 安装指定版本：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.18.0
+curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.19.0
 ```
 
 Windows 说明：不再支持原生 Windows，请通过 WSL 运行 UXC。

--- a/docs/site/getting-started/install.md
+++ b/docs/site/getting-started/install.md
@@ -16,7 +16,7 @@ curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.18.0
+curl -fsSL https://raw.githubusercontent.com/holon-run/uxc/main/scripts/install.sh | bash -s -- -v v0.19.0
 ```
 
 ## Cargo

--- a/packages/uxc-daemon-client/package.json
+++ b/packages/uxc-daemon-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holon-run/uxc-daemon-client",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Thin Node.js client for UXC daemon-backed operations",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

Bump UXC version to 0.19.0 for release.

- `Cargo.toml` / `Cargo.lock`: 0.18.0 → 0.19.0
- `packages/uxc-daemon-client/package.json`: 0.18.0 → 0.19.0
- `CHANGELOG.md`: add 0.19.0 release entry
- Install docs version references: `README.md`, `README.zh-CN.md`, `docs/site/getting-started/install.md`

## Why

main has a new feature commit since v0.18.0: f6dc5ff `feat(daemon): expose email.send and email.reply RPC` (#443). Per semver convention this warrants a minor version bump.

## How

- Standard release version bump across Rust crate, npm workspace package, changelog, and install docs.

## Testing

- `./scripts/release-check.sh v0.19.0` passed: cargo clippy, cargo test, cargo build, daemon-client build + vitest (20 tests).