### PR TITLE
feat(email): add IMAP/SMTP XOAUTH2 for Microsoft personal accounts

### DIFF
--- a/docs/site/sources/email.md
+++ b/docs/site/sources/email.md
@@ -201,11 +201,12 @@ Notes:
 
 - Use `--auth` with credentials containing `username`/`user`/`account` and
   `password`/`secret` fields when SMTP AUTH is required.
-- `smtp://` upgrades to TLS via STARTTLS automatically when the server
-  advertises it; `smtps://` (implicit TLS, port 465) is also supported.
-- Password AUTH (`AUTH PLAIN`) over a `smtp://` connection that cannot be
-  upgraded requires explicit `--allow-insecure-auth`; prefer a trusted local
-  relay or STARTTLS-capable submission endpoint.
+- `smtps://` (implicit TLS, port 465) is supported for every auth mode; for
+  OAuth credentials, `smtp://` also upgrades to TLS via STARTTLS automatically
+  when the server advertises it.
+- Password AUTH (`AUTH PLAIN`) over `smtp://` is not auto-upgraded and requires
+  explicit `--allow-insecure-auth` (the password travels in cleartext); prefer
+  a trusted local relay, `smtps://`, or OAuth credentials.
 - OAuth credentials authenticate with `AUTH XOAUTH2`. This is how Microsoft
   personal accounts send mail:
 

--- a/docs/site/sources/email.md
+++ b/docs/site/sources/email.md
@@ -33,14 +33,59 @@ shell that runs `uxc source ensure`. `uxc source ensure` warns on stderr in
 that case; see [Secret Sources](../auth/secret-sources.md) for recommended
 alternatives such as literal secrets or 1Password references.
 
-> **Microsoft personal accounts do not support IMAP basic auth.**
+> **Microsoft personal accounts require OAuth (XOAUTH2).**
 > Personal Microsoft accounts (`outlook.com`, `hotmail.com`, `live.com`)
-> reject `LOGIN` with `NO Basic authentication is disabled` before validating
-> credentials, so no password fix can make IMAP IDLE work for them. UXC
-> detects this server-side policy rejection, reports the source as `failed`
-> with an actionable error, and stops reconnecting. To read mail from a
-> personal Microsoft account, use [Provider Polling](#provider-polling) with
-> `provider=graph` and a Microsoft Graph OAuth credential instead.
+> reject IMAP `LOGIN` with `NO Basic authentication is disabled` before
+> validating credentials, so no password fix can make basic auth work for
+> them. UXC detects this server-side policy rejection, reports the source as
+> `failed` with an actionable error, and stops reconnecting. Use the
+> [XOAUTH2 flow below](#microsoft-personal-accounts-xoauth2) to keep IMAP
+> IDLE push delivery, or fall back to [Provider Polling](#provider-polling)
+> with `provider=graph` for minute-level polling instead.
+
+### Microsoft Personal Accounts (XOAUTH2)
+
+IMAP for personal Microsoft accounts authenticates with OAuth via the
+XOAUTH2 SASL mechanism. UXC ships a provider preset that borrows the public
+Thunderbird client id, so a personal account needs two commands and one
+browser consent — no Azure app registration:
+
+```bash
+# 1. Device-code login; opens a consent page in the browser
+uxc auth oauth login outlook-imap --provider outlook
+
+# 2. Subscribe over IMAP IDLE with the OAuth credential
+uxc source ensure agentinbox email:primary imaps://outlook.office365.com:993 \
+  --transport email-imap-idle \
+  --auth outlook-imap mailbox=INBOX
+```
+
+The `--provider outlook` preset fills in:
+
+| Preset default | Value |
+| --- | --- |
+| Client id | Mozilla Thunderbird public client `9e5f94bc-e8a4-4e73-b8be-63364c29d753` |
+| Issuer / tenant | `https://login.microsoftonline.com/consumers` |
+| Scopes | `https://outlook.office.com/IMAP.AccessAsUser.All`, `https://outlook.office.com/SMTP.Send`, `offline_access` |
+
+Notes:
+
+- Pass `--client-id <id>` to use your own Azure app registration instead of
+  the Thunderbird client id; organization (work/school) accounts typically
+  need their own registration and admin consent.
+- The OAuth profile's mailbox address is resolved from the profile's
+  `username`/`user`/`email` field, the `account=` argument, or finally the
+  credential id. Set a `username` field (for example
+  `uxc auth credential set outlook-imap --field username=literal:user@hotmail.com`)
+  if the credential id is not the mailbox address.
+- UXC refreshes the access token before every (re)connect and persists the
+  refreshed token, so long-lived IDLE sessions survive token expiry without
+  manual `auth oauth refresh`.
+- If the server rejects the token, the source fails with an actionable error
+  (re-consent via `uxc auth oauth login ... --provider outlook`) instead of
+  retrying forever.
+- Attachment retrieval (`uxc email attachment get`) uses the same XOAUTH2
+  path with the same credential.
 
 ### Provider Polling
 
@@ -64,6 +109,20 @@ return the provider's message-list JSON, so UXC can map it onto the same
 Microsoft Graph only returns attachment metadata when the endpoint includes
 `$expand=attachments`; see [Email Attachments](./email-attachments.md) for the
 partial-metadata semantics.
+
+### Microsoft Graph with Personal Accounts
+
+The Graph mail API (`/v1.0/me/messages`, delegated `Mail.Read`) also serves
+personal Microsoft accounts, so `provider=graph` polling works for them as a
+no-IDLE alternative to IMAP XOAUTH2:
+
+- Use an OAuth credential with Graph scopes (`Mail.Read offline_access`) —
+  note the Thunderbird client id registered IMAP/SMTP resource permissions
+  and cannot consent Graph scopes, so this path needs your own Azure app
+  registration (`--client-id`) or another client authorized for Graph.
+- Expect minute-level latency (poll interval) instead of IMAP IDLE's
+  second-level push, and keep intervals >= 60s to stay clear of Graph
+  throttling.
 
 ## Event Envelope
 
@@ -142,7 +201,23 @@ Notes:
 
 - Use `--auth` with credentials containing `username`/`user`/`account` and
   `password`/`secret` fields when SMTP AUTH is required.
-- SMTP AUTH over cleartext `smtp://` requires explicit
-  `--allow-insecure-auth`; prefer a trusted local relay until
-  STARTTLS/TLS is supported.
+- `smtp://` upgrades to TLS via STARTTLS automatically when the server
+  advertises it; `smtps://` (implicit TLS, port 465) is also supported.
+- Password AUTH (`AUTH PLAIN`) over a `smtp://` connection that cannot be
+  upgraded requires explicit `--allow-insecure-auth`; prefer a trusted local
+  relay or STARTTLS-capable submission endpoint.
+- OAuth credentials authenticate with `AUTH XOAUTH2`. This is how Microsoft
+  personal accounts send mail:
+
+```bash
+uxc auth oauth login outlook-imap --provider outlook   # same credential as IMAP
+
+uxc email send --smtp smtp://smtp-mail.outlook.com:587 \
+  --from user@hotmail.com --to someone@example.com \
+  --subject 'Hello' --text-body 'Hi' \
+  --auth outlook-imap
+```
+
+  OAuth tokens are never sent over cleartext: `smtp://` must offer STARTTLS
+  (Microsoft's submission endpoint does) or use `smtps://`.
 - Add `--dry-run` to preview a message without delivering it.

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -1234,6 +1234,104 @@ fn endpoint_is_matrix_client(endpoint: &str) -> bool {
         .is_some_and(|url| url.path().starts_with("/_matrix/client/"))
 }
 
+/// Public Thunderbird OAuth client id published by Mozilla for IMAP/POP/SMTP
+/// XOAUTH2 against `outlook.office365.com`. Personal Microsoft accounts can
+/// consent to it directly; organization tenants may require admin consent.
+/// `uxc auth oauth login --provider outlook` uses it as the default so users
+/// do not need their own Azure app registration; `--client-id` overrides it.
+pub const OUTLOOK_PUBLIC_CLIENT_ID: &str = "9e5f94bc-e8a4-4e73-b8be-63364c29d753";
+
+const OUTLOOK_CONSUMERS_ISSUER: &str = "https://login.microsoftonline.com/consumers";
+const OUTLOOK_CONSUMERS_TOKEN_ENDPOINT: &str =
+    "https://login.microsoftonline.com/consumers/oauth2/v2.0/token";
+const OUTLOOK_CONSUMERS_DEVICE_AUTHORIZATION_ENDPOINT: &str =
+    "https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode";
+const OUTLOOK_IMAP_SCOPE: &str = "https://outlook.office.com/IMAP.AccessAsUser.All";
+const OUTLOOK_SMTP_SCOPE: &str = "https://outlook.office.com/SMTP.Send";
+const OUTLOOK_OFFLINE_ACCESS_SCOPE: &str = "offline_access";
+
+/// Built-in OAuth login presets for well-known providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OAuthLoginPreset {
+    /// Microsoft personal accounts (`outlook.com`/`hotmail.com`/`live.com`)
+    /// with IMAP XOAUTH2 (`email-imap-idle`) and SMTP XOAUTH2
+    /// (`uxc email send`). Uses the `consumers` tenant; organization
+    /// accounts should register their own client and pass `--client-id`.
+    Outlook,
+}
+
+impl OAuthLoginPreset {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "outlook" | "outlook.com" | "microsoft" => Ok(Self::Outlook),
+            other => Err(UxcError::InvalidArguments(format!(
+                "unknown OAuth provider preset '{}'; expected outlook",
+                other
+            ))
+            .into()),
+        }
+    }
+}
+
+/// Login arguments after applying a provider preset: every field carries the
+/// preset default unless the caller passed an explicit value, which keeps
+/// `--client-id`/`--scope`/endpoint overrides working on top of the preset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OAuthLoginPresetDefaults {
+    /// Fallback discovery endpoint (never requested on the wire when the
+    /// preset endpoint overrides already satisfy discovery requirements).
+    pub endpoint: String,
+    pub client_id: String,
+    pub issuer: Option<String>,
+    pub token_endpoint: Option<String>,
+    pub device_authorization_endpoint: Option<String>,
+    /// Preset scopes, used only when the caller passed no `--scope`.
+    pub default_scopes: Vec<String>,
+}
+
+/// Merge an OAuth login preset with explicit CLI arguments. Explicit values
+/// win over preset defaults so bring-your-own client ids stay possible.
+pub fn apply_oauth_login_preset(
+    preset: OAuthLoginPreset,
+    endpoint: Option<&str>,
+    client_id: Option<&str>,
+    scopes: &[String],
+    issuer: Option<&str>,
+    token_endpoint: Option<&str>,
+    device_authorization_endpoint: Option<&str>,
+) -> OAuthLoginPresetDefaults {
+    match preset {
+        OAuthLoginPreset::Outlook => OAuthLoginPresetDefaults {
+            endpoint: endpoint
+                .map(str::to_string)
+                .unwrap_or_else(|| OUTLOOK_CONSUMERS_ISSUER.to_string()),
+            client_id: client_id
+                .map(str::to_string)
+                .unwrap_or_else(|| OUTLOOK_PUBLIC_CLIENT_ID.to_string()),
+            issuer: Some(issuer.unwrap_or(OUTLOOK_CONSUMERS_ISSUER).to_string()),
+            token_endpoint: Some(
+                token_endpoint
+                    .unwrap_or(OUTLOOK_CONSUMERS_TOKEN_ENDPOINT)
+                    .to_string(),
+            ),
+            device_authorization_endpoint: Some(
+                device_authorization_endpoint
+                    .unwrap_or(OUTLOOK_CONSUMERS_DEVICE_AUTHORIZATION_ENDPOINT)
+                    .to_string(),
+            ),
+            default_scopes: if scopes.is_empty() {
+                vec![
+                    OUTLOOK_IMAP_SCOPE.to_string(),
+                    OUTLOOK_SMTP_SCOPE.to_string(),
+                    OUTLOOK_OFFLINE_ACCESS_SCOPE.to_string(),
+                ]
+            } else {
+                scopes.to_vec()
+            },
+        },
+    }
+}
+
 fn random_matrix_device_suffix(len: usize) -> Result<String> {
     const ALPHANUM: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     let mut bytes = vec![0u8; len];
@@ -1797,6 +1895,75 @@ mod tests {
             parse_resource_metadata_from_www_authenticate(header).as_deref(),
             Some("https://api.example.com/.well-known/oauth-protected-resource")
         );
+    }
+
+    #[test]
+    fn login_preset_parse_accepts_known_aliases() {
+        assert_eq!(
+            OAuthLoginPreset::parse("outlook").unwrap(),
+            OAuthLoginPreset::Outlook
+        );
+        assert_eq!(
+            OAuthLoginPreset::parse("Outlook.com").unwrap(),
+            OAuthLoginPreset::Outlook
+        );
+        assert!(OAuthLoginPreset::parse("gmail").is_err());
+    }
+
+    #[test]
+    fn login_preset_outlook_fills_thunderbird_defaults() {
+        let defaults =
+            apply_oauth_login_preset(OAuthLoginPreset::Outlook, None, None, &[], None, None, None);
+        assert_eq!(defaults.client_id, OUTLOOK_PUBLIC_CLIENT_ID);
+        assert_eq!(
+            defaults.endpoint,
+            "https://login.microsoftonline.com/consumers"
+        );
+        assert_eq!(
+            defaults.issuer.as_deref(),
+            Some("https://login.microsoftonline.com/consumers")
+        );
+        assert_eq!(
+            defaults.device_authorization_endpoint.as_deref(),
+            Some("https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode")
+        );
+        assert_eq!(
+            defaults.default_scopes,
+            vec![
+                "https://outlook.office.com/IMAP.AccessAsUser.All".to_string(),
+                "https://outlook.office.com/SMTP.Send".to_string(),
+                "offline_access".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn login_preset_explicit_arguments_override_defaults() {
+        let scopes = vec!["custom".to_string()];
+        let defaults = apply_oauth_login_preset(
+            OAuthLoginPreset::Outlook,
+            Some("https://example.com"),
+            Some("my-client-id"),
+            &scopes,
+            Some("https://issuer.example.com"),
+            Some("https://issuer.example.com/token"),
+            Some("https://issuer.example.com/device"),
+        );
+        assert_eq!(defaults.client_id, "my-client-id");
+        assert_eq!(defaults.endpoint, "https://example.com");
+        assert_eq!(
+            defaults.issuer.as_deref(),
+            Some("https://issuer.example.com")
+        );
+        assert_eq!(
+            defaults.token_endpoint.as_deref(),
+            Some("https://issuer.example.com/token")
+        );
+        assert_eq!(
+            defaults.device_authorization_endpoint.as_deref(),
+            Some("https://issuer.example.com/device")
+        );
+        assert_eq!(defaults.default_scopes, scopes);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6118,11 +6118,13 @@ async fn run_email_imap_idle_subscription_job(
     view: Arc<Mutex<SubscriptionJobView>>,
     mut stop_rx: watch::Receiver<bool>,
 ) -> Result<()> {
-    let auth_profile =
-        auth::resolve_auth_for_endpoint(&request.endpoint, request.options.auth.clone())?
-            .ok_or_else(|| {
-                anyhow!("email-imap-idle requires an auth profile with username/password fields")
-            })?;
+    let auth_profile = auth::resolve_auth_for_endpoint(
+        &request.endpoint,
+        request.options.auth.clone(),
+    )?
+    .ok_or_else(|| {
+        anyhow!("email-imap-idle requires an auth profile (password fields, or OAuth for XOAUTH2)")
+    })?;
     let config: EmailImapIdleRuntimeConfig =
         resolve_email_imap_idle_runtime_config(request, &auth_profile)?;
     let mut seq = 0u64;

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,11 +1,18 @@
 use anyhow::{anyhow, bail, Context, Result};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
+use tokio_rustls::rustls::pki_types::ServerName;
+use tokio_rustls::rustls::{ClientConfig, RootCertStore};
+use tokio_rustls::TlsConnector;
 use url::Url;
 
 use crate::auth;
+use crate::subscription_email::AsyncReadWrite;
+
+type SmtpIo = Box<dyn AsyncReadWrite>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EmailReplyHandle {
@@ -58,10 +65,14 @@ pub struct EmailSendResult {
     pub accepted_recipients: usize,
 }
 
-#[derive(Debug, Clone)]
-struct SmtpAuth {
-    username: String,
-    password: String,
+/// How `send_email` authenticates against the SMTP server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SmtpAuth {
+    /// `AUTH PLAIN` with username and password.
+    Plain { username: String, password: String },
+    /// `AUTH XOAUTH2` with an OAuth access token (for example a Microsoft
+    /// personal account via `uxc auth oauth login --provider outlook`).
+    Xoauth2 { username: String, token: String },
 }
 
 pub async fn send_email(request: EmailSendRequest) -> Result<EmailSendResult> {
@@ -156,7 +167,7 @@ fn parse_smtp_url(raw: &str) -> Result<Url> {
     let url = Url::parse(raw).context("invalid SMTP endpoint URL")?;
     match url.scheme() {
         "smtp" => Ok(url),
-        "smtps" => bail!("smtps:// is not supported yet; use smtp:// with a trusted local relay"),
+        "smtps" => Ok(url),
         other => bail!("unsupported SMTP URL scheme '{}'; expected smtp://", other),
     }
 }
@@ -166,27 +177,69 @@ fn validate_smtp_auth_transport(
     auth: Option<&SmtpAuth>,
     allow_insecure_auth: bool,
 ) -> Result<()> {
-    if auth.is_some() && url.scheme() == "smtp" && !allow_insecure_auth {
-        bail!(
-            "refusing to send SMTP credentials over unencrypted smtp://; configure a trusted local relay without --auth, or pass --allow-insecure-auth to acknowledge the cleartext credential risk"
-        );
+    let Some(auth) = auth else {
+        return Ok(());
+    };
+    match (url.scheme(), auth) {
+        // Passwords over smtp:// stay opt-in: the local-relay workflow keeps
+        // working only when the operator acknowledges the cleartext risk.
+        ("smtp", SmtpAuth::Plain { .. }) if !allow_insecure_auth => bail!(
+            "refusing to send SMTP password over unencrypted smtp://; configure a trusted local relay without --auth, pass --allow-insecure-auth to acknowledge the cleartext credential risk, or use smtps://"
+        ),
+        // OAuth tokens never travel in cleartext: smtp:// upgrades via
+        // STARTTLS (enforced at send time) and smtps:// is implicit TLS.
+        ("smtp" | "smtps", SmtpAuth::Xoauth2 { .. }) => Ok(()),
+        _ => Ok(()),
     }
-    Ok(())
 }
 
 async fn resolve_smtp_auth(
     endpoint: &str,
     explicit_auth: Option<String>,
 ) -> Result<Option<SmtpAuth>> {
-    let Some(profile) = auth::resolve_auth_for_endpoint(endpoint, explicit_auth)? else {
+    let Some(mut profile) = auth::resolve_auth_for_endpoint(endpoint, explicit_auth)? else {
         return Ok(None);
     };
+    if profile.auth_type == auth::AuthType::OAuth {
+        // One-shot send: refresh a stale token up front and persist it so
+        // the next send reuses the fresh token without another login.
+        let client = reqwest::Client::new();
+        let refreshed = auth::refresh_effective_auth_profile(
+            &mut profile,
+            &client,
+            false,
+            crate::subscription_email::IMAP_XOAUTH2_REFRESH_SKEW_SECS,
+            None,
+        )
+        .await?;
+        if refreshed {
+            auth::persist_profile_if_named(&profile)?;
+        }
+        let username = first_field(&profile, &["username", "user", "email", "account"])?
+            .or_else(|| profile.name.clone())
+            .ok_or_else(|| {
+                anyhow!(
+                    "SMTP OAuth auth profile requires a username/user/email/account field, or the credential id to name the mailbox address"
+                )
+            })?;
+        let token = profile
+            .oauth
+            .as_ref()
+            .and_then(|oauth| oauth.access_token.clone())
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| {
+                anyhow!(
+                    "SMTP OAuth auth profile has no access token; run `uxc auth oauth login` first"
+                )
+            })?;
+        return Ok(Some(SmtpAuth::Xoauth2 { username, token }));
+    }
     let username = first_field(&profile, &["username", "user", "account"])?
         .or_else(|| profile.name.clone())
         .ok_or_else(|| anyhow!("SMTP auth profile requires username/user/account field"))?;
     let password = first_field(&profile, &["password", "secret"])?
         .ok_or_else(|| anyhow!("SMTP auth profile requires password or secret field"))?;
-    Ok(Some(SmtpAuth { username, password }))
+    Ok(Some(SmtpAuth::Plain { username, password }))
 }
 
 fn first_field(profile: &auth::Profile, names: &[&str]) -> Result<Option<String>> {
@@ -282,21 +335,48 @@ async fn send_smtp(
     let host = url
         .host_str()
         .ok_or_else(|| anyhow!("SMTP URL must include a host"))?;
-    let port = url.port_or_known_default().unwrap_or(25);
-    let stream = TcpStream::connect((host, port))
+    // `Url` knows smtp but not smtps, so map the implicit-TLS port manually.
+    let default_port = if url.scheme() == "smtps" { 465 } else { 25 };
+    let port = url.port().unwrap_or(default_port);
+    let tcp = TcpStream::connect((host, port))
         .await
         .with_context(|| format!("failed to connect SMTP server {}:{}", host, port))?;
-    let mut client = SmtpClient::new(stream);
+    let mut client = match url.scheme() {
+        // smtps:// upgrades the TCP stream to TLS before the greeting.
+        "smtps" => SmtpClient::new(Box::new(tls_upgrade(host, tcp).await?)),
+        _ => SmtpClient::new(Box::new(tcp)),
+    };
     client.expect_code(&[220]).await?;
-    client
-        .command(&format!("EHLO {}\r\n", local_hostname()), &[250])
-        .await?;
+    let capabilities = client.ehlo().await?;
+    // OAuth tokens must never travel over cleartext smtp://: upgrade via
+    // STARTTLS when the server advertises it, refuse otherwise.
+    if url.scheme() == "smtp" && matches!(auth, Some(SmtpAuth::Xoauth2 { .. })) {
+        if capabilities
+            .iter()
+            .any(|cap| cap.eq_ignore_ascii_case("STARTTLS"))
+        {
+            client = client.starttls(host).await?;
+            client.ehlo().await?;
+        } else {
+            bail!(
+                "SMTP server {} does not advertise STARTTLS; refusing to send the OAuth token over unencrypted smtp://. Use smtps:// or a STARTTLS-capable submission endpoint (for Microsoft personal accounts: smtp-mail.outlook.com:587)",
+                host
+            );
+        }
+    }
     if let Some(auth) = auth {
-        let encoded = base64::engine::general_purpose::STANDARD
-            .encode(format!("\0{}\0{}", auth.username, auth.password));
-        client
-            .command(&format!("AUTH PLAIN {}\r\n", encoded), &[235])
-            .await?;
+        match auth {
+            SmtpAuth::Plain { username, password } => {
+                let encoded = base64::engine::general_purpose::STANDARD
+                    .encode(format!("\0{username}\0{password}"));
+                client
+                    .command(&format!("AUTH PLAIN {encoded}\r\n"), &[235])
+                    .await?;
+            }
+            SmtpAuth::Xoauth2 { username, token } => {
+                client.auth_xoauth2(username, token).await?;
+            }
+        }
     }
     client
         .command(&format!("MAIL FROM:<{}>\r\n", from), &[250])
@@ -312,6 +392,27 @@ async fn send_smtp(
     client.expect_code(&[250]).await?;
     let _ = client.command("QUIT\r\n", &[221]).await;
     Ok(())
+}
+
+async fn tls_upgrade<S: AsyncReadWrite>(
+    host: &str,
+    stream: S,
+) -> Result<tokio_rustls::client::TlsStream<S>> {
+    let mut roots = RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let tls_config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(tls_config));
+    let server_name = ServerName::try_from(host.to_string())
+        .map_err(|_| anyhow!("invalid SMTP TLS server name"))?;
+    tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        connector.connect(server_name, stream),
+    )
+    .await
+    .context("SMTP TLS handshake timed out")?
+    .context("SMTP TLS handshake failed")
 }
 
 fn local_hostname() -> String {
@@ -334,25 +435,104 @@ fn dot_stuff(message: &str) -> String {
 }
 
 struct SmtpClient {
-    reader: BufReader<TcpStream>,
+    reader: BufReader<tokio::io::ReadHalf<SmtpIo>>,
+    writer: tokio::io::WriteHalf<SmtpIo>,
 }
 
 impl SmtpClient {
-    fn new(stream: TcpStream) -> Self {
+    fn new(io: SmtpIo) -> Self {
+        let (reader, writer) = tokio::io::split(io);
         Self {
-            reader: BufReader::new(stream),
+            reader: BufReader::new(reader),
+            writer,
         }
     }
 
     async fn write_all(&mut self, bytes: &[u8]) -> Result<()> {
-        self.reader.get_mut().write_all(bytes).await?;
-        self.reader.get_mut().flush().await?;
+        self.writer.write_all(bytes).await?;
+        self.writer.flush().await?;
         Ok(())
     }
 
-    async fn command(&mut self, command: &str, expected: &[u16]) -> Result<u16> {
+    /// Write a command and return the full multiline response when the code
+    /// matches, so callers can inspect capability lines.
+    async fn command_lines(
+        &mut self,
+        command: &str,
+        expected: &[u16],
+    ) -> Result<(u16, Vec<String>)> {
         self.write_all(command.as_bytes()).await?;
-        self.expect_code(expected).await
+        let (code, lines) = self.read_response().await?;
+        if expected.contains(&code) {
+            Ok((code, lines))
+        } else {
+            bail!(
+                "SMTP server returned {}, expected {:?}: {}",
+                code,
+                expected,
+                lines.join(" | ")
+            )
+        }
+    }
+
+    /// Send EHLO and return the advertised capability keywords (upper-cased
+    /// verb per line, e.g. `STARTTLS`, `AUTH`).
+    async fn ehlo(&mut self) -> Result<Vec<String>> {
+        let (_, lines) = self
+            .command_lines(&format!("EHLO {}\r\n", local_hostname()), &[250])
+            .await?;
+        Ok(lines
+            .iter()
+            // Skip the response code prefix ("250 " or "250-") on each
+            .skip(1)
+            .filter_map(|line| line.get(4..))
+            .map(|rest| rest.split(' ').next().unwrap_or("").to_string())
+            .filter(|verb| !verb.is_empty())
+            .collect())
+    }
+
+    /// Upgrade the current plaintext connection with STARTTLS. Returns a new
+    /// client wrapping the TLS stream; the plaintext client is consumed.
+    async fn starttls(self, host: &str) -> Result<Self> {
+        let mut plaintext = self;
+        if !plaintext.reader.buffer().is_empty() {
+            bail!("SMTP STARTTLS refused: buffered plaintext data would be discarded");
+        }
+        plaintext.command("STARTTLS\r\n", &[220]).await?;
+        let read_half = plaintext.reader.into_inner();
+        // Both halves come from the same `split`, so `unsplit` cannot fail.
+        let io = read_half.unsplit(plaintext.writer);
+        let tls = tls_upgrade(host, io).await?;
+        Ok(Self::new(Box::new(tls)))
+    }
+
+    /// `AUTH XOAUTH2` with an inline initial response. On a `334` challenge
+    /// (base64 JSON error) the client aborts SASL with `*` per RFC 4954.
+    async fn auth_xoauth2(&mut self, username: &str, token: &str) -> Result<()> {
+        let sasl = crate::subscription_email::build_xoauth2_sasl_string(username, token);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(sasl);
+        self.write_all(format!("AUTH XOAUTH2 {encoded}\r\n").as_bytes())
+            .await?;
+        let (code, lines) = self.read_response().await?;
+        if code == 235 {
+            return Ok(());
+        }
+        let mut detail = lines.join(" | ");
+        if code == 334 {
+            self.write_all(b"*\r\n").await?;
+            let (_, abort_lines) = self.read_response().await?;
+            detail.push_str(" | abort: ");
+            detail.push_str(&abort_lines.join(" | "));
+        }
+        bail!(
+            "SMTP AUTH XOAUTH2 rejected ({}): the access token is missing, expired, or lacks the required SMTP scope (for Microsoft accounts: https://outlook.office.com/SMTP.Send). Re-run `uxc auth oauth login <credential> --provider outlook` to refresh the token. Server response: {}",
+            code,
+            detail
+        )
+    }
+
+    async fn command(&mut self, command: &str, expected: &[u16]) -> Result<u16> {
+        Ok(self.command_lines(command, expected).await?.0)
     }
 
     async fn expect_code(&mut self, expected: &[u16]) -> Result<u16> {
@@ -455,13 +635,126 @@ mod tests {
     #[test]
     fn rejects_plaintext_smtp_auth_without_opt_in() {
         let url = parse_smtp_url("smtp://localhost:2525").unwrap();
-        let auth = SmtpAuth {
+        let auth = SmtpAuth::Plain {
             username: "user".to_string(),
             password: "password".to_string(),
         };
         assert!(validate_smtp_auth_transport(&url, Some(&auth), false).is_err());
         assert!(validate_smtp_auth_transport(&url, Some(&auth), true).is_ok());
         assert!(validate_smtp_auth_transport(&url, None, false).is_ok());
+    }
+
+    #[test]
+    fn smtps_and_xoauth2_are_allowed_without_insecure_opt_in() {
+        let smtps = parse_smtp_url("smtps://smtp.example.com:465").unwrap();
+        let auth = SmtpAuth::Xoauth2 {
+            username: "user@hotmail.com".to_string(),
+            token: "token".to_string(),
+        };
+        // OAuth tokens ride inside TLS (STARTTLS upgrade or implicit TLS),
+        // so the cleartext opt-in flag does not apply to them.
+        assert!(validate_smtp_auth_transport(&smtps, Some(&auth), false).is_ok());
+        let smtp = parse_smtp_url("smtp://smtp-mail.outlook.com:587").unwrap();
+        assert!(validate_smtp_auth_transport(&smtp, Some(&auth), false).is_ok());
+        // Passwords still need the flag even on smtps://-shaped URLs? No:
+        // smtps is implicit TLS, so passwords are encrypted there.
+        let plain = SmtpAuth::Plain {
+            username: "user".to_string(),
+            password: "password".to_string(),
+        };
+        assert!(validate_smtp_auth_transport(&smtps, Some(&plain), false).is_ok());
+    }
+
+    #[tokio::test]
+    async fn smtp_auth_xoauth2_accepts_235() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut smtp = SmtpClient::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            let expected = base64::engine::general_purpose::STANDARD
+                .encode("user=user@hotmail.com\x01auth=Bearer token1\x01\x01");
+            assert_eq!(line, format!("AUTH XOAUTH2 {expected}\r\n"));
+            writer.write_all(b"235 2.7.0 Accepted\r\n").await.unwrap();
+        });
+
+        smtp.auth_xoauth2("user@hotmail.com", "token1")
+            .await
+            .unwrap();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn smtp_auth_xoauth2_aborts_challenge_with_actionable_error() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut smtp = SmtpClient::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            assert!(line.starts_with("AUTH XOAUTH2 "));
+            writer.write_all(b"334 ").await.unwrap();
+            let challenge = base64::engine::general_purpose::STANDARD
+                .encode(r#"{"status":"401","schemes":"XOAUTH2","scope":"https://outlook.office.com/SMTP.Send"}"#);
+            writer
+                .write_all(format!("{challenge}\r\n").as_bytes())
+                .await
+                .unwrap();
+            // Client aborts SASL with `*`, then the server reports failure.
+            let mut abort = String::new();
+            reader.read_line(&mut abort).await.unwrap();
+            assert_eq!(abort, "*\r\n");
+            writer
+                .write_all(b"500 Authentication failed\r\n")
+                .await
+                .unwrap();
+        });
+
+        let err = smtp
+            .auth_xoauth2("user@hotmail.com", "stale")
+            .await
+            .unwrap_err();
+        server.await.unwrap();
+        let message = err.to_string();
+        assert!(message.contains("SMTP AUTH XOAUTH2 rejected"));
+        assert!(message.contains("SMTP.Send"));
+        assert!(message.contains("auth oauth login"));
+    }
+
+    #[tokio::test]
+    async fn smtp_ehlo_collects_capability_verbs() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut smtp = SmtpClient::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            assert!(line.starts_with("EHLO "));
+            writer
+                .write_all(
+                    b"250-smtp.example.com\r\n250-STARTTLS\r\n250-AUTH XOAUTH2 PLAIN\r\n250 OK\r\n",
+                )
+                .await
+                .unwrap();
+        });
+
+        let capabilities = smtp.ehlo().await.unwrap();
+        server.await.unwrap();
+        assert!(capabilities.iter().any(|cap| cap == "STARTTLS"));
+        assert!(capabilities.iter().any(|cap| cap == "AUTH"));
+        assert!(!capabilities.iter().any(|cap| cap == "250-smtp.example.com"));
+    }
+
+    #[test]
+    fn parse_smtp_url_accepts_smtps() {
+        let url = parse_smtp_url("smtps://smtp.example.com").unwrap();
+        assert_eq!(url.scheme(), "smtps");
+        assert_eq!(url.port(), None);
+        assert!(parse_smtp_url("smtpx://host").is_err());
     }
 
     #[test]

--- a/src/email_attachment_get.rs
+++ b/src/email_attachment_get.rs
@@ -328,28 +328,63 @@ where
 {
     let profile_name = required_profile_name(handle, request)?;
     let profile = load_profile(&profile_name)?;
-    let username = resolve_first_profile_field(&profile, &["username", "user", "email"])
-        .ok_or_else(|| {
-            structured(
-                "auth_profile_missing",
-                format!(
-                    "auth profile '{}' has no username/user/email field for IMAP retrieval",
-                    profile_name
-                ),
-                None,
-            )
-        })?;
-    let password = resolve_first_profile_field(&profile, &["password", "app_password", "secret"])
-        .ok_or_else(|| {
-        structured(
-            "auth_profile_missing",
-            format!(
-                "auth profile '{}' has no password/app_password/secret field for IMAP retrieval",
-                profile_name
-            ),
-            None,
-        )
-    })?;
+    let mut profile = profile;
+    let auth_method = if profile.auth_type == crate::auth::AuthType::OAuth {
+        refresh_oauth_profile_for_retrieval(&mut profile).await?;
+        let username = resolve_first_profile_field(&profile, &["username", "user", "email"])
+            .or_else(|| profile.name.clone())
+            .ok_or_else(|| {
+                structured(
+                    "auth_profile_missing",
+                    format!(
+                        "auth profile '{}' has no username/user/email field for IMAP retrieval",
+                        profile_name
+                    ),
+                    None,
+                )
+            })?;
+        let token = profile
+            .oauth
+            .as_ref()
+            .and_then(|oauth| oauth.access_token.clone())
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| {
+                structured(
+                    "auth_profile_missing",
+                    format!(
+                        "auth profile '{}' has no OAuth access token for IMAP retrieval",
+                        profile_name
+                    ),
+                    None,
+                )
+            })?;
+        crate::subscription_email::ImapAuthMethod::Xoauth2 { username, token }
+    } else {
+        let username = resolve_first_profile_field(&profile, &["username", "user", "email"])
+            .ok_or_else(|| {
+                structured(
+                    "auth_profile_missing",
+                    format!(
+                        "auth profile '{}' has no username/user/email field for IMAP retrieval",
+                        profile_name
+                    ),
+                    None,
+                )
+            })?;
+        let password =
+            resolve_first_profile_field(&profile, &["password", "app_password", "secret"])
+                .ok_or_else(|| {
+                    structured(
+                        "auth_profile_missing",
+                        format!(
+                            "auth profile '{}' has no password/app_password/secret field for IMAP retrieval",
+                            profile_name
+                        ),
+                        None,
+                    )
+                })?;
+        crate::subscription_email::ImapAuthMethod::Basic { username, password }
+    };
     let url = Url::parse(&handle.endpoint).map_err(|err| {
         invalid_handle(&format!(
             "invalid IMAP endpoint '{}': {}",
@@ -380,8 +415,7 @@ where
         host,
         port,
         use_tls,
-        username: username.clone(),
-        password: password.clone(),
+        auth_method: auth_method.clone(),
         mailbox: mailbox.clone(),
         account: handle.account.clone(),
         auth_profile: Some(profile_name),
@@ -390,32 +424,62 @@ where
     let mut conn = connector(config)
         .await
         .map_err(|err| provider_request_failed(format!("IMAP connect failed: {err}")))?;
-    let attachment = run_imap_retrieval(&mut conn, handle, &username, &password, &mailbox).await;
+    let attachment = run_imap_retrieval(&mut conn, handle, &auth_method, &mailbox).await;
     let _ = conn.logout().await;
     attachment
+}
+
+/// Refresh the OAuth access token (when stale) before a one-shot retrieval
+/// and persist it so subsequent retrievals reuse the fresh token.
+async fn refresh_oauth_profile_for_retrieval(profile: &mut crate::auth::Profile) -> Result<()> {
+    let client = reqwest::Client::new();
+    let refreshed = crate::auth::refresh_effective_auth_profile(
+        profile,
+        &client,
+        false,
+        crate::subscription_email::IMAP_XOAUTH2_REFRESH_SKEW_SECS,
+        None,
+    )
+    .await
+    .map_err(|err| {
+        structured(
+            "auth_failed",
+            format!("OAuth token refresh failed: {err}"),
+            None,
+        )
+    })?;
+    if refreshed {
+        crate::auth::persist_profile_if_named(profile)?;
+    }
+    Ok(())
 }
 
 async fn run_imap_retrieval(
     conn: &mut ImapConnection,
     handle: &EmailAttachmentHandle,
-    username: &str,
-    password: &str,
+    auth_method: &crate::subscription_email::ImapAuthMethod,
     mailbox: &str,
 ) -> Result<FetchedAttachment> {
     conn.expect_greeting()
         .await
         .map_err(|err| provider_request_failed(format!("IMAP greeting failed: {err}")))?;
-    if let Err(err) = conn
-        .command_ok(&format!(
-            "LOGIN {} {}",
-            quote_imap_string(username),
-            quote_imap_string(password)
-        ))
-        .await
-    {
+    let auth_result = match auth_method {
+        crate::subscription_email::ImapAuthMethod::Basic { username, password } => conn
+            .command_ok(&format!(
+                "LOGIN {} {}",
+                quote_imap_string(username),
+                quote_imap_string(password)
+            ))
+            .await
+            .map(|_| ()),
+        crate::subscription_email::ImapAuthMethod::Xoauth2 { username, token } => {
+            conn.authenticate_xoauth2(username, token).await
+        }
+    };
+    if let Err(err) = auth_result {
         return Err(structured(
             "auth_failed",
-            format!("IMAP LOGIN failed: {err}"),
+            format!("IMAP auth failed: {err}"),
             None,
         ));
     }
@@ -859,6 +923,16 @@ mod tests {
                     "username": {"kind": "literal", "value": "user@example.com"},
                     "password": {"kind": "literal", "value": "app-pass"}
                 }
+            },
+            "imap-oauth-test": {
+                "auth_type": "oauth",
+                "fields": {
+                    "username": {"kind": "literal", "value": "user@hotmail.com"}
+                },
+                "oauth": {
+                    "access_token": "imap-oauth-token",
+                    "scopes": ["https://outlook.office.com/IMAP.AccessAsUser.All"]
+                }
             }
         }
     }"#;
@@ -1067,6 +1141,61 @@ mod tests {
         assert_eq!(
             std::fs::read(&result.saved_path).unwrap(),
             b"hello payload".to_vec()
+        );
+    }
+
+    #[tokio::test]
+    async fn imap_download_authenticates_with_xoauth2_for_oauth_profiles() {
+        let _guard = credentials_env_lock().lock().unwrap();
+        let _credentials = set_credentials_file(GMAIL_CREDENTIALS);
+        let output = test_output_dir();
+        let mime = imap_mime_headers();
+        // The MIME section advertises base64 transfer encoding, so the body
+        // literal must be the encoded payload.
+        let body = base64::engine::general_purpose::STANDARD
+            .encode("oauth payload")
+            .into_bytes();
+        let mime_entry = format!(
+            "* 1 FETCH (UID 42 BODY[2.MIME] {{{}}}\r\n{}\r\n)",
+            mime.len(),
+            String::from_utf8_lossy(&mime)
+        );
+        let body_entry = literal_response("2", &body);
+        let script = vec![
+            (
+                "A0001 AUTHENTICATE XOAUTH2".to_string(),
+                "A0001 OK Authenticated.".to_string(),
+            ),
+            (
+                "A0002 SELECT".to_string(),
+                "* OK [UIDVALIDITY 3857529045] UIDs valid\r\n* 0 EXISTS\r\nA0002 OK [READ-WRITE] SELECT done".to_string(),
+            ),
+            (
+                "A0003 UID FETCH".to_string(),
+                format!("{mime_entry}\r\nA0003 OK fetch done"),
+            ),
+            (
+                "A0004 UID FETCH".to_string(),
+                format!("{body_entry}\r\nA0004 OK fetch done"),
+            ),
+            ("A0005 LOGOUT".to_string(), "A0005 OK logout".to_string()),
+        ];
+        let connector = imap_scripted_connector(script);
+        let mut handle =
+            serde_json::from_str::<serde_json::Value>(&imap_handle(Some(3857529045))).unwrap();
+        handle["auth_profile"] = json!("imap-oauth-test");
+        let request = request(
+            handle.to_string(),
+            Some(output.join("oauth.bin").display().to_string()),
+            0,
+        );
+        let result = get_email_attachment_with(&request, connector)
+            .await
+            .unwrap();
+        assert_eq!(result.provider, "imap");
+        assert_eq!(
+            std::fs::read(&result.saved_path).unwrap(),
+            b"oauth payload".to_vec()
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -875,9 +875,14 @@ enum AuthOauthCommands {
         #[arg(value_name = "CREDENTIAL_ID")]
         credential_id: String,
 
+        /// Built-in provider preset (outlook) filling default client id,
+        /// issuer, endpoints, and scopes; explicit flags still override
+        #[arg(long)]
+        provider: Option<String>,
+
         /// Service endpoint URL used for OAuth discovery
         #[arg(long)]
-        endpoint: String,
+        endpoint: Option<String>,
 
         /// OAuth flow type
         #[arg(long, default_value = "device_code")]
@@ -2957,10 +2962,13 @@ fn help_data_for_path(path: &[&str]) -> HelpData {
         ["auth", "oauth", "login"] => HelpData {
             path: "uxc auth oauth login".to_string(),
             about: "Login with OAuth and save tokens".to_string(),
-            usage: "uxc auth oauth login <credential_id> --endpoint <url> [--flow <device_code|authorization_code|client_credentials>] [--scope <scope>] [--client-id <id>] [--client-secret <secret>] [--redirect-uri <uri>] [--authorization-code <code>] [--issuer <url>] [--authorization-endpoint <url>] [--token-endpoint <url>] [--device-authorization-endpoint <url>] [--registration-endpoint <url>] [--resource-metadata-url <url>]".to_string(),
+            usage: "uxc auth oauth login <credential_id> (--endpoint <url> | --provider <outlook>) [--flow <device_code|authorization_code|client_credentials>] [--scope <scope>] [--client-id <id>] [--client-secret <secret>] [--redirect-uri <uri>] [--authorization-code <code>] [--issuer <url>] [--authorization-endpoint <url>] [--token-endpoint <url>] [--device-authorization-endpoint <url>] [--registration-endpoint <url>] [--resource-metadata-url <url>]".to_string(),
             commands: vec![],
-            notes: vec![],
-            examples: vec!["uxc auth oauth login deepwiki --endpoint https://mcp.deepwiki.com/mcp --flow device_code --client-id <id>".to_string()],
+            notes: vec!["--provider outlook fills the Thunderbird public client id, Microsoft consumers issuer, token/device endpoints, and IMAP+SMTP XOAUTH2 scopes; explicit flags override the preset.".to_string()],
+            examples: vec![
+                "uxc auth oauth login deepwiki --endpoint https://mcp.deepwiki.com/mcp --flow device_code --client-id <id>".to_string(),
+                "uxc auth oauth login outlook-imap --provider outlook".to_string(),
+            ],
         },
         ["auth", "oauth", "refresh"] => HelpData {
             path: "uxc auth oauth refresh".to_string(),
@@ -7408,6 +7416,7 @@ async fn handle_auth_oauth_command(command: &AuthOauthCommands) -> Result<Output
         }
         AuthOauthCommands::Login {
             credential_id,
+            provider,
             endpoint,
             flow,
             scope,
@@ -7423,20 +7432,59 @@ async fn handle_auth_oauth_command(command: &AuthOauthCommands) -> Result<Output
             resource_metadata_url,
         } => {
             let flow = parse_oauth_flow(flow)?;
-            let endpoint = normalize_endpoint_url(endpoint);
-            let scopes = auth::oauth::resolve_oauth_scopes_for_endpoint(
-                &endpoint,
-                &auth::oauth::parse_scopes(scope),
-            )?;
+            let raw_scopes = auth::oauth::parse_scopes(scope);
+            let (
+                endpoint,
+                client_id,
+                issuer,
+                token_endpoint,
+                device_authorization_endpoint,
+                scopes,
+            ) = if let Some(provider) = provider.as_deref() {
+                let preset = auth::oauth::OAuthLoginPreset::parse(provider)?;
+                let defaults = auth::oauth::apply_oauth_login_preset(
+                    preset,
+                    endpoint.as_deref(),
+                    client_id.as_deref(),
+                    &raw_scopes,
+                    issuer.as_deref(),
+                    token_endpoint.as_deref(),
+                    device_authorization_endpoint.as_deref(),
+                );
+                (
+                    defaults.endpoint,
+                    Some(defaults.client_id),
+                    defaults.issuer,
+                    defaults.token_endpoint,
+                    defaults.device_authorization_endpoint,
+                    defaults.default_scopes,
+                )
+            } else {
+                let endpoint = endpoint.clone().ok_or_else(|| {
+                    UxcError::InvalidArguments(
+                        "--endpoint is required without --provider".to_string(),
+                    )
+                })?;
+                (
+                    endpoint,
+                    client_id.clone(),
+                    issuer.clone(),
+                    token_endpoint.clone(),
+                    device_authorization_endpoint.clone(),
+                    raw_scopes,
+                )
+            };
+            let endpoint = normalize_endpoint_url(&endpoint);
+            let scopes = auth::oauth::resolve_oauth_scopes_for_endpoint(&endpoint, &scopes)?;
             let client = build_resilient_http_client(
                 std::time::Duration::from_secs(30),
                 "OAuth login command",
             )?;
             let discovery_overrides = build_oauth_discovery_overrides(
-                issuer,
+                &issuer,
                 authorization_endpoint,
-                token_endpoint,
-                device_authorization_endpoint,
+                &token_endpoint,
+                &device_authorization_endpoint,
                 registration_endpoint,
                 resource_metadata_url,
             );

--- a/src/subscription_email.rs
+++ b/src/subscription_email.rs
@@ -6,6 +6,7 @@ use crate::email_attachment::{
 };
 use crate::subscription_poll::{PollCheckpointState, PollFetchResult};
 use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use rustls_pki_types::ServerName;
 use serde_json::{json, Map, Value};
@@ -53,12 +54,30 @@ pub struct EmailImapIdleRuntimeConfig {
     pub host: String,
     pub port: u16,
     pub use_tls: bool,
-    pub username: String,
-    pub password: String,
+    pub auth_method: ImapAuthMethod,
     pub mailbox: String,
     pub account: Option<String>,
     pub auth_profile: Option<String>,
     pub initial_fetch_limit: usize,
+}
+
+/// How an `email-imap-idle` session authenticates against the IMAP server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImapAuthMethod {
+    /// Classic `LOGIN` with username and password. Personal Microsoft
+    /// accounts reject this path server-side.
+    Basic { username: String, password: String },
+    /// `AUTHENTICATE XOAUTH2` with an OAuth access token (Microsoft
+    /// personal/organization accounts, Gmail with OAuth, etc).
+    Xoauth2 { username: String, token: String },
+}
+
+impl ImapAuthMethod {
+    pub(crate) fn username(&self) -> &str {
+        match self {
+            Self::Basic { username, .. } | Self::Xoauth2 { username, .. } => username,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -121,22 +140,46 @@ pub fn resolve_email_imap_idle_runtime_config(
         .and_then(Value::as_u64)
         .unwrap_or(EMAIL_IMAP_DEFAULT_INITIAL_FETCH_LIMIT)
         .min(EMAIL_IMAP_MAX_INITIAL_FETCH_LIMIT) as usize;
-    let username = resolve_first_profile_field(auth_profile, &["username", "user", "email"])?
-        .ok_or_else(|| {
+    let auth_method = if auth_profile.auth_type == crate::auth::AuthType::OAuth {
+        let username = resolve_first_profile_field(auth_profile, &["username", "user", "email"])?
+            .or_else(|| account.clone())
+            .or_else(|| auth_profile.name.clone())
+            .ok_or_else(|| {
+                anyhow!(
+                    "email-imap-idle OAuth auth profile requires a username/user/email field, an account, or the credential id to name the mailbox address"
+                )
+            })?;
+        let token = auth_profile
+            .oauth
+            .as_ref()
+            .and_then(|oauth| oauth.access_token.clone())
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| {
+                anyhow!(
+                    "email-imap-idle OAuth auth profile has no access token; run `uxc auth oauth login` first"
+                )
+            })?;
+        ImapAuthMethod::Xoauth2 { username, token }
+    } else {
+        let username = resolve_first_profile_field(auth_profile, &["username", "user", "email"])?
+            .ok_or_else(|| {
             anyhow!("email-imap-idle auth profile requires username/user/email field")
         })?;
-    let password =
-        resolve_first_profile_field(auth_profile, &["password", "app_password", "secret"])?
-            .ok_or_else(|| {
-                anyhow!("email-imap-idle auth profile requires password/app_password/secret field")
-            })?;
+        let password =
+            resolve_first_profile_field(auth_profile, &["password", "app_password", "secret"])?
+                .ok_or_else(|| {
+                    anyhow!(
+                        "email-imap-idle auth profile requires password/app_password/secret field"
+                    )
+                })?;
+        ImapAuthMethod::Basic { username, password }
+    };
     Ok(EmailImapIdleRuntimeConfig {
         endpoint: request.endpoint.clone(),
         host,
         port,
         use_tls,
-        username,
-        password,
+        auth_method,
         auth_profile: request.options.auth.clone(),
         mailbox,
         account,
@@ -174,13 +217,17 @@ where
     R: SubscriptionEventRecorder,
     C: Fn(EmailImapIdleRuntimeConfig) -> BoxFutureResult<ImapConnection>,
 {
+    let mut config = config;
     let mut delay_secs = 1u64;
     loop {
+        if let ImapAuthMethod::Xoauth2 { token, .. } = &mut config.auth_method {
+            refresh_imap_xoauth2_token_if_stale(token, config.auth_profile.as_deref()).await?;
+        }
         match run_email_imap_idle_session_once(&config, recorder, stop_rx, &connector).await {
             Ok(()) => return Ok(()),
             Err(err) => {
                 let message = err.to_string();
-                let permanent = is_imap_basic_auth_disabled_message(&message);
+                let permanent = is_imap_permanent_auth_failure(&message);
                 recorder
                     .emit(
                         "email_imap_idle",
@@ -223,6 +270,114 @@ fn is_imap_basic_auth_disabled_message(message: &str) -> bool {
     message
         .to_lowercase()
         .contains(IMAP_BASIC_AUTH_DISABLED_MARKER)
+}
+
+/// Auth failures that retrying with the same credentials can never fix.
+/// Used to stop the reconnect backoff instead of hammering the server.
+fn is_imap_permanent_auth_failure(message: &str) -> bool {
+    is_imap_basic_auth_disabled_message(message) || message.contains(IMAP_XOAUTH2_REJECTED_MARKER)
+}
+
+/// Marker embedded in the actionable XOAUTH2 rejection error below.
+const IMAP_XOAUTH2_REJECTED_MARKER: &str = "IMAP AUTHENTICATE XOAUTH2 rejected";
+
+/// Refresh skew applied before reconnecting: refresh slightly early so the
+/// freshly connected session never carries an about-to-expire token.
+pub(crate) const IMAP_XOAUTH2_REFRESH_SKEW_SECS: i64 = 120;
+
+async fn refresh_imap_xoauth2_token_if_stale(
+    token: &mut String,
+    profile_name: Option<&str>,
+) -> Result<()> {
+    let Some(name) = profile_name
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        // Anonymous profile: nothing to refresh on disk; the resolved token
+        // from subscribe time is used as-is.
+        return Ok(());
+    };
+    let profiles = crate::auth::Profiles::load_profiles()?;
+    let mut profile = match profiles.get_profile(name) {
+        Ok(profile) => profile.clone(),
+        Err(_) => return Ok(()),
+    };
+    if profile.auth_type != crate::auth::AuthType::OAuth {
+        return Ok(());
+    }
+    let client = reqwest::Client::new();
+    let refreshed = crate::auth::refresh_effective_auth_profile(
+        &mut profile,
+        &client,
+        false,
+        IMAP_XOAUTH2_REFRESH_SKEW_SECS,
+        None,
+    )
+    .await;
+    match refreshed {
+        Ok(true) => {
+            crate::auth::persist_profile_if_named(&profile)?;
+        }
+        Ok(false) => {}
+        Err(err) => {
+            // Keep the current token when refresh fails transiently; the
+            // server rejects it via AUTHENTICATE if it really is dead.
+            if token.is_empty() {
+                return Err(err);
+            }
+        }
+    }
+    if let Some(new_token) = profile
+        .oauth
+        .as_ref()
+        .and_then(|oauth| oauth.access_token.clone())
+        .filter(|value| !value.is_empty())
+    {
+        *token = new_token;
+    }
+    Ok(())
+}
+
+/// Build the XOAUTH2 SASL initial-response string:
+/// `user=<u>\x01auth=Bearer <token>\x01\x01`.
+pub(crate) fn build_xoauth2_sasl_string(username: &str, token: &str) -> String {
+    format!("user={username}\x01auth=Bearer {token}\x01\x01")
+}
+
+fn decode_base64_json_challenge(payload: &str) -> Option<String> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(payload.trim())
+        .ok()?;
+    let text = String::from_utf8(bytes).ok()?;
+    if serde_json::from_str::<serde_json::Value>(&text).is_ok() {
+        Some(text)
+    } else {
+        None
+    }
+}
+
+fn imap_xoauth2_rejected_error(tagged_line: &str, challenge_json: Option<&str>) -> anyhow::Error {
+    let mut server_detail = tagged_line.trim().to_string();
+    if let Some(challenge) = challenge_json {
+        server_detail.push_str("; challenge: ");
+        server_detail.push_str(challenge);
+    }
+    anyhow!(
+        "IMAP AUTHENTICATE XOAUTH2 rejected: the access token is missing, expired, or lacks the \
+         required IMAP scope (for Microsoft accounts: \
+         https://outlook.office.com/IMAP.AccessAsUser.All). Re-run \
+         `uxc auth oauth login <credential> --provider outlook` (or with your own --client-id) \
+         to consent and refresh the token, then restart the source. Server response: {}",
+        server_detail
+    )
+}
+
+async fn imap_authenticate_xoauth2(
+    conn: &mut ImapConnection,
+    username: &str,
+    token: &str,
+) -> Result<()> {
+    conn.authenticate_xoauth2(username, token).await
 }
 
 fn imap_basic_auth_disabled_error(server_lines: &[String]) -> anyhow::Error {
@@ -275,7 +430,14 @@ where
     }
     let mut conn = connector(config.clone()).await?;
     conn.expect_greeting().await?;
-    imap_login(&mut conn, &config.username, &config.password).await?;
+    match &config.auth_method {
+        ImapAuthMethod::Basic { username, password } => {
+            imap_login(&mut conn, username, password).await?;
+        }
+        ImapAuthMethod::Xoauth2 { username, token } => {
+            imap_authenticate_xoauth2(&mut conn, username, token).await?;
+        }
+    }
     let select_lines = conn
         .command_ok(&format!("SELECT {}", quote_imap_string(&config.mailbox)))
         .await?;
@@ -421,7 +583,10 @@ fn build_email_event(
     let message_id = header_value(&headers, "message-id").unwrap_or_else(|| message.uid.clone());
     let thread_id =
         header_value(&headers, "references").or_else(|| header_value(&headers, "in-reply-to"));
-    let account = config.account.as_deref().unwrap_or(&config.username);
+    let account = config
+        .account
+        .as_deref()
+        .unwrap_or(config.auth_method.username());
     let attachments = imap_message_attachments(
         &message.raw,
         &ImapAttachmentContext {
@@ -1292,6 +1457,44 @@ impl ImapConnection {
         }
     }
 
+    /// Authenticate with SASL XOAUTH2 (RFC 7628 style, OAuth 2.0 SASL).
+    ///
+    /// The initial response carries the base64 credential string inline. On
+    /// rejection most servers (including Microsoft Exchange) answer with a
+    /// `+ <base64 JSON>` continuation instead of a tagged NO, so the client
+    /// must send an empty line to abort SASL before the tagged status line
+    /// arrives; both shapes are handled here and mapped to one actionable
+    /// error.
+    pub(crate) async fn authenticate_xoauth2(&mut self, username: &str, token: &str) -> Result<()> {
+        let tag = format!("A{:04}", self.next_tag);
+        self.next_tag = self.next_tag.saturating_add(1);
+        let encoded = base64::engine::general_purpose::STANDARD
+            .encode(build_xoauth2_sasl_string(username, token));
+        self.write_line(&format!("{tag} AUTHENTICATE XOAUTH2 {encoded}"))
+            .await?;
+        let mut challenge_json: Option<String> = None;
+        let tagged = loop {
+            let line = self.read_response_line_with_literals().await?;
+            if let Some(payload) = line.strip_prefix('+') {
+                challenge_json = decode_base64_json_challenge(payload);
+                // Abort SASL with an empty response so the server finishes
+                // the exchange with a tagged NO instead of waiting forever.
+                self.write_line("").await?;
+                continue;
+            }
+            if line.starts_with(&format!("{tag} ")) {
+                break line;
+            }
+        };
+        if tagged.contains(" OK") {
+            return Ok(());
+        }
+        Err(imap_xoauth2_rejected_error(
+            &tagged,
+            challenge_json.as_deref(),
+        ))
+    }
+
     /// Fetch one MIME section by UID with binary-safe literal handling.
     ///
     /// Unlike [`ImapConnection::command`], literal bytes are returned as raw
@@ -1521,8 +1724,10 @@ mod tests {
             host: "imap.example.com".to_string(),
             port: 993,
             use_tls: true,
-            username: "agent@example.com".to_string(),
-            password: "secret".to_string(),
+            auth_method: ImapAuthMethod::Basic {
+                username: "agent@example.com".to_string(),
+                password: "secret".to_string(),
+            },
             auth_profile: None,
             mailbox: "INBOX".to_string(),
             account: Some("primary".to_string()),
@@ -1554,8 +1759,10 @@ mod tests {
             host: "imap.example.com".to_string(),
             port: 993,
             use_tls: true,
-            username: "agent@example.com".to_string(),
-            password: "secret".to_string(),
+            auth_method: ImapAuthMethod::Basic {
+                username: "agent@example.com".to_string(),
+                password: "secret".to_string(),
+            },
             auth_profile: Some("imap-primary".to_string()),
             mailbox: "INBOX".to_string(),
             account: Some("primary".to_string()),
@@ -2049,8 +2256,10 @@ mod tests {
             host: "imap.example.com".to_string(),
             port: 993,
             use_tls: true,
-            username: "agent@example.com".to_string(),
-            password: "secret".to_string(),
+            auth_method: ImapAuthMethod::Basic {
+                username: "agent@example.com".to_string(),
+                password: "secret".to_string(),
+            },
             auth_profile: None,
             mailbox: "INBOX".to_string(),
             account: None,
@@ -2154,6 +2363,208 @@ mod tests {
             .all(|(kind, _)| kind == "email_imap_idle"));
     }
 
+    fn subscribe_request_for_resolve(endpoint: &str) -> crate::daemon::SubscribeStartRequest {
+        serde_json::from_value(serde_json::json!({
+            "request_id": "test-request",
+            "endpoint": endpoint,
+            "sink": "memory:",
+            "mode": "stream",
+            "options": {
+                "auth": null,
+                "no_cache": false,
+                "refresh_schema": false,
+                "schema_url": null,
+                "link_name": null,
+                "schema_mapping_file": null,
+            },
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn xoauth2_sasl_string_has_expected_shape() {
+        let value = build_xoauth2_sasl_string("user@example.com", "token1");
+        assert_eq!(value, "user=user@example.com\x01auth=Bearer token1\x01\x01");
+    }
+
+    #[test]
+    fn decode_base64_json_challenge_accepts_json_only() {
+        let payload = base64::engine::general_purpose::STANDARD
+            .encode(r#"{"status":"401","schemes":"Bearer,XOAUTH2"}"#);
+        assert!(decode_base64_json_challenge(&payload).is_some());
+        let not_json = base64::engine::general_purpose::STANDARD.encode("plain text");
+        assert!(decode_base64_json_challenge(&not_json).is_none());
+        assert!(decode_base64_json_challenge("!!!not-base64!!!").is_none());
+    }
+
+    #[tokio::test]
+    async fn imap_authenticate_xoauth2_accepts_tagged_ok() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut conn = ImapConnection::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut command = String::new();
+            reader.read_line(&mut command).await.unwrap();
+            assert!(command.starts_with("A0001 AUTHENTICATE XOAUTH2 "));
+            assert!(command.ends_with("\r\n"));
+            writer
+                .write_all(b"A0001 OK Authenticated.\r\n")
+                .await
+                .unwrap();
+        });
+
+        conn.authenticate_xoauth2("user@example.com", "token1")
+            .await
+            .unwrap();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn imap_authenticate_xoauth2_aborts_challenge_and_maps_actionable_error() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut conn = ImapConnection::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut command = String::new();
+            reader.read_line(&mut command).await.unwrap();
+            assert!(command.starts_with("A0001 AUTHENTICATE XOAUTH2 "));
+            let challenge = base64::engine::general_purpose::STANDARD.encode(
+                r#"{"status":"401","schemes":"Bearer,XOAUTH2","scope":"https://outlook.office.com/IMAP.AccessAsUser.All"}"#,
+            );
+            writer
+                .write_all(format!("+ {challenge}\r\n").as_bytes())
+                .await
+                .unwrap();
+            // After the SASL abort (empty line), the server finishes with NO.
+            let mut abort = String::new();
+            reader.read_line(&mut abort).await.unwrap();
+            assert_eq!(abort, "\r\n");
+            writer
+                .write_all(b"A0001 NO AUTHENTICATE failed.\r\n")
+                .await
+                .unwrap();
+        });
+
+        let err = conn
+            .authenticate_xoauth2("user@hotmail.com", "stale-token")
+            .await
+            .unwrap_err();
+        server.await.unwrap();
+        let message = err.to_string();
+        assert!(message.contains(IMAP_XOAUTH2_REJECTED_MARKER));
+        assert!(message.contains("IMAP.AccessAsUser.All"));
+        assert!(message.contains("auth oauth login"));
+        assert!(message.contains("AUTHENTICATE failed"));
+        // The base64 JSON challenge is decoded into the error detail.
+        assert!(message.contains("\"status\":\"401\""));
+        assert!(is_imap_permanent_auth_failure(&message));
+    }
+
+    #[tokio::test]
+    async fn imap_authenticate_xoauth2_maps_direct_no_rejection() {
+        let (client, server) = tokio::io::duplex(4096);
+        let mut conn = ImapConnection::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut command = String::new();
+            reader.read_line(&mut command).await.unwrap();
+            writer
+                .write_all(b"A0001 NO AUTHENTICATE failed.\r\n")
+                .await
+                .unwrap();
+        });
+
+        let err = conn
+            .authenticate_xoauth2("user@hotmail.com", "token1")
+            .await
+            .unwrap_err();
+        server.await.unwrap();
+        let message = err.to_string();
+        assert!(message.contains(IMAP_XOAUTH2_REJECTED_MARKER));
+        assert!(is_imap_permanent_auth_failure(&message));
+    }
+
+    fn oauth_profile_for_imap(username_field: Option<(&str, &str)>) -> Profile {
+        let mut profile = Profile::new(String::new(), crate::auth::AuthType::OAuth);
+        profile.name = Some("outlook-imap".to_string());
+        let oauth = crate::auth::OAuthProfile {
+            access_token: Some("access-token-1".to_string()),
+            scopes: vec!["https://outlook.office.com/IMAP.AccessAsUser.All".to_string()],
+            ..Default::default()
+        };
+        profile.oauth = Some(oauth);
+        if let Some((name, value)) = username_field {
+            profile
+                .set_field_source(
+                    name.to_string(),
+                    crate::auth::SecretSource::Literal {
+                        value: value.to_string(),
+                    },
+                )
+                .unwrap();
+        }
+        profile
+    }
+
+    #[test]
+    fn resolve_config_uses_xoauth2_for_oauth_profiles() {
+        let mut request = subscribe_request_for_resolve("imaps://outlook.office365.com:993");
+        request.options.auth = Some("outlook-imap".to_string());
+        let profile = oauth_profile_for_imap(Some(("email", "user@hotmail.com")));
+        let config = resolve_email_imap_idle_runtime_config(&request, &profile).unwrap();
+        assert_eq!(
+            config.auth_method,
+            ImapAuthMethod::Xoauth2 {
+                username: "user@hotmail.com".to_string(),
+                token: "access-token-1".to_string(),
+            }
+        );
+        // Without a username field the account arg and finally the profile
+        // name act as the mailbox address.
+        let profile = oauth_profile_for_imap(None);
+        let config = resolve_email_imap_idle_runtime_config(&request, &profile).unwrap();
+        assert_eq!(
+            config.auth_method,
+            ImapAuthMethod::Xoauth2 {
+                username: "outlook-imap".to_string(),
+                token: "access-token-1".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_config_keeps_basic_auth_for_password_profiles() {
+        let request = subscribe_request_for_resolve("imaps://imap.example.com:993");
+        let mut profile = Profile::new(String::new(), crate::auth::AuthType::Basic);
+        profile
+            .set_field_source(
+                "username".to_string(),
+                crate::auth::SecretSource::Literal {
+                    value: "agent@example.com".to_string(),
+                },
+            )
+            .unwrap();
+        profile
+            .set_field_source(
+                "password".to_string(),
+                crate::auth::SecretSource::Literal {
+                    value: "secret".to_string(),
+                },
+            )
+            .unwrap();
+        let config = resolve_email_imap_idle_runtime_config(&request, &profile).unwrap();
+        assert_eq!(
+            config.auth_method,
+            ImapAuthMethod::Basic {
+                username: "agent@example.com".to_string(),
+                password: "secret".to_string(),
+            }
+        );
+    }
+
     fn basic_auth_disabled_server_script() -> &'static [u8] {
         b"* OK Microsoft Exchange IMAP4 service ready.\r\n"
     }
@@ -2222,8 +2633,10 @@ mod tests {
             host: "outlook.office365.com".to_string(),
             port: 993,
             use_tls: true,
-            username: "jolestar@hotmail.com".to_string(),
-            password: "secret".to_string(),
+            auth_method: ImapAuthMethod::Basic {
+                username: "jolestar@hotmail.com".to_string(),
+                password: "secret".to_string(),
+            },
             auth_profile: Some("email-hotmail".to_string()),
             mailbox: "INBOX".to_string(),
             account: Some("primary".to_string()),

--- a/src/subscription_email.rs
+++ b/src/subscription_email.rs
@@ -1477,9 +1477,9 @@ impl ImapConnection {
             let line = self.read_response_line_with_literals().await?;
             if let Some(payload) = line.strip_prefix('+') {
                 challenge_json = decode_base64_json_challenge(payload);
-                // Abort SASL with an empty response so the server finishes
-                // the exchange with a tagged NO instead of waiting forever.
-                self.write_line("").await?;
+                // Abort SASL with `*` (RFC 3501 section 6.2.2) so the server
+                // finishes the exchange with a tagged NO instead of waiting forever.
+                self.write_line("*").await?;
                 continue;
             }
             if line.starts_with(&format!("{tag} ")) {
@@ -2437,10 +2437,10 @@ mod tests {
                 .write_all(format!("+ {challenge}\r\n").as_bytes())
                 .await
                 .unwrap();
-            // After the SASL abort (empty line), the server finishes with NO.
+            // After the SASL abort (`*` per RFC 3501), the server finishes with NO.
             let mut abort = String::new();
             reader.read_line(&mut abort).await.unwrap();
-            assert_eq!(abort, "\r\n");
+            assert_eq!(abort, "*\r\n");
             writer
                 .write_all(b"A0001 NO AUTHENTICATE failed.\r\n")
                 .await

--- a/tests/oauth_cli_test.rs
+++ b/tests/oauth_cli_test.rs
@@ -664,3 +664,54 @@ fn oauth_session_file_permissions_are_0600() {
         & 0o777;
     assert_eq!(mode, 0o600, "session file should be mode 0600");
 }
+
+#[test]
+fn oauth_login_outlook_preset_sends_thunderbird_client_id_and_scopes() {
+    let files = AuthFiles::new();
+    let mut server = mockito::Server::new();
+
+    let device_mock = server
+        .mock("POST", "/devicecode")
+        .match_body(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::Regex("client_id=9e5f94bc-e8a4-4e73-b8be-63364c29d753".to_string()),
+            mockito::Matcher::Regex("IMAP.AccessAsUser.All".to_string()),
+            mockito::Matcher::Regex("SMTP.Send".to_string()),
+            mockito::Matcher::Regex("offline_access".to_string()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"device_code":"dc-1","user_code":"ABCDEF","verification_uri":"https://microsoft.com/devicelogin","expires_in":1,"interval":1}"#,
+        )
+        .create();
+    let _token_mock = server
+        .mock("POST", "/token")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error":"authorization_pending"}"#)
+        .create();
+
+    let output = uxc_command(&files)
+        .arg("auth")
+        .arg("oauth")
+        .arg("login")
+        .arg("outlook-imap")
+        .arg("--provider")
+        .arg("outlook")
+        .arg("--device-authorization-endpoint")
+        .arg(format!("{}/devicecode", server.url()))
+        .arg("--token-endpoint")
+        .arg(format!("{}/token", server.url()))
+        .output()
+        .expect("oauth login should run");
+
+    // Nobody completes the device consent in this test, so the login times
+    // out after the 1s expiry; the important assertion is that the preset
+    // filled the Thunderbird client id and IMAP+SMTP+offline_access scopes
+    // into the device-authorization request without explicit flags.
+    device_mock.assert();
+    assert!(
+        !output.status.success(),
+        "login should fail while device code is pending"
+    );
+}


### PR DESCRIPTION
## What

- `uxc auth oauth login --provider outlook`: built-in preset that fills the public Thunderbird client id, Microsoft consumers issuer, token/device endpoints, and IMAP+SMTP XOAUTH2 scopes; explicit flags override the preset and `--endpoint` becomes optional in preset mode.
- `email-imap-idle`: OAuth credentials now authenticate via SASL XOAUTH2 instead of failing with basic-auth-disabled; tokens refresh on stale before login, and XOAUTH2 rejections are decoded (base64 JSON challenge) into actionable errors.
- SMTP send: STARTTLS upgrade and `smtps://` support, plus `AUTH XOAUTH2` for OAuth credentials; OAuth transports are treated as secure and no longer require `--allow-insecure-auth`.
- IMAP attachment download refreshes OAuth tokens on demand.
- Docs: personal-account onboarding for IMAP IDLE (device-code login + subscribe) and the Microsoft Graph poll alternative.

## Why

Issue #445: Microsoft personal (consumer) accounts reject IMAP basic auth, so email subscriptions and OAuth-based sending could not work end to end. Phase 1 (merged in #454) only surfaced an actionable error; this delivers the OAuth path.

## How

- `src/auth/oauth.rs`: `OAuthLoginPreset` (outlook) + `apply_oauth_login_preset` merging preset defaults with explicit CLI overrides.
- `src/subscription_email.rs`: `ImapAuthMethod`, `build_xoauth2_sasl_string`, `imap_authenticate_xoauth2`, stale-token refresh with skew, permanent-failure classification, XOAUTH2 rejected-marker errors.
- `src/email.rs`: `tls_upgrade` (STARTTLS), `SmtpIo` reader, `ehlo` capability collection, `auth_xoauth2` with challenge abort, URL parsing for `smtps`, secure-transport gate update.
- `src/email_attachment_get.rs`: `refresh_oauth_profile_for_retrieval` used by IMAP download.
- `src/main.rs`: `--provider` flag and preset wiring for `auth oauth login`.

## Testing

- Unit/integration tests: outlook preset defaults + overrides (`tests/oauth_cli_test.rs`), SMTP XOAUTH2 accept/challenge-abort (`src/email.rs`), IMAP XOAUTH2 auth via duplex io mock (`src/subscription_email.rs`), smtps URL parsing, insecure-auth gate for OAuth transports.
- Local: `cargo test` (full suite) ✅, `cargo fmt --all -- --check` ✅, CI-mode `cargo clippy -- -D warnings -A ...` ✅, `npm run docs:index` ✅ (no index changes needed).
- Live personal-account verification against outlook.office365.com remains operator-confirmed before/after merge (documented in docs/site/sources/email.md).

Closes #445