### PR TITLE
fix(auth): accept password-class fields as usable basic-auth secret

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -28,6 +28,10 @@ const CREDENTIALS_FILE_ENV: &str = "UXC_CREDENTIALS_FILE";
 const AUTH_BINDINGS_FILE_ENV: &str = "UXC_AUTH_BINDINGS_FILE";
 pub const PRIMARY_SECRET_FIELD: &str = "secret";
 
+/// Field names that basic-auth transports resolve as the effective password
+/// secret (mirrors `resolve_email_imap_idle_runtime_config`).
+pub const BASIC_PASSWORD_FIELD_NAMES: [&str; 2] = ["password", "app_password"];
+
 /// Authentication type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthType {
@@ -640,6 +644,17 @@ impl Profile {
 
     pub fn has_bootstrap_config(&self) -> bool {
         self.bootstrap.is_some()
+    }
+
+    /// Whether a password-class field is configured for basic-auth transports.
+    ///
+    /// Basic-auth transports (for example `email-imap-idle`) resolve the
+    /// effective secret from the `password`/`app_password` fields, so such a
+    /// profile has a usable secret even when the main secret is empty.
+    pub fn has_basic_password_field(&self) -> bool {
+        BASIC_PASSWORD_FIELD_NAMES
+            .iter()
+            .any(|name| self.fields.contains_key(*name))
     }
 
     fn active_secret_for_masking(&self) -> String {
@@ -1576,6 +1591,17 @@ fn validate_ready(profile: &Profile) -> Result<()> {
             if profile.api_key.is_empty() {
                 anyhow::bail!(
                     "Credential '{}' does not have a usable secret. Set it with --secret, --secret-env, or --secret-op.",
+                    profile.name.as_deref().unwrap_or("unknown"),
+                );
+            }
+        }
+        AuthType::Basic => {
+            if profile.api_key.is_empty()
+                && !profile.has_bootstrap_config()
+                && !profile.has_basic_password_field()
+            {
+                anyhow::bail!(
+                    "Credential '{}' does not have a usable secret. Set it with --secret, --secret-env, --secret-op, or a password/app_password field.",
                     profile.name.as_deref().unwrap_or("unknown"),
                 );
             }
@@ -3391,6 +3417,92 @@ mod tests {
         }));
 
         validate_ready(&profile).unwrap();
+    }
+
+    #[test]
+    fn has_basic_password_field_detects_password_class_fields() {
+        let mut profile = Profile::new(String::new(), AuthType::Basic);
+        assert!(!profile.has_basic_password_field());
+
+        profile
+            .set_field_source(
+                "username".to_string(),
+                SecretSource::Literal {
+                    value: "user@example.com".to_string(),
+                },
+            )
+            .unwrap();
+        assert!(!profile.has_basic_password_field());
+
+        profile
+            .set_field_source(
+                "app_password".to_string(),
+                SecretSource::Literal {
+                    value: "pw".to_string(),
+                },
+            )
+            .unwrap();
+        assert!(profile.has_basic_password_field());
+    }
+
+    #[test]
+    fn validate_ready_accepts_basic_password_fields_as_usable_secret() {
+        for field_name in ["password", "app_password"] {
+            let mut profile = Profile::new(String::new(), AuthType::Basic);
+            profile.name = Some("email-basic".to_string());
+            profile
+                .set_field_source(
+                    "username".to_string(),
+                    SecretSource::Literal {
+                        value: "user@example.com".to_string(),
+                    },
+                )
+                .unwrap();
+            profile
+                .set_field_source(
+                    field_name.to_string(),
+                    SecretSource::Literal {
+                        value: "pw".to_string(),
+                    },
+                )
+                .unwrap();
+            let profile = profile.materialize_runtime().unwrap();
+            validate_ready(&profile).unwrap();
+        }
+    }
+
+    #[test]
+    fn validate_ready_rejects_basic_without_any_secret() {
+        let mut profile = Profile::new(String::new(), AuthType::Basic);
+        profile.name = Some("email-basic".to_string());
+        profile
+            .set_field_source(
+                "username".to_string(),
+                SecretSource::Literal {
+                    value: "user@example.com".to_string(),
+                },
+            )
+            .unwrap();
+        let profile = profile.materialize_runtime().unwrap();
+        let err = validate_ready(&profile).unwrap_err();
+        assert!(err.to_string().contains("usable secret"));
+        assert!(err.to_string().contains("password/app_password field"));
+    }
+
+    #[test]
+    fn validate_ready_does_not_extend_password_fields_to_bearer() {
+        let mut profile = Profile::new(String::new(), AuthType::Bearer);
+        profile
+            .set_field_source(
+                "password".to_string(),
+                SecretSource::Literal {
+                    value: "pw".to_string(),
+                },
+            )
+            .unwrap();
+        let profile = profile.materialize_runtime().unwrap();
+        let err = validate_ready(&profile).unwrap_err();
+        assert!(err.to_string().contains("usable secret"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1083,6 +1083,9 @@ struct AuthProfileView {
     name: String,
     auth_type: String,
     api_key_masked: String,
+    /// Present when the main secret is empty but a password-class field
+    /// covers basic-auth transports.
+    secret_hint: Option<String>,
     secret_source: Option<AuthSecretSourceView>,
     fields: Option<Vec<AuthFieldView>>,
     auth_headers: Option<Vec<AuthHeaderView>>,
@@ -3259,6 +3262,9 @@ fn render_text_output(envelope: &OutputEnvelope) -> Result<()> {
             println!("Credential: {}", credential.name);
             println!("  Type: {}", credential.auth_type);
             println!("  Secret: {}", credential.api_key_masked);
+            if let Some(hint) = credential.secret_hint {
+                println!("  Secret Hint: {}", hint);
+            }
             if let Some(source) = credential.secret_source {
                 println!("  Source: {}", source.kind);
             }
@@ -6658,13 +6664,19 @@ async fn handle_auth_credential_command(
             }
 
             if resolved_auth_type != AuthType::OAuth {
-                let has_existing_secret = matches!(
-                    profile_obj.secret_source,
-                    Some(crate::auth::SecretSource::Literal { .. })
-                        | Some(crate::auth::SecretSource::Env { .. })
-                        | Some(crate::auth::SecretSource::Op { .. })
-                ) || (previous_auth_type != Some(AuthType::OAuth)
-                    && !profile_obj.api_key.is_empty());
+                let has_existing_secret =
+                    profile_obj
+                        .secret_source
+                        .as_ref()
+                        .is_some_and(|source| match source {
+                            // An empty literal (the `Profile::new` default) is not
+                            // a usable secret; do not let it bypass validation.
+                            crate::auth::SecretSource::Literal { value } => !value.is_empty(),
+                            crate::auth::SecretSource::Env { .. }
+                            | crate::auth::SecretSource::Op { .. } => true,
+                        })
+                        || (previous_auth_type != Some(AuthType::OAuth)
+                            && !profile_obj.api_key.is_empty());
 
                 let requires_secret = if resolved_auth_type == AuthType::ApiKey {
                     if profile_obj.has_custom_api_key_headers()
@@ -6675,6 +6687,14 @@ async fn handle_auth_credential_command(
                     } else {
                         profile_obj.fields.is_empty()
                     }
+                } else if resolved_auth_type == AuthType::Basic {
+                    // Basic-auth transports resolve the secret from
+                    // password-class fields, so they do not require a main
+                    // secret when one of those (or a `secret` field) exists.
+                    !(profile_obj
+                        .fields
+                        .contains_key(crate::auth::PRIMARY_SECRET_FIELD)
+                        || profile_obj.has_basic_password_field())
                 } else if resolved_auth_type == AuthType::Bearer {
                     profile_obj.fields.is_empty()
                 } else {
@@ -6682,11 +6702,12 @@ async fn handle_auth_credential_command(
                 };
 
                 if provided_secret_flags == 0 && !has_existing_secret && requires_secret {
-                    return Err(UxcError::InvalidArguments(
+                    let message = if resolved_auth_type == AuthType::Basic {
+                        "Credential set requires one of --secret, --secret-env, --secret-op, or a password/app_password field"
+                    } else {
                         "Credential set requires one of --secret, --secret-env, or --secret-op"
-                            .to_string(),
-                    )
-                    .into());
+                    };
+                    return Err(UxcError::InvalidArguments(message.to_string()).into());
                 }
             }
 
@@ -7617,6 +7638,7 @@ fn to_auth_profile_view(name: &str, profile: &Profile) -> AuthProfileView {
         name: name.to_string(),
         auth_type: profile.auth_type.to_string(),
         api_key_masked: profile.mask_api_key(),
+        secret_hint: basic_secret_hint(profile),
         secret_source: profile
             .secret_source
             .as_ref()
@@ -7666,6 +7688,22 @@ fn to_auth_profile_view(name: &str, profile: &Profile) -> AuthProfileView {
         description: profile.description.clone(),
         oauth,
         bootstrap,
+    }
+}
+
+/// Hint shown by `credential info` when a basic-auth credential has no main
+/// secret but a password-class field that basic-auth transports resolve.
+fn basic_secret_hint(profile: &Profile) -> Option<String> {
+    if profile.auth_type == crate::auth::AuthType::Basic
+        && profile.mask_api_key().is_empty()
+        && profile.has_basic_password_field()
+    {
+        Some(
+            "main secret is empty; basic-auth transports will use the password/app_password field as the secret"
+                .to_string(),
+        )
+    } else {
+        None
     }
 }
 

--- a/tests/auth_credential_basic_secret_cli_test.rs
+++ b/tests/auth_credential_basic_secret_cli_test.rs
@@ -1,0 +1,130 @@
+//! CLI tests for basic-auth credentials whose secret lives in password-class
+//! fields instead of the main secret (issue #447).
+
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+
+struct AuthFiles {
+    _temp_dir: TempDir,
+    credentials_file: PathBuf,
+    bindings_file: PathBuf,
+}
+
+impl AuthFiles {
+    fn new() -> Self {
+        let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+        Self {
+            credentials_file: temp_dir.path().join("credentials.json"),
+            bindings_file: temp_dir.path().join("auth_bindings.json"),
+            _temp_dir: temp_dir,
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_uxc"));
+        cmd.env("UXC_CREDENTIALS_FILE", &self.credentials_file);
+        cmd.env("UXC_AUTH_BINDINGS_FILE", &self.bindings_file);
+        cmd
+    }
+}
+
+fn run(cmd: &mut Command) -> Value {
+    let output = cmd.output().expect("uxc command should run");
+    serde_json::from_slice(&output.stdout).expect("stdout should be a JSON envelope")
+}
+
+#[test]
+fn credential_set_basic_accepts_password_field_without_main_secret() {
+    let files = AuthFiles::new();
+
+    let envelope = run(files.command().args([
+        "auth",
+        "credential",
+        "set",
+        "email-basic",
+        "--auth-type",
+        "basic",
+        "--field",
+        "username=literal:user@example.com",
+        "--field",
+        "password=literal:app-password",
+    ]));
+
+    assert_eq!(envelope["ok"], true, "set should succeed: {}", envelope);
+    assert_eq!(envelope["kind"], "auth_set_result");
+    assert_eq!(envelope["data"]["api_key_masked"], "");
+    let hint = envelope["data"]["secret_hint"]
+        .as_str()
+        .expect("set result should carry a secret hint");
+    assert!(
+        hint.contains("password/app_password field"),
+        "hint: {}",
+        hint
+    );
+
+    let info = run(files
+        .command()
+        .args(["auth", "credential", "info", "email-basic"]));
+    assert_eq!(info["ok"], true);
+    assert_eq!(info["kind"], "auth_info");
+    assert_eq!(info["data"]["api_key_masked"], "");
+    assert!(info["data"]["secret_hint"]
+        .as_str()
+        .expect("info should carry a secret hint")
+        .contains("password/app_password field"));
+}
+
+#[test]
+fn credential_set_basic_without_any_secret_fails_fast() {
+    let files = AuthFiles::new();
+
+    let output = files
+        .command()
+        .args([
+            "auth",
+            "credential",
+            "set",
+            "email-basic",
+            "--auth-type",
+            "basic",
+            "--field",
+            "username=literal:user@example.com",
+        ])
+        .output()
+        .expect("uxc command should run");
+
+    assert!(
+        !output.status.success(),
+        "set without any secret should fail"
+    );
+    let envelope: Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be a JSON envelope");
+    assert_eq!(envelope["ok"], false);
+    assert_eq!(envelope["error"]["code"], "INVALID_ARGUMENT");
+    assert!(envelope["error"]["message"]
+        .as_str()
+        .expect("error message")
+        .contains("password/app_password field"));
+}
+
+#[test]
+fn credential_set_basic_accepts_secret_field() {
+    let files = AuthFiles::new();
+
+    let envelope = run(files.command().args([
+        "auth",
+        "credential",
+        "set",
+        "email-basic",
+        "--auth-type",
+        "basic",
+        "--field",
+        "secret=literal:app-password",
+    ]));
+
+    assert_eq!(envelope["ok"], true, "set should succeed: {}", envelope);
+    assert_ne!(envelope["data"]["api_key_masked"], "");
+    assert_eq!(envelope["data"]["secret_hint"], Value::Null);
+}

--- a/tests/auth_integration_test.rs
+++ b/tests/auth_integration_test.rs
@@ -548,3 +548,70 @@ fn test_profile_name_validation_starts_with_digit() {
         .to_string()
         .contains("cannot start with a digit"));
 }
+
+#[test]
+fn test_resolve_auth_accepts_basic_password_field_secret() {
+    let _temp_dir = setup_test_env();
+
+    let mut profiles = Profiles::new();
+    let mut profile = Profile::new(String::new(), AuthType::Basic);
+    profile.name = Some("email-basic".to_string());
+    profile
+        .set_field_source(
+            "username".to_string(),
+            uxc::auth::SecretSource::Literal {
+                value: "user@example.com".to_string(),
+            },
+        )
+        .expect("username field should be accepted");
+    profile
+        .set_field_source(
+            "password".to_string(),
+            uxc::auth::SecretSource::Literal {
+                value: "app-password".to_string(),
+            },
+        )
+        .expect("password field should be accepted");
+    profiles
+        .set_profile("email-basic".to_string(), profile)
+        .expect("Failed to set profile");
+    profiles.save_profiles().expect("Failed to save profiles");
+
+    // Basic-auth transports resolve the password from fields, so the
+    // credential must be considered ready even without a main secret.
+    let resolved = uxc::auth::resolve_auth_for_endpoint(
+        "imaps://outlook.office365.com:993",
+        Some("email-basic".to_string()),
+    )
+    .expect("basic credential with password field should resolve");
+    assert!(resolved.is_some());
+}
+
+#[test]
+fn test_resolve_auth_rejects_basic_without_any_secret() {
+    let _temp_dir = setup_test_env();
+
+    let mut profiles = Profiles::new();
+    let mut profile = Profile::new(String::new(), AuthType::Basic);
+    profile.name = Some("email-basic".to_string());
+    profile
+        .set_field_source(
+            "username".to_string(),
+            uxc::auth::SecretSource::Literal {
+                value: "user@example.com".to_string(),
+            },
+        )
+        .expect("username field should be accepted");
+    profiles
+        .set_profile("email-basic".to_string(), profile)
+        .expect("Failed to set profile");
+    profiles.save_profiles().expect("Failed to save profiles");
+
+    let err = uxc::auth::resolve_auth_for_endpoint(
+        "imaps://outlook.office365.com:993",
+        Some("email-basic".to_string()),
+    )
+    .expect_err("basic credential without any secret should fail");
+    assert!(err.to_string().contains("does not have a usable secret"));
+    assert!(err.to_string().contains("password/app_password field"));
+}


### PR DESCRIPTION
## What

- `validate_ready` now treats `password` / `app_password` fields as a usable secret for `AuthType::Basic` credentials, matching how basic-auth transports (e.g. `email-imap-idle`) resolve the effective secret at runtime.
- `credential info` (and the `credential set` result) reports a `secret_hint` when the main secret is empty but a password-class field covers basic-auth transports; text output shows a `Secret Hint` line.
- `credential set --auth-type basic` no longer demands a main secret when a `password`/`app_password` (or `secret`) field is provided; the error message lists the password-field option.
- Fixed a validation bypass where an empty `Literal` secret source (the `Profile::new` default) counted as an existing secret during `credential set`.

## Why

Issue #447: basic-auth transports such as `email-imap-idle` keep the real password in profile fields (`password`/`app_password`), but the generic readiness check only looked at the main secret, so `credential set` and other `validate_ready` consumers failed late with "does not have a usable secret" even though the transport could resolve the secret from the fields.

## How

- `src/auth/mod.rs`: new `BASIC_PASSWORD_FIELD_NAMES` (`password`, `app_password`) mirroring `resolve_email_imap_idle_runtime_config`, `Profile::has_basic_password_field()`, and a dedicated `AuthType::Basic` branch in `validate_ready`.
- `src/main.rs`: `AuthProfileView.secret_hint` + `basic_secret_hint()`, a text-mode `Secret Hint` line, and set-time secret validation aligned for basic auth (including the empty-Literal fix).

## Testing

- Unit tests: basic + `password`/`app_password` field passes `validate_ready`; basic without any secret still fails with the updated message; bearer is unaffected.
- New CLI integration test `tests/auth_credential_basic_secret_cli_test.rs`: `credential set` with only a password field succeeds and returns the `secret_hint`.
- `tests/auth_integration_test.rs`: set-time validation coverage for the new basic-auth path.
- Full `cargo test` passed locally; `cargo fmt --check` and CI-equivalent `cargo clippy -- -D warnings ...` clean.

Closes #447