### PR TITLE
feat(email): controllable first-look backfill depth

### DIFF
--- a/packages/uxc-daemon-client/src/index.ts
+++ b/packages/uxc-daemon-client/src/index.ts
@@ -279,6 +279,15 @@ export interface PollSubscriptionConfig {
   response_cursor_pointer?: string;
   cursor_from_item_pointer?: string;
   cursor_transform?: "increment";
+  /**
+   * First-look backfill depth. When set, only the initial poll cycle after a
+   * fresh checkpoint emits items: the whole first page is recorded in the
+   * checkpoint, but at most this many unseen items are emitted. `0`
+   * establishes the baseline without emitting anything ("new items only").
+   * Later cycles are unaffected. Requires the item_key, watermark, or
+   * content_hash checkpoint strategy.
+   */
+  initial_items_limit?: number;
   checkpoint_strategy:
     | {
         type: "cursor_only";

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10714,6 +10714,7 @@ mod tests {
             etag: Some("\"etag-v1\"".to_string()),
             etag_set_at_unix: None,
             consecutive_304_count: 0,
+            baseline_done: false,
         };
         let checkpoint_path = runtime.managed_source_checkpoint_path(&record.run_id);
         fs::create_dir_all(checkpoint_path.parent().unwrap()).unwrap();
@@ -10757,6 +10758,7 @@ mod tests {
             etag: Some("\"etag-v2\"".to_string()),
             etag_set_at_unix: None,
             consecutive_304_count: 0,
+            baseline_done: false,
         };
         let offsets = runtime
             .managed_sources

--- a/src/subscription_email.rs
+++ b/src/subscription_email.rs
@@ -28,6 +28,10 @@ const DEFAULT_MAILBOX: &str = "INBOX";
 const IMAP_CONNECT_TIMEOUT_SECS: u64 = 10;
 const IMAP_COMMAND_TIMEOUT_SECS: u64 = 30;
 const IMAP_IDLE_DONE_TIMEOUT_SECS: u64 = 5;
+/// Number of existing messages fetched on the first look by default.
+pub const EMAIL_IMAP_DEFAULT_INITIAL_FETCH_LIMIT: u64 = 25;
+/// Upper bound for the IMAP first-look backfill depth.
+pub const EMAIL_IMAP_MAX_INITIAL_FETCH_LIMIT: u64 = 100;
 const IMAP_ATTACHMENT_TIMEOUT_SECS: u64 = 120;
 const EMAIL_SNIPPET_CHARS: usize = 512;
 const EMAIL_RAW_INLINE_BYTES: usize = 32 * 1024;
@@ -105,11 +109,13 @@ pub fn resolve_email_imap_idle_runtime_config(
         .and_then(Value::as_str)
         .map(str::to_string)
         .or_else(|| auth_profile.resolve_field_value("account").ok().flatten());
+    // 0 means "new mail only": skip the initial backfill entirely and only
+    // emit messages that arrive after the subscription is established.
     let initial_fetch_limit = args
         .and_then(|args| args.get("initial_fetch_limit"))
         .and_then(Value::as_u64)
-        .unwrap_or(25)
-        .min(100) as usize;
+        .unwrap_or(EMAIL_IMAP_DEFAULT_INITIAL_FETCH_LIMIT)
+        .min(EMAIL_IMAP_MAX_INITIAL_FETCH_LIMIT) as usize;
     let username = resolve_first_profile_field(auth_profile, &["username", "user", "email"])?
         .ok_or_else(|| {
             anyhow!("email-imap-idle auth profile requires username/user/email field")
@@ -305,6 +311,11 @@ async fn emit_recent_messages<R>(
 where
     R: SubscriptionEventRecorder,
 {
+    if config.initial_fetch_limit == 0 {
+        // New mail only: establish the high-water UID without fetching or
+        // emitting any pre-existing messages.
+        return conn.latest_uid().await;
+    }
     let messages = conn.fetch_recent(config.initial_fetch_limit).await?;
     emit_messages(config, messages, recorder, uidvalidity).await
 }
@@ -1291,6 +1302,17 @@ impl ImapConnection {
         self.fetch_uid_set(&uids.join(",")).await
     }
 
+    /// Returns the highest message UID in the selected mailbox without
+    /// fetching any message bodies. Used to establish the high-water mark for
+    /// `initial_fetch_limit = 0` ("new mail only") subscriptions.
+    async fn latest_uid(&mut self) -> Result<Option<u64>> {
+        let search_lines = self.command_ok("UID SEARCH ALL").await?;
+        Ok(parse_uid_search_uids(&search_lines)
+            .iter()
+            .filter_map(|uid| parse_uid_number(uid))
+            .max())
+    }
+
     async fn fetch_since_uid(&mut self, last_uid: u64) -> Result<Vec<ImapFetchedMessage>> {
         self.fetch_uid_set(&format!("{}:*", last_uid.saturating_add(1)))
             .await
@@ -1921,5 +1943,145 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["42", "43"]
         );
+    }
+
+    #[derive(Default)]
+    struct RecordingRecorder {
+        events: Vec<(String, String)>,
+    }
+
+    #[async_trait::async_trait]
+    impl SubscriptionEventRecorder for RecordingRecorder {
+        async fn emit(
+            &mut self,
+            source_kind: &str,
+            event_kind: &str,
+            _data: Option<Value>,
+            _meta: Option<Value>,
+        ) -> Result<()> {
+            self.events
+                .push((source_kind.to_string(), event_kind.to_string()));
+            Ok(())
+        }
+
+        async fn update_status(
+            &mut self,
+            _status: Option<&str>,
+            _last_error: Option<String>,
+            _increment_reconnect: bool,
+        ) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn imap_idle_test_config(initial_fetch_limit: usize) -> EmailImapIdleRuntimeConfig {
+        EmailImapIdleRuntimeConfig {
+            endpoint: "imaps://imap.example.com:993".to_string(),
+            host: "imap.example.com".to_string(),
+            port: 993,
+            use_tls: true,
+            username: "agent@example.com".to_string(),
+            password: "secret".to_string(),
+            auth_profile: None,
+            mailbox: "INBOX".to_string(),
+            account: None,
+            initial_fetch_limit,
+        }
+    }
+
+    #[tokio::test]
+    async fn latest_uid_returns_max_search_uid_without_fetching() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut conn = ImapConnection::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut command = String::new();
+            reader.read_line(&mut command).await.unwrap();
+            assert_eq!(command, "A0001 UID SEARCH ALL\r\n");
+            writer
+                .write_all(b"* SEARCH 7 42 43\r\nA0001 OK search done\r\n")
+                .await
+                .unwrap();
+        });
+
+        let latest = conn.latest_uid().await.unwrap();
+        server.await.unwrap();
+        assert_eq!(latest, Some(43));
+    }
+
+    #[tokio::test]
+    async fn emit_recent_messages_with_zero_limit_baselines_without_emitting() {
+        let config = imap_idle_test_config(0);
+        let (client, server) = tokio::io::duplex(4096);
+        let mut conn = ImapConnection::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut command = String::new();
+            reader.read_line(&mut command).await.unwrap();
+            assert_eq!(command, "A0001 UID SEARCH ALL\r\n");
+            writer
+                .write_all(b"* SEARCH 7 42 43\r\nA0001 OK search done\r\n")
+                .await
+                .unwrap();
+            // The connection must not receive a UID FETCH command afterwards:
+            // dropping the writer closes the pipe and any further read fails.
+        });
+
+        let mut recorder = RecordingRecorder::default();
+        let last_uid = emit_recent_messages(&config, &mut conn, &mut recorder, None)
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(last_uid, Some(43));
+        assert!(recorder.events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn emit_recent_messages_with_positive_limit_fetches_and_emits() {
+        let config = imap_idle_test_config(25);
+        let (client, server) = tokio::io::duplex(4096);
+        let mut conn = ImapConnection::new(Box::new(client));
+        let raw =
+            "Message-ID: <m43@example.com>\r\nSubject: New\r\nFrom: sender@example.com\r\n\r\nBody";
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut command = String::new();
+            reader.read_line(&mut command).await.unwrap();
+            assert_eq!(command, "A0001 UID SEARCH ALL\r\n");
+            writer
+                .write_all(b"* SEARCH 42 43\r\nA0001 OK search done\r\n")
+                .await
+                .unwrap();
+
+            command.clear();
+            reader.read_line(&mut command).await.unwrap();
+            assert_eq!(command, "A0002 UID FETCH 42,43 (UID FLAGS BODY.PEEK[])\r\n");
+            writer
+                .write_all(
+                    format!(
+                        "* 1 FETCH (UID 42 FLAGS () BODY[] \"Subject: Old\\r\\n\\r\\nOld\")\r\n* 2 FETCH (UID 43 FLAGS () BODY[] {{{}}}\r\n{})\r\nA0002 OK fetch done\r\n",
+                        raw.len(),
+                        raw
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+
+        let mut recorder = RecordingRecorder::default();
+        let last_uid = emit_recent_messages(&config, &mut conn, &mut recorder, None)
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(last_uid, Some(43));
+        assert_eq!(recorder.events.len(), 2);
+        assert!(recorder
+            .events
+            .iter()
+            .all(|(kind, _)| kind == "email_imap_idle"));
     }
 }

--- a/src/subscription_poll.rs
+++ b/src/subscription_poll.rs
@@ -19,6 +19,14 @@ pub struct PollSubscriptionConfig {
     pub cursor_from_item_pointer: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cursor_transform: Option<PollCursorTransform>,
+    /// First-look backfill depth. When set, only the initial poll cycle after
+    /// a fresh checkpoint emits items: the whole first page is recorded in the
+    /// checkpoint, but at most this many unseen items are emitted. `Some(0)`
+    /// establishes the baseline without emitting anything ("new items only").
+    /// Later cycles are unaffected. Requires the item_key, watermark, or
+    /// content_hash checkpoint strategy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initial_items_limit: Option<usize>,
     pub checkpoint_strategy: PollCheckpointStrategy,
 }
 
@@ -66,6 +74,10 @@ pub struct PollCheckpointState {
     pub etag_set_at_unix: Option<u64>,
     #[serde(default, skip_serializing_if = "is_zero_u32")]
     pub consecutive_304_count: u32,
+    /// Set once the first-look backfill policy (`initial_items_limit`) has
+    /// been applied, so an empty first page does not re-trigger the baseline.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub baseline_done: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -128,6 +140,13 @@ impl PollSubscriptionConfig {
         if self.response_cursor_pointer.is_some() && self.cursor_from_item_pointer.is_some() {
             bail!(
                 "poll response_cursor_pointer and cursor_from_item_pointer are mutually exclusive"
+            );
+        }
+        if self.initial_items_limit.is_some()
+            && matches!(self.checkpoint_strategy, PollCheckpointStrategy::CursorOnly)
+        {
+            bail!(
+                "poll initial_items_limit requires item_key, watermark, or content_hash checkpoint strategy"
             );
         }
 
@@ -215,12 +234,23 @@ impl PollSubscriptionRunner {
         let fetched_items = items.len();
         let previous_checkpoint = self.checkpoint.clone();
         let strategy = self.config.checkpoint_strategy.clone();
+        let baseline_limit =
+            if self.config.initial_items_limit.is_some() && !self.checkpoint.baseline_done {
+                self.config.initial_items_limit
+            } else {
+                None
+            };
         let emitted_items = match strategy {
             PollCheckpointStrategy::CursorOnly => items.to_vec(),
             PollCheckpointStrategy::ItemKey {
                 item_key_pointer,
                 seen_window,
-            } => self.filter_by_item_key(items, &item_key_pointer, seen_window.unwrap_or(1024))?,
+            } => self.filter_by_item_key(
+                items,
+                &item_key_pointer,
+                seen_window.unwrap_or(1024),
+                baseline_limit,
+            )?,
             PollCheckpointStrategy::Watermark {
                 item_watermark_pointer,
                 item_tiebreaker_pointer,
@@ -230,11 +260,18 @@ impl PollSubscriptionRunner {
                 &item_watermark_pointer,
                 item_tiebreaker_pointer.as_deref(),
                 seen_window.unwrap_or(1024),
+                baseline_limit,
             )?,
             PollCheckpointStrategy::ContentHash { seen_window } => {
-                self.filter_by_content_hash(items, seen_window.unwrap_or(1024))?
+                self.filter_by_content_hash(items, seen_window.unwrap_or(1024), baseline_limit)?
             }
         };
+
+        if baseline_limit.is_some() {
+            // The first-look policy applied to this cycle (even when the page
+            // was empty); it must not run again after this checkpoint.
+            self.checkpoint.baseline_done = true;
+        }
 
         if let Some(pointer) = self.config.response_cursor_pointer.as_ref() {
             self.checkpoint.cursor = Some(
@@ -284,6 +321,7 @@ impl PollSubscriptionRunner {
         items: &[Value],
         pointer: &str,
         seen_window: usize,
+        baseline_limit: Option<usize>,
     ) -> Result<Vec<Value>> {
         let mut emitted = Vec::new();
         for item in items {
@@ -294,6 +332,10 @@ impl PollSubscriptionRunner {
                 continue;
             }
             push_seen_key(&mut self.checkpoint.seen_keys, key, seen_window);
+            if baseline_limit.is_some_and(|limit| emitted.len() >= limit) {
+                // Baseline cycle: record the item as seen without emitting.
+                continue;
+            }
             emitted.push(item.clone());
         }
         Ok(emitted)
@@ -305,6 +347,7 @@ impl PollSubscriptionRunner {
         watermark_pointer: &str,
         tiebreaker_pointer: Option<&str>,
         seen_window: usize,
+        baseline_limit: Option<usize>,
     ) -> Result<Vec<Value>> {
         let mut emitted = Vec::new();
         let mut max_watermark = self.checkpoint.watermark.clone();
@@ -343,7 +386,12 @@ impl PollSubscriptionRunner {
                 self.checkpoint.watermark.as_ref(),
                 self.checkpoint.tie_breaker.as_ref(),
             ) {
-                emitted.push(item.clone());
+                if baseline_limit.is_some_and(|limit| emitted.len() >= limit) {
+                    // Baseline cycle: still advance the watermark below, but
+                    // do not emit beyond the first-look budget.
+                } else {
+                    emitted.push(item.clone());
+                }
                 if let Some(key) = seen_key {
                     push_seen_key(&mut self.checkpoint.seen_keys, key, seen_window);
                 }
@@ -369,6 +417,7 @@ impl PollSubscriptionRunner {
         &mut self,
         items: &[Value],
         seen_window: usize,
+        baseline_limit: Option<usize>,
     ) -> Result<Vec<Value>> {
         let mut emitted = Vec::new();
         for item in items {
@@ -377,6 +426,9 @@ impl PollSubscriptionRunner {
                 continue;
             }
             push_seen_key(&mut self.checkpoint.seen_keys, key, seen_window);
+            if baseline_limit.is_some_and(|limit| emitted.len() >= limit) {
+                continue;
+            }
             emitted.push(item.clone());
         }
         Ok(emitted)
@@ -585,6 +637,10 @@ fn is_zero_u32(v: &u32) -> bool {
     *v == 0
 }
 
+fn is_false(v: &bool) -> bool {
+    !*v
+}
+
 trait ResultExt<T> {
     fn with_context<F>(self, f: F) -> Result<T>
     where
@@ -613,6 +669,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: None,
             cursor_transform: None,
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::ItemKey {
                 item_key_pointer: "/id".to_string(),
                 seen_window: Some(4),
@@ -630,6 +687,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: None,
             cursor_transform: None,
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::CursorOnly,
         }
         .validate()
@@ -653,6 +711,100 @@ mod tests {
     }
 
     #[test]
+    fn initial_items_limit_caps_first_look_and_baselines_page() {
+        let mut config = item_key_config();
+        config.initial_items_limit = Some(1);
+        let mut runner = PollSubscriptionRunner::new(config).unwrap();
+        let first = runner
+            .process_response(json!({"items":[{"id":1},{"id":2},{"id":3}]}), None)
+            .unwrap();
+        assert_eq!(first.emitted_items, vec![json!({"id":1})]);
+        // The whole first page was baselined; only genuinely new items emit.
+        let second = runner
+            .process_response(json!({"items":[{"id":2},{"id":3},{"id":4}]}), None)
+            .unwrap();
+        assert_eq!(second.emitted_items, vec![json!({"id":4})]);
+    }
+
+    #[test]
+    fn initial_items_limit_zero_emits_nothing_on_first_look() {
+        let mut config = item_key_config();
+        config.initial_items_limit = Some(0);
+        let mut runner = PollSubscriptionRunner::new(config).unwrap();
+        let first = runner
+            .process_response(json!({"items":[{"id":1},{"id":2}]}), None)
+            .unwrap();
+        assert!(first.emitted_items.is_empty());
+        let second = runner
+            .process_response(json!({"items":[{"id":2},{"id":3}]}), None)
+            .unwrap();
+        assert_eq!(second.emitted_items, vec![json!({"id":3})]);
+    }
+
+    #[test]
+    fn initial_items_limit_baseline_applies_once_even_with_empty_first_page() {
+        let mut config = item_key_config();
+        config.initial_items_limit = Some(0);
+        let mut runner = PollSubscriptionRunner::new(config).unwrap();
+        let empty = runner.process_response(json!({"items":[]}), None).unwrap();
+        assert!(empty.emitted_items.is_empty());
+        // Baseline was established even though the first page was empty, so
+        // later arrivals must not be swallowed by the zero limit.
+        let later = runner
+            .process_response(json!({"items":[{"id":9}]}), None)
+            .unwrap();
+        assert_eq!(later.emitted_items, vec![json!({"id":9})]);
+    }
+
+    #[test]
+    fn initial_items_limit_caps_watermark_first_look() {
+        let mut runner = PollSubscriptionRunner::new(PollSubscriptionConfig {
+            interval_secs: 1,
+            extract_items_pointer: "/items".to_string(),
+            missing_extract_items_pointer_as_empty: false,
+            request_cursor_arg: None,
+            response_cursor_pointer: None,
+            cursor_from_item_pointer: None,
+            cursor_transform: None,
+            initial_items_limit: Some(1),
+            checkpoint_strategy: PollCheckpointStrategy::Watermark {
+                item_watermark_pointer: "/ts".to_string(),
+                item_tiebreaker_pointer: None,
+                seen_window: Some(4),
+            },
+        })
+        .unwrap();
+        let first = runner
+            .process_response(json!({"items":[{"ts":1},{"ts":2}]}), None)
+            .unwrap();
+        assert_eq!(first.emitted_items, vec![json!({"ts":1})]);
+        // The watermark advanced past the whole first page.
+        let second = runner
+            .process_response(json!({"items":[{"ts":2},{"ts":3}]}), None)
+            .unwrap();
+        assert_eq!(second.emitted_items, vec![json!({"ts":3})]);
+    }
+
+    #[test]
+    fn initial_items_limit_rejects_cursor_only_strategy() {
+        let err = PollSubscriptionConfig {
+            interval_secs: 1,
+            extract_items_pointer: "/items".to_string(),
+            missing_extract_items_pointer_as_empty: false,
+            request_cursor_arg: Some("cursor".to_string()),
+            response_cursor_pointer: Some("/next".to_string()),
+            cursor_from_item_pointer: None,
+            cursor_transform: None,
+            initial_items_limit: Some(5),
+            checkpoint_strategy: PollCheckpointStrategy::CursorOnly,
+        }
+        .validate()
+        .unwrap_err();
+
+        assert!(err.to_string().contains("initial_items_limit"));
+    }
+
+    #[test]
     fn watermark_strategy_uses_tiebreaker() {
         let mut runner = PollSubscriptionRunner::new(PollSubscriptionConfig {
             interval_secs: 1,
@@ -662,6 +814,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: None,
             cursor_transform: None,
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::Watermark {
                 item_watermark_pointer: "/updated_at".to_string(),
                 item_tiebreaker_pointer: Some("/id".to_string()),
@@ -710,6 +863,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: None,
             cursor_transform: None,
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::ContentHash {
                 seen_window: Some(4),
             },
@@ -732,6 +886,7 @@ mod tests {
             response_cursor_pointer: Some("/next_cursor".to_string()),
             cursor_from_item_pointer: None,
             cursor_transform: None,
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::CursorOnly,
         })
         .unwrap();
@@ -753,6 +908,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: None,
             cursor_transform: None,
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::Watermark {
                 item_watermark_pointer: "/updated_at".to_string(),
                 item_tiebreaker_pointer: Some("/id".to_string()),
@@ -791,6 +947,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: None,
             cursor_transform: Some(PollCursorTransform::Increment),
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::ItemKey {
                 item_key_pointer: "/id".to_string(),
                 seen_window: Some(4),
@@ -814,6 +971,7 @@ mod tests {
             response_cursor_pointer: Some("/next_cursor".to_string()),
             cursor_from_item_pointer: Some("/update_id".to_string()),
             cursor_transform: None,
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::CursorOnly,
         }
         .validate()
@@ -832,6 +990,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: Some("/update_id".to_string()),
             cursor_transform: Some(PollCursorTransform::Increment),
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::ItemKey {
                 item_key_pointer: "/update_id".to_string(),
                 seen_window: Some(8),
@@ -863,6 +1022,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: Some("/update_id".to_string()),
             cursor_transform: Some(PollCursorTransform::Increment),
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::ItemKey {
                 item_key_pointer: "/update_id".to_string(),
                 seen_window: Some(8),
@@ -896,6 +1056,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: Some("/update_id".to_string()),
             cursor_transform: Some(PollCursorTransform::Increment),
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::ItemKey {
                 item_key_pointer: "/update_id".to_string(),
                 seen_window: Some(8),
@@ -935,6 +1096,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: Some("/update_id".to_string()),
             cursor_transform: Some(PollCursorTransform::Increment),
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::ItemKey {
                 item_key_pointer: "/update_id".to_string(),
                 seen_window: Some(8),
@@ -959,6 +1121,7 @@ mod tests {
             response_cursor_pointer: Some("/next_batch".to_string()),
             cursor_from_item_pointer: None,
             cursor_transform: None,
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::CursorOnly,
         })
         .unwrap();
@@ -982,6 +1145,7 @@ mod tests {
             response_cursor_pointer: Some("/next_batch".to_string()),
             cursor_from_item_pointer: None,
             cursor_transform: None,
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::CursorOnly,
         })
         .unwrap();
@@ -1005,6 +1169,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: None,
             cursor_transform: None,
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::ItemKey {
                 item_key_pointer: "/id".to_string(),
                 seen_window: Some(8),
@@ -1036,6 +1201,7 @@ mod tests {
             response_cursor_pointer: None,
             cursor_from_item_pointer: None,
             cursor_transform: None,
+            initial_items_limit: None,
             checkpoint_strategy: PollCheckpointStrategy::ContentHash {
                 seen_window: Some(8),
             },


### PR DESCRIPTION
Companion to holon-run/agentinbox#241 (email onboarding cannot control initial backfill depth).

## Problem
- `imap idle` subscriptions read `args.initial_fetch_limit` (default 25, max 100), but the value was not passable from agentinbox, and **0 meant "fetch everything"** (`fetch_recent(0)` skips the window split) — the opposite of the requested "0 = new mail only".
- provider-poll transports (gmail/graph/jmap) had no first-look depth control at all: the first poll emitted the whole provider page (~100 for Gmail).

## Changes
### IMAP IDLE (`subscription_email.rs`)
- `initial_fetch_limit = 0` now means **new mail only**: the subscription establishes the high-water UID via `UID SEARCH ALL` (new `latest_uid()`) without fetching or emitting pre-existing messages; only mail arriving after the subscription starts is emitted.
- Default 25 / max 100 promoted to named constants.

### Poll engine (`subscription_poll.rs`)
- `PollSubscriptionConfig.initial_items_limit` bounds the first-look backfill for the item_key / watermark / content_hash strategies:
  - the whole first page is recorded in the checkpoint (nothing older is ever re-delivered),
  - at most N unseen items are emitted in page order (providers return newest first),
  - `0` establishes the baseline without emitting anything.
- A persisted `baseline_done` checkpoint marker applies the policy to exactly one cycle — an empty first page still counts, so later arrivals are never swallowed. Existing checkpoints deserialize with the marker unset and are conservatively re-baselined once on upgrade.
- `cursor_only` rejects the option in `validate()` (no seen-state to baseline against).
- `packages/uxc-daemon-client` types carry the new field.

## Compatibility
Old daemons ignore the unknown `poll_config` field (serde default), so agentinbox can ship the passthrough independently.

## Test plan
- `cargo test` — full suite green (new cases: zero-limit baseline, first-look caps for item_key/watermark, empty-first-page baseline, cursor_only rejection, `latest_uid`, `emit_recent_messages` for 0 and positive limits)
- `cargo fmt --check`, `cargo clippy` clean