### PR TITLE
fix(schema_mapping): add builtin api.telegram.org OpenAPI mapping

### DIFF
--- a/src/schema_mapping/mod.rs
+++ b/src/schema_mapping/mod.rs
@@ -106,13 +106,25 @@ impl OpenApiMappingRule {
 }
 
 fn builtin_openapi_rules() -> Vec<OpenApiMappingRule> {
-    vec![OpenApiMappingRule {
-        host: "api.github.com".to_string(),
-        path_prefix: Some("/".to_string()),
-        schema_url: "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json".to_string(),
-        enabled: true,
-        priority: 1000,
-    }]
+    vec![
+        OpenApiMappingRule {
+            host: "api.github.com".to_string(),
+            path_prefix: Some("/".to_string()),
+            schema_url: "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json".to_string(),
+            enabled: true,
+            priority: 1000,
+        },
+        // Telegram Bot API has no official auto-discoverable OpenAPI document.
+        // Map it to the curated schema shipped in this repository (#206) so
+        // protocol detection succeeds without per-caller schema_url overrides (#460).
+        OpenApiMappingRule {
+            host: "api.telegram.org".to_string(),
+            path_prefix: Some("/".to_string()),
+            schema_url: "https://raw.githubusercontent.com/holon-run/uxc/main/skills/telegram-openapi-skill/references/telegram-bot.openapi.json".to_string(),
+            enabled: true,
+            priority: 1000,
+        },
+    ]
 }
 
 fn resolve_user_mappings_path() -> Option<PathBuf> {
@@ -239,6 +251,22 @@ mod tests {
 
         assert_eq!(resolved.source, MappingSource::Builtin);
         assert!(resolved.schema_url.contains("api.github.com.json"));
+    }
+
+    #[test]
+    fn builtin_mapping_matches_telegram() {
+        let resolved = resolve_from_rules(
+            "https://api.telegram.org",
+            Vec::new(),
+            builtin_openapi_rules(),
+        )
+        .expect("should resolve telegram mapping");
+
+        assert_eq!(resolved.source, MappingSource::Builtin);
+        assert_eq!(
+            resolved.schema_url,
+            "https://raw.githubusercontent.com/holon-run/uxc/main/skills/telegram-openapi-skill/references/telegram-bot.openapi.json"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Add a builtin OpenAPI schema mapping rule for `api.telegram.org` in `builtin_openapi_rules()`, pointing to the curated telegram-bot schema already shipped in this repository (`skills/telegram-openapi-skill/references/telegram-bot.openapi.json`, introduced in #206). Same pattern (host + `/` path prefix) as the existing `api.github.com` rule.

## Why

Telegram Bot API has no official auto-discoverable OpenAPI document, so `ProtocolDetector`'s OpenAPI probe against `api.telegram.org` always fails. Consumers without a per-call `schema_url` (e.g. agentinbox `telegram_bot` poll sources calling `POST /bot<token>/getUpdates`) fall into a permanent reconnect loop, burning CPU and logs with `protocol_detection_failure` — every round probes MCP → GraphQL → OpenAPI → JSON-RPC → gRPC and fails. Mapping the host to the curated schema lets protocol detection succeed out of the box for all consumers.

Closes #460

## How

- Extend `builtin_openapi_rules()` in `src/schema_mapping/mod.rs` with the `api.telegram.org` rule (raw GitHub URL pinned to `main`, priority 1000, matching the github rule).
- Add unit test `builtin_mapping_matches_telegram` asserting the builtin rule resolves with `MappingSource::Builtin` and the expected schema URL.

## Testing

- `cargo test --lib schema_mapping` — 4/4 passed (incl. new test)
- `cargo test --test protocol_test` — 31/31 passed
- `cargo test schema` — 72 passed across suites
- `cargo fmt` clean
- `cargo clippy -- -D warnings -A dead_code ...` (CI invocation) clean