### PR TITLE
fix(auth): warn when daemon-managed sources reference env-sourced secrets

### DIFF
--- a/docs/site/auth/secret-sources.md
+++ b/docs/site/auth/secret-sources.md
@@ -38,6 +38,27 @@ uxc auth credential set flipside --auth-type api_key --query-param "apiKey={{sec
 - `--header` and `--query-param` can be repeated and templated
 - resolved values from `env` and `op` are used at runtime and are not stored as plaintext
 
+## Env Sources and Daemon Resolution
+
+`env` secret sources are resolved in whichever process performs the call:
+
+- one-off CLI calls resolve the variable from your current shell
+- daemon-managed sources (`uxc source ensure ...`, for example email IMAP IDLE
+  or provider poll sources) resolve credentials inside the daemon process
+
+An already-running daemon does not inherit variables exported in the shell that
+later runs `uxc source ensure`, so an env-sourced secret attached to a
+daemon-managed source can fail authentication with no hint that the lookup
+happened in a different process. `uxc source ensure` prints a warning on stderr
+whenever the resolved credential references env-sourced secrets.
+
+Recommended alternatives for daemon-managed sources:
+
+- store the secret directly: `uxc auth credential set demo --secret <value>`
+- reference 1Password: `uxc auth credential set demo --secret-op op://vault/demo/token`
+  (the daemon must have a valid 1Password auth context)
+- or export the variable in the daemon's own environment and restart the daemon
+
 ## 1Password and Daemon Scope
 
 When using `--secret-op`, resolution happens in the daemon execution path.

--- a/docs/site/daemon/index.md
+++ b/docs/site/daemon/index.md
@@ -29,6 +29,11 @@ npm install @holon-run/uxc-daemon-client
 The daemon is especially useful when auth resolution, session reuse, or
 background subscriptions should stay outside one-off CLI processes.
 
+Credentials for daemon-managed sources are resolved inside the daemon process,
+which does not inherit env vars exported in the invoking shell; see
+[Secret Sources](../auth/secret-sources.md) for the boundary and recommended
+alternatives.
+
 <!-- INDEX:START -->
 
 - [Daemon API](./api.md)

--- a/docs/site/sources/email.md
+++ b/docs/site/sources/email.md
@@ -27,6 +27,12 @@ The subscription holds the connection open with IMAP IDLE and emits one
 auth profile (`--auth email-primary`); store the IMAP username and password in
 that profile with your preferred auth mechanism.
 
+These subscriptions resolve credentials inside the daemon process, so
+env-sourced secrets (`--secret-env`) cannot see variables exported in the
+shell that runs `uxc source ensure`. `uxc source ensure` warns on stderr in
+that case; see [Secret Sources](../auth/secret-sources.md) for recommended
+alternatives such as literal secrets or 1Password references.
+
 ### Provider Polling
 
 ```bash

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -614,6 +614,32 @@ impl Profile {
         Ok(self)
     }
 
+    /// Describe env-sourced secret references in this profile.
+    ///
+    /// Entries look like `secret (env DEMO_TOKEN)` for the primary secret and
+    /// `field 'password' (env IMAP_PASSWORD)` for named fields. The CLI uses
+    /// this to warn when a daemon-resolved credential references environment
+    /// the daemon process cannot see.
+    pub fn env_sourced_secret_refs(&self) -> Vec<String> {
+        let mut refs = Vec::new();
+        if let Some(SecretSource::Env { key }) = &self.secret_source {
+            refs.push(format!("secret (env {})", key));
+        }
+        let mut env_fields: Vec<(&String, &String)> = self
+            .fields
+            .iter()
+            .filter_map(|(name, source)| match source {
+                SecretSource::Env { key } => Some((name, key)),
+                _ => None,
+            })
+            .collect();
+        env_fields.sort_by(|a, b| a.0.cmp(b.0));
+        for (name, key) in env_fields {
+            refs.push(format!("field '{}' (env {})", name, key));
+        }
+        refs
+    }
+
     /// Mask the API key for display (show only first 8 and last 4 characters)
     pub fn mask_api_key(&self) -> String {
         let key = self.active_secret_for_masking();
@@ -3039,6 +3065,45 @@ mod tests {
         let profile = Profile::new("test-key".to_string(), AuthType::ApiKey)
             .with_description("Test profile".to_string());
         assert_eq!(profile.description, Some("Test profile".to_string()));
+    }
+
+    #[test]
+    fn test_env_sourced_secret_refs_describes_primary_and_fields() {
+        let mut profile = Profile::new("test-key".to_string(), AuthType::ApiKey);
+        profile.secret_source = Some(SecretSource::Env {
+            key: "DEMO_TOKEN".to_string(),
+        });
+        profile.fields.insert(
+            "password".to_string(),
+            SecretSource::Env {
+                key: "IMAP_PASSWORD".to_string(),
+            },
+        );
+        profile.fields.insert(
+            "literal_field".to_string(),
+            SecretSource::Literal {
+                value: "plain".to_string(),
+            },
+        );
+        assert_eq!(
+            profile.env_sourced_secret_refs(),
+            vec![
+                "secret (env DEMO_TOKEN)".to_string(),
+                "field 'password' (env IMAP_PASSWORD)".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_env_sourced_secret_refs_empty_for_non_env_sources() {
+        let mut profile = Profile::new("test-key".to_string(), AuthType::ApiKey);
+        profile.fields.insert(
+            "api_key".to_string(),
+            SecretSource::Op {
+                reference: "op://vault/demo/token".to_string(),
+            },
+        );
+        assert!(profile.env_sourced_secret_refs().is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6051,12 +6051,50 @@ fn build_managed_source_spec(
     })
 }
 
+/// Daemon-managed sources resolve credentials inside the daemon process, which
+/// does not inherit env vars exported in the invoking shell after the daemon
+/// started. Warn before sending the ensure request so this failure mode is
+/// visible instead of authentication failing with no hint about where the env
+/// lookup happened.
+fn warn_daemon_env_sourced_secrets(endpoint: &str, explicit_auth: Option<&str>) {
+    let credential_id = match explicit_auth {
+        Some(id) => Some(id.to_string()),
+        None => AuthBindings::load_bindings().ok().and_then(|bindings| {
+            bindings
+                .matching_rule(endpoint)
+                .map(|rule| rule.credential.clone())
+        }),
+    };
+    let Some(credential_id) = credential_id else {
+        return;
+    };
+    let Ok(profiles) = Profiles::load_profiles() else {
+        return;
+    };
+    let Ok(profile) = profiles.get_profile(&credential_id) else {
+        return;
+    };
+    let refs = profile.env_sourced_secret_refs();
+    if refs.is_empty() {
+        return;
+    }
+    eprintln!(
+        "Warning: daemon-managed sources resolve credentials inside the daemon process, which may not see env vars exported in this shell. Credential '{}' resolves {} from the environment. If the source fails authentication, re-create the credential with `uxc auth credential set {} --secret <value>` or `--secret-op <ref>`, or make the variable available to the daemon process and restart it.",
+        credential_id,
+        refs.join(", "),
+        credential_id
+    );
+}
+
 async fn handle_source_command(command: &SourceCommands, cli: &Cli) -> Result<OutputEnvelope> {
     if cli.schema_url.is_some() {
         return Err(UxcError::InvalidArguments(
             "--schema-url is not supported for source commands".to_string(),
         )
         .into());
+    }
+    if let SourceCommands::Ensure { endpoint, .. } = command {
+        warn_daemon_env_sourced_secrets(endpoint, cli.auth.as_deref());
     }
     let daemon_ensure = daemon::ensure_compatible_daemon_running().await?;
     let daemon_autostarted =

--- a/tests/source_cli_test.rs
+++ b/tests/source_cli_test.rs
@@ -186,3 +186,109 @@ fn source_doctor_warns_on_legacy_cursor_file() {
 
     daemon_stop_best_effort_with_home(temp_home.path());
 }
+
+#[test]
+#[serial]
+fn source_ensure_warns_when_credential_uses_env_secret() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+    let server = start_test_server("openapi", "ok");
+
+    let credential = uxc_command_with_home(temp_home.path())
+        .arg("auth")
+        .arg("credential")
+        .arg("set")
+        .arg("env-demo")
+        .arg("--secret-env")
+        .arg("UXC_ITEST_UNSET_ENV_SECRET")
+        .output()
+        .expect("uxc auth credential set should run");
+    assert!(
+        credential.status.success(),
+        "credential set should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&credential.stdout),
+        String::from_utf8_lossy(&credential.stderr)
+    );
+
+    let mut ensure = uxc_command_with_home(temp_home.path());
+    ensure
+        .arg("source")
+        .arg("ensure")
+        .arg("test")
+        .arg("warn-env-secret")
+        .arg(&server.addr)
+        .arg("get:/poll/events")
+        .arg("--mode")
+        .arg("poll")
+        .arg("--poll-config")
+        .arg(
+            r#"{"interval_secs":1,"extract_items_pointer":"/items","request_cursor_arg":"cursor","response_cursor_pointer":"/next_cursor","checkpoint_strategy":{"type":"cursor_only"}}"#,
+        )
+        .arg("--auth")
+        .arg("env-demo")
+        .env_remove("UXC_ITEST_UNSET_ENV_SECRET");
+    let output = ensure.output().expect("uxc source ensure should run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("daemon-managed sources resolve credentials inside the daemon process"),
+        "expected env-secret warning on stderr, got:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains("env-demo"),
+        "warning should name the credential, got:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains("UXC_ITEST_UNSET_ENV_SECRET"),
+        "warning should name the env var, got:\n{}",
+        stderr
+    );
+
+    daemon_stop_best_effort_with_home(temp_home.path());
+}
+
+#[test]
+#[serial]
+fn source_ensure_does_not_warn_for_literal_secret() {
+    let temp_home = tempfile::tempdir().expect("temp home should be created");
+    daemon_stop_best_effort_with_home(temp_home.path());
+    let server = start_test_server("openapi", "ok");
+
+    let credential = uxc_command_with_home(temp_home.path())
+        .arg("auth")
+        .arg("credential")
+        .arg("set")
+        .arg("literal-demo")
+        .arg("--secret")
+        .arg("sk-test-literal")
+        .output()
+        .expect("uxc auth credential set should run");
+    assert!(credential.status.success());
+
+    let output = uxc_command_with_home(temp_home.path())
+        .arg("source")
+        .arg("ensure")
+        .arg("test")
+        .arg("literal-secret")
+        .arg(&server.addr)
+        .arg("get:/poll/events")
+        .arg("--mode")
+        .arg("poll")
+        .arg("--poll-config")
+        .arg(
+            r#"{"interval_secs":1,"extract_items_pointer":"/items","request_cursor_arg":"cursor","response_cursor_pointer":"/next_cursor","checkpoint_strategy":{"type":"cursor_only"}}"#,
+        )
+        .arg("--auth")
+        .arg("literal-demo")
+        .output()
+        .expect("uxc source ensure should run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("env-sourced") && !stderr.contains("env vars exported in this shell"),
+        "literal secret should not trigger the env warning, got:\n{}",
+        stderr
+    );
+
+    daemon_stop_best_effort_with_home(temp_home.path());
+}


### PR DESCRIPTION
## What

- Add `Profile::env_sourced_secret_refs` describing env-sourced primary secret and field references for a credential profile.
- `uxc source ensure` now checks the resolved credential (explicit `--auth` or endpoint binding) before sending the ensure request and prints a stderr warning when it references env-sourced secrets.
- Document the daemon secret resolution boundary and recommended alternatives (`--secret` literal, `--secret-op` 1Password reference) in the secret-sources, daemon, and email docs.

## Why

Daemon-managed sources resolve credentials inside the daemon process, which does not inherit env vars exported in the invoking shell, so env-sourced secrets fail authentication with no hint about where the lookup happened (#448).

## How

- `src/auth/mod.rs`: new profile helper that enumerates env-sourced secret references (primary `secret_source` plus per-field sources).
- `src/main.rs`: pre-flight check in the `source ensure` CLI path that emits the warning before the RPC is sent; warning only, no behavior change to resolution itself.
- `docs/site/`: resolution-boundary notes added where secret sources and daemon/email sources are documented.

## Testing

- New CLI warning tests in `tests/source_cli_test.rs` covering explicit `--auth` and endpoint-binding resolution paths.
- Full `cargo test` passed locally (exit 0).

Closes #448