### PR TITLE
fix(email): install rustls ring provider and stabilize IMAP IDLE

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1328,6 +1328,12 @@ struct LinkLauncherConfig<'a> {
 
 #[tokio::main]
 async fn main() {
+    // Install the process-level rustls CryptoProvider explicitly: the
+    // dependency graph enables both `ring` (direct rustls feature) and
+    // `aws-lc-rs` (tokio-rustls default), so provider auto-detection panics
+    // at the first TLS handshake (e.g. email-imap-idle imaps sources).
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()

--- a/src/subscription_email.rs
+++ b/src/subscription_email.rs
@@ -27,6 +27,8 @@ use url::Url;
 const DEFAULT_MAILBOX: &str = "INBOX";
 const IMAP_CONNECT_TIMEOUT_SECS: u64 = 10;
 const IMAP_COMMAND_TIMEOUT_SECS: u64 = 30;
+const IMAP_LITERAL_TIMEOUT_SECS: u64 = 300;
+const IMAP_IDLE_READ_TIMEOUT_SECS: u64 = 60;
 const IMAP_IDLE_DONE_TIMEOUT_SECS: u64 = 5;
 /// Number of existing messages fetched on the first look by default.
 pub const EMAIL_IMAP_DEFAULT_INITIAL_FETCH_LIMIT: u64 = 25;
@@ -303,27 +305,45 @@ where
             return Ok(());
         }
         let idle_tag = conn.start_idle().await?;
-        tokio::select! {
-            changed = stop_rx.changed() => {
-                if changed.is_ok() && *stop_rx.borrow() {
-                    conn.done_idle(&idle_tag).await?;
-                    let _ = conn.logout().await;
-                    close_email_subscription(recorder, "stopped").await?;
-                    return Ok(());
+        // Quiet-read ticks since the last server output. During IDLE the
+        // server may legitimately stay silent; timeouts are benign and IDLE
+        // is re-issued periodically to stay inside the server-side window.
+        let mut quiet_ticks: u32 = 0;
+        loop {
+            tokio::select! {
+                changed = stop_rx.changed() => {
+                    if changed.is_ok() && *stop_rx.borrow() {
+                        conn.done_idle(&idle_tag).await?;
+                        let _ = conn.logout().await;
+                        close_email_subscription(recorder, "stopped").await?;
+                        return Ok(());
+                    }
                 }
-            }
-            line = conn.read_line() => {
-                let line = line?;
-                if line.contains(" EXISTS") || line.contains(" RECENT") {
-                    conn.done_idle(&idle_tag).await?;
-                    let messages = match last_seen_uid {
-                        Some(uid) => conn.fetch_since_uid(uid).await?,
-                        None => conn.fetch_recent(config.initial_fetch_limit).await?,
-                    };
-                    if let Some(uid) =
-                        emit_messages(config, messages, recorder, uidvalidity).await?
-                    {
-                        last_seen_uid = Some(last_seen_uid.map_or(uid, |last| last.max(uid)));
+                line = conn.read_line_idle() => {
+                    match line? {
+                        Some(line) if line.contains(" EXISTS") || line.contains(" RECENT") => {
+                            conn.done_idle(&idle_tag).await?;
+                        let messages = match last_seen_uid {
+                            Some(uid) => conn.fetch_since_uid(uid).await?,
+                            None => conn.fetch_recent(config.initial_fetch_limit).await?,
+                        };
+                        if let Some(uid) =
+                            emit_messages(config, messages, recorder, uidvalidity).await?
+                        {
+                            last_seen_uid = Some(last_seen_uid.map_or(uid, |last| last.max(uid)));
+                        }
+                            break;
+                        }
+                        Some(_) => {
+                            quiet_ticks = 0;
+                        }
+                        None => {
+                            quiet_ticks += 1;
+                            if quiet_ticks >= 10 {
+                                conn.done_idle(&idle_tag).await?;
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -1246,6 +1266,25 @@ impl ImapConnection {
         Ok(line.trim_end_matches(['\r', '\n']).to_string())
     }
 
+    /// Like [`ImapConnection::read_line`], but a read timeout surfaces as
+    /// `Ok(None)` instead of an error. During IMAP IDLE the server may
+    /// legitimately stay silent for long stretches, so a quiet connection must
+    /// not kill the session.
+    async fn read_line_idle(&mut self) -> Result<Option<String>> {
+        let mut line = String::new();
+        match tokio::time::timeout(
+            Duration::from_secs(IMAP_IDLE_READ_TIMEOUT_SECS),
+            self.reader.read_line(&mut line),
+        )
+        .await
+        {
+            Ok(Ok(read)) if read > 0 => Ok(Some(line.trim_end_matches(['\r', '\n']).to_string())),
+            Ok(Ok(_)) => bail!("IMAP connection closed"),
+            Ok(Err(err)) => Err(anyhow!("IMAP read failed: {}", err)),
+            Err(_) => Ok(None),
+        }
+    }
+
     async fn command(&mut self, command: &str) -> Result<Vec<String>> {
         let tag = format!("A{:04}", self.next_tag);
         self.next_tag = self.next_tag.saturating_add(1);
@@ -1267,7 +1306,7 @@ impl ImapConnection {
         while let Some(len) = trailing_literal_len(&line) {
             let mut literal = vec![0u8; len];
             tokio::time::timeout(
-                Duration::from_secs(IMAP_COMMAND_TIMEOUT_SECS),
+                Duration::from_secs(IMAP_LITERAL_TIMEOUT_SECS),
                 self.reader.read_exact(&mut literal),
             )
             .await


### PR DESCRIPTION
## Summary

Fixes two defects in the `email-imap-idle` transport that together made imaps
sources unusable under the daemon.

Fixes #456
Fixes #457

### 1. TLS provider panic at first handshake (#456)

The dependency graph enables both `ring` (direct rustls feature) and
`aws-lc-rs` (tokio-rustls default feature). rustls provider auto-detection
cannot pick a process-level CryptoProvider in that case and panics at the
first TLS handshake (`rustls-0.23/src/crypto/mod.rs:249`). When the daemon is
autostarted with stderr redirected to /dev/null, this only surfaces as a
generic "exited unexpectedly; restarting" supervision loop with no trace.

`main()` now explicitly installs `rustls::crypto::ring::default_provider()`.

### 2. IMAP IDLE read timeouts and backfill duplication (#457)

- Literal reads now use a dedicated `IMAP_LITERAL_TIMEOUT_SECS` (300s) instead
  of the 30s command timeout, so slow-path initial backfill survives large
  mailboxes.
- New `read_line_idle()` treats a read timeout as a benign quiet tick during
  IDLE instead of an error, and IDLE is re-issued after ~10 quiet ticks
  (~10 min) to stay inside the server-side window. Previously every 30s read
  timeout killed the session, and each reconnect re-ran the full initial
  backfill, duplicating messages.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test` pass.
- Verified against a real Gmail IMAP account (app-password, imaps): source
  running stable, 25-message initial backfill persisted and consumed by
  agentinbox, IDLE quiet periods no longer kill the session.
