### PR TITLE
fix(daemon): self-terminate orphaned daemons and harden test teardown

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -58,12 +58,15 @@ use std::ffi::OsString;
 use std::fs;
 use std::io::{ErrorKind, Seek, SeekFrom, Write};
 #[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+#[cfg(unix)]
 use std::os::unix::net::UnixStream as StdUnixStream;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::process::Stdio;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 #[cfg(unix)]
@@ -87,6 +90,14 @@ const MCP_IDLE_TTL_DEFAULT_SECS: u64 = 3600;
 const MCP_IDLE_TTL_ENV: &str = "UXC_DAEMON_MCP_IDLE_TTL_SECS";
 const MCP_IDLE_TTL_MAX_SECS: u64 = 24 * 60 * 60;
 const MCP_IDLE_CLEANUP_INTERVAL_MS: u64 = 500;
+// How often the daemon watchdog verifies that its socket (and therefore its
+// state dir) still exists. A daemon whose temp state dir was removed (e.g. a
+// leaked test daemon) exits within one tick of becoming orphaned instead of
+// idling forever.
+const DAEMON_WATCHDOG_TICK_MS: u64 = 2_000;
+// Optional idle self-shutdown for daemon processes. Mainly used by test
+// harnesses that spawn short-lived daemons and may never run teardown.
+const DAEMON_IDLE_TIMEOUT_ENV: &str = "UXC_DAEMON_IDLE_TIMEOUT_SECS";
 // Five seconds is long enough for cooperative stdio servers to notice stdin EOF
 // and release external resources, while still bounding daemon-side eviction stalls.
 const MCP_STDIO_EXIT_TIMEOUT_SECS: u64 = 5;
@@ -7320,6 +7331,100 @@ pub async fn ensure_compatible_daemon_running() -> Result<EnsureDaemonOutcome> {
     bail!("uxcd daemon is not supported on this platform; run uxc inside WSL")
 }
 
+/// Outcome of one watchdog probe of the daemon socket path.
+#[cfg(unix)]
+enum DaemonSocketWatch {
+    Healthy,
+    Orphaned(&'static str),
+    TransientError,
+}
+
+/// Decide whether the daemon still owns its socket. `stat_ino` is the current
+/// inode of the socket path (if stat succeeded) and `expected_ino` is the inode
+/// recorded right after binding.
+#[cfg(unix)]
+fn classify_daemon_socket_watch(
+    stat_ino: std::io::Result<u64>,
+    expected_ino: u64,
+) -> DaemonSocketWatch {
+    match stat_ino {
+        Ok(ino) if ino == expected_ino => DaemonSocketWatch::Healthy,
+        Ok(_) => DaemonSocketWatch::Orphaned("socket path is now owned by another daemon"),
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            DaemonSocketWatch::Orphaned("daemon state dir or socket no longer exists")
+        }
+        Err(_) => DaemonSocketWatch::TransientError,
+    }
+}
+
+/// Tracks external client activity so the daemon can self-terminate when idle.
+/// Internal work (managed source polling, MCP session cleanup) does not count;
+/// only accepted client connections do.
+#[cfg(unix)]
+struct DaemonActivity {
+    open_connections: AtomicUsize,
+    last_activity: std::sync::Mutex<Instant>,
+}
+
+#[cfg(unix)]
+impl DaemonActivity {
+    fn new() -> Self {
+        Self {
+            open_connections: AtomicUsize::new(0),
+            last_activity: std::sync::Mutex::new(Instant::now()),
+        }
+    }
+
+    fn open_connection(self: &Arc<Self>) -> DaemonConnectionGuard {
+        self.open_connections.fetch_add(1, Ordering::SeqCst);
+        *self
+            .last_activity
+            .lock()
+            .expect("daemon activity lock poisoned") = Instant::now();
+        DaemonConnectionGuard {
+            activity: Arc::clone(self),
+        }
+    }
+
+    fn idle_for(&self, timeout: Duration) -> bool {
+        self.open_connections.load(Ordering::SeqCst) == 0
+            && self
+                .last_activity
+                .lock()
+                .expect("daemon activity lock poisoned")
+                .elapsed()
+                >= timeout
+    }
+}
+
+/// RAII marker for one accepted daemon connection; decrements the open
+/// connection count when the connection handler finishes.
+#[cfg(unix)]
+struct DaemonConnectionGuard {
+    activity: Arc<DaemonActivity>,
+}
+
+#[cfg(unix)]
+impl Drop for DaemonConnectionGuard {
+    fn drop(&mut self) {
+        self.activity
+            .open_connections
+            .fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// Optional daemon idle self-shutdown window. Mainly for test harnesses that
+/// spawn short-lived daemons and may never run teardown (e.g. an interrupted
+/// test run). Unset or non-positive values disable it.
+#[cfg(unix)]
+fn daemon_idle_timeout_secs() -> Option<Duration> {
+    std::env::var(DAEMON_IDLE_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .map(Duration::from_secs)
+}
+
 #[cfg(unix)]
 pub async fn run_daemon_server() -> Result<()> {
     let dir = daemon_dir();
@@ -7341,6 +7446,15 @@ pub async fn run_daemon_server() -> Result<()> {
     let listener = UnixListener::bind(&socket)
         .with_context(|| format!("Failed to bind daemon socket at {}", socket.display()))?;
 
+    // Record the socket identity so the watchdog can distinguish "state dir
+    // deleted under us" (e.g. a test temp HOME) from "socket replaced by a
+    // newer daemon owner after this one was orphaned".
+    let socket_ino = fs::metadata(&socket)
+        .with_context(|| format!("Failed to stat daemon socket at {}", socket.display()))?
+        .ino();
+    let idle_timeout = daemon_idle_timeout_secs();
+    let activity = Arc::new(DaemonActivity::new());
+
     let runtime = Arc::new(DaemonRuntime::try_new()?);
     let resume_runtime = runtime.clone();
     tokio::spawn(async move {
@@ -7361,6 +7475,50 @@ pub async fn run_daemon_server() -> Result<()> {
             cleanup_runtime.mcp.cleanup_idle().await;
         }
     });
+    let watchdog_runtime = runtime.clone();
+    let watchdog_socket = socket.clone();
+    let watchdog_activity = activity.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_millis(DAEMON_WATCHDOG_TICK_MS));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            if watchdog_runtime.should_stop().await {
+                break;
+            }
+            match classify_daemon_socket_watch(
+                fs::metadata(&watchdog_socket).map(|meta| meta.ino()),
+                socket_ino,
+            ) {
+                DaemonSocketWatch::Healthy => {}
+                DaemonSocketWatch::TransientError => {}
+                DaemonSocketWatch::Orphaned(reason) => {
+                    tracing::warn!(
+                        "Daemon is orphaned ({}); exiting. socket={} pid={}",
+                        reason,
+                        watchdog_socket.display(),
+                        std::process::id()
+                    );
+                    // The state dir (and with it the owner lock and log files)
+                    // is already gone, so there is nothing to clean up. Exit
+                    // directly instead of waiting for the accept loop.
+                    std::process::exit(0);
+                }
+            }
+            if let Some(timeout) = idle_timeout {
+                if watchdog_activity.idle_for(timeout) {
+                    tracing::warn!(
+                        "Daemon received no client connections for more than {:?}; \
+                         shutting down ({} is set)",
+                        timeout,
+                        DAEMON_IDLE_TIMEOUT_ENV
+                    );
+                    watchdog_runtime.request_stop().await;
+                    break;
+                }
+            }
+        }
+    });
 
     // Log daemon start
     runtime
@@ -7370,7 +7528,9 @@ pub async fn run_daemon_server() -> Result<()> {
     loop {
         let (stream, _) = listener.accept().await?;
         let runtime_for_conn = runtime.clone();
+        let conn_activity = activity.clone();
         tokio::spawn(async move {
+            let _open_connection = conn_activity.open_connection();
             if let Err(err) = handle_connection(stream, runtime_for_conn).await {
                 tracing::debug!("daemon connection failed: {}", err);
             }
@@ -10056,6 +10216,76 @@ mod tests {
         with_mcp_idle_ttl_env(Some("9999999999999999999"), || {
             assert_eq!(default_mcp_idle_ttl_secs(), MCP_IDLE_TTL_MAX_SECS);
         });
+    }
+
+    fn with_daemon_idle_timeout_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+        let previous = std::env::var_os(DAEMON_IDLE_TIMEOUT_ENV);
+        match value {
+            Some(value) => std::env::set_var(DAEMON_IDLE_TIMEOUT_ENV, value),
+            None => std::env::remove_var(DAEMON_IDLE_TIMEOUT_ENV),
+        }
+
+        let result = f();
+
+        match previous {
+            Some(previous) => std::env::set_var(DAEMON_IDLE_TIMEOUT_ENV, previous),
+            None => std::env::remove_var(DAEMON_IDLE_TIMEOUT_ENV),
+        }
+        result
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_idle_timeout_secs_is_optional_and_validated() {
+        with_daemon_idle_timeout_env(None, || {
+            assert_eq!(daemon_idle_timeout_secs(), None);
+        });
+        with_daemon_idle_timeout_env(Some("0"), || {
+            assert_eq!(daemon_idle_timeout_secs(), None);
+        });
+        with_daemon_idle_timeout_env(Some("not-a-number"), || {
+            assert_eq!(daemon_idle_timeout_secs(), None);
+        });
+        with_daemon_idle_timeout_env(Some(" 30 "), || {
+            assert_eq!(daemon_idle_timeout_secs(), Some(Duration::from_secs(30)));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_daemon_socket_watch_detects_orphan_and_replacement() {
+        assert!(matches!(
+            classify_daemon_socket_watch(Ok(42), 42),
+            DaemonSocketWatch::Healthy
+        ));
+        assert!(matches!(
+            classify_daemon_socket_watch(Ok(7), 42),
+            DaemonSocketWatch::Orphaned(_)
+        ));
+        assert!(matches!(
+            classify_daemon_socket_watch(Err(std::io::Error::from(ErrorKind::NotFound)), 42),
+            DaemonSocketWatch::Orphaned(_)
+        ));
+        assert!(matches!(
+            classify_daemon_socket_watch(
+                Err(std::io::Error::from(ErrorKind::PermissionDenied)),
+                42
+            ),
+            DaemonSocketWatch::TransientError
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_activity_counts_open_connections_for_idle_detection() {
+        let activity = Arc::new(DaemonActivity::new());
+        let guard = activity.open_connection();
+        assert!(!activity.idle_for(Duration::from_millis(1)));
+        drop(guard);
+        std::thread::sleep(Duration::from_millis(3));
+        assert!(activity.idle_for(Duration::from_millis(1)));
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -11,6 +11,19 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
+/// Env var read by the daemon for idle self-shutdown; must stay in sync with
+/// `DAEMON_IDLE_TIMEOUT_ENV` in src/daemon.rs.
+pub const DAEMON_IDLE_TIMEOUT_ENV: &str = "UXC_DAEMON_IDLE_TIMEOUT_SECS";
+
+/// Idle self-shutdown window (seconds) for daemons auto-started by tests.
+/// Bounds the lifetime of daemons whose teardown never runs (e.g. an
+/// interrupted test run), while staying far above the longest gap between
+/// commands within a single test.
+pub const TEST_DAEMON_IDLE_TIMEOUT_SECS: &str = "120";
+
+const TEST_DAEMON_STOP_RETRIES: usize = 10;
+const TEST_DAEMON_STOP_RETRY_INTERVAL: Duration = Duration::from_millis(200);
+
 fn cargo_target_dir() -> PathBuf {
     std::env::var_os("CARGO_TARGET_DIR")
         .map(PathBuf::from)
@@ -53,7 +66,9 @@ pub fn uxc_binary() -> PathBuf {
 
 #[allow(deprecated)]
 pub fn uxc_command() -> AssertCommand {
-    AssertCommand::cargo_bin("uxc").expect("uxc binary should build")
+    let mut cmd = AssertCommand::cargo_bin("uxc").expect("uxc binary should build");
+    cmd.env(DAEMON_IDLE_TIMEOUT_ENV, TEST_DAEMON_IDLE_TIMEOUT_SECS);
+    cmd
 }
 
 pub fn uxc_command_with_home(home: &std::path::Path) -> AssertCommand {
@@ -174,6 +189,7 @@ pub fn run_uxc_in_home(args: &[&str], test_home: &std::path::Path) -> Result<Str
     fs::create_dir_all(&runtime_dir).expect("Failed to create test runtime dir");
     let output = Command::new(&uxc)
         .args(args)
+        .env(DAEMON_IDLE_TIMEOUT_ENV, TEST_DAEMON_IDLE_TIMEOUT_SECS)
         .env("HOME", test_home)
         .env("USERPROFILE", test_home)
         .env("XDG_RUNTIME_DIR", &runtime_dir)
@@ -226,16 +242,50 @@ impl AsRef<OsStr> for TestHome {
 
 impl Drop for TestHome {
     fn drop(&mut self) {
-        let runtime_dir = self.path.join("runtime");
-        let _ = fs::create_dir_all(&runtime_dir);
-        let _ = Command::new(uxc_binary())
-            .args(["daemon", "stop"])
-            .env("HOME", &self.path)
-            .env("USERPROFILE", &self.path)
-            .env("XDG_RUNTIME_DIR", &runtime_dir)
-            .output();
+        stop_test_daemon(&self.path);
         let _ = fs::remove_dir_all(&self.path);
     }
+}
+
+/// Stop the daemon serving `home` and wait until it is actually down.
+///
+/// `daemon stop` is idempotent and falls back to SIGTERM/SIGKILL via the
+/// owner pid recorded in daemon.lock, but a daemon that is still mid-startup
+/// holds neither socket nor owner lock yet, so a single stop attempt can miss
+/// it and leak an orphan once the temp HOME is deleted. Retry until
+/// `daemon status` is unreachable; if the daemon still refuses to stop, rely
+/// on the daemon-side orphan watchdog instead of deleting the HOME blindly.
+pub fn stop_test_daemon(home: &Path) {
+    let runtime_dir = home.join("runtime");
+    let _ = fs::create_dir_all(&runtime_dir);
+    for _ in 0..TEST_DAEMON_STOP_RETRIES {
+        let _ = Command::new(uxc_binary())
+            .args(["daemon", "stop"])
+            .env("HOME", home)
+            .env("USERPROFILE", home)
+            .env("XDG_RUNTIME_DIR", &runtime_dir)
+            .output();
+        let status = Command::new(uxc_binary())
+            .args(["daemon", "status"])
+            .env("HOME", home)
+            .env("USERPROFILE", home)
+            .env("XDG_RUNTIME_DIR", &runtime_dir)
+            .output();
+        let daemon_down = match status {
+            Ok(output) => !output.status.success(),
+            Err(_) => true,
+        };
+        if daemon_down {
+            return;
+        }
+        std::thread::sleep(TEST_DAEMON_STOP_RETRY_INTERVAL);
+    }
+    eprintln!(
+        "WARNING: daemon for test home {} did not stop after {} attempts; \
+         relying on orphan watchdog self-termination",
+        home.display(),
+        TEST_DAEMON_STOP_RETRIES
+    );
 }
 
 /// Create a fresh HOME directory for test isolation.

--- a/tests/daemon_orphan_exit_test.rs
+++ b/tests/daemon_orphan_exit_test.rs
@@ -1,0 +1,127 @@
+//! Regression tests for issue #459: test runs must not leak
+//! `uxc daemon _serve` processes.
+//!
+//! Covers the two daemon-side self-termination paths:
+//! - the orphan watchdog: the daemon exits once its state dir (socket path)
+//!   disappears, even though no client can address it anymore;
+//! - the idle timeout: with `UXC_DAEMON_IDLE_TIMEOUT_SECS` set, the daemon
+//!   shuts itself down after the window passes with no client connections,
+//!   which also bounds leaks from test runs that are killed mid-run and never
+//!   run their teardown.
+
+mod common;
+
+use common::{fresh_test_home_dir, uxc_command_with_home, DAEMON_IDLE_TIMEOUT_ENV};
+use serial_test::serial;
+use std::fs;
+use std::path::Path;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn daemon_lock_path(home: &Path) -> std::path::PathBuf {
+    home.join(".uxc").join("daemon").join("daemon.lock")
+}
+
+fn read_owner_pid(home: &Path) -> u32 {
+    let raw = fs::read_to_string(daemon_lock_path(home))
+        .expect("daemon.lock should exist after daemon start");
+    let value: serde_json::Value =
+        serde_json::from_str(&raw).expect("daemon.lock should contain JSON metadata");
+    value["pid"]
+        .as_u64()
+        .expect("daemon.lock should record the owner pid") as u32
+}
+
+/// Whether `pid` is still a live (non-zombie) process.
+#[cfg(target_os = "linux")]
+fn pid_alive(pid: u32) -> bool {
+    let stat = match fs::read_to_string(format!("/proc/{pid}/stat")) {
+        Ok(stat) => stat,
+        Err(_) => return false,
+    };
+    // The second field (process state) follows the comm name in parentheses.
+    match stat.rsplit(')').next() {
+        Some(rest) => !rest.trim_start().starts_with('Z'),
+        None => true,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn pid_alive(pid: u32) -> bool {
+    use std::process::Command;
+    Command::new("kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn wait_for_pid_exit(pid: u32, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if !pid_alive(pid) {
+            return;
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+    panic!(
+        "daemon pid {} was still alive after {:?}; it leaked",
+        pid, timeout
+    );
+}
+
+fn start_daemon_and_read_pid(home: &Path) -> u32 {
+    let output = uxc_command_with_home(home)
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("uxc daemon start should run");
+    assert!(
+        output.status.success(),
+        "daemon start should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    read_owner_pid(home)
+}
+
+#[test]
+#[serial]
+fn daemon_exits_when_its_state_dir_is_deleted() {
+    let home = fresh_test_home_dir();
+    let pid = start_daemon_and_read_pid(home.path());
+    assert!(pid_alive(pid), "daemon should be running after start");
+
+    // Simulate the leak scenario: the test HOME is removed without stopping
+    // the daemon first. The socket and daemon.lock vanish with it, so no
+    // client can address or kill the daemon by metadata anymore.
+    fs::remove_dir_all(home.path()).expect("test HOME should be removable");
+
+    // The orphan watchdog checks every DAEMON_WATCHDOG_TICK_MS.
+    wait_for_pid_exit(pid, Duration::from_secs(15));
+}
+
+#[test]
+#[serial]
+fn daemon_self_terminates_after_idle_timeout() {
+    let home = fresh_test_home_dir();
+    let output = uxc_command_with_home(home.path())
+        .env(DAEMON_IDLE_TIMEOUT_ENV, "2")
+        .arg("daemon")
+        .arg("start")
+        .output()
+        .expect("uxc daemon start should run");
+    assert!(
+        output.status.success(),
+        "daemon start should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let pid = read_owner_pid(home.path());
+    assert!(pid_alive(pid), "daemon should be running after start");
+
+    // No client connections are made after start; the daemon must shut
+    // itself down once the 2s idle window passes.
+    wait_for_pid_exit(pid, Duration::from_secs(15));
+}

--- a/tests/daemon_reuse_test.rs
+++ b/tests/daemon_reuse_test.rs
@@ -13,11 +13,9 @@ fn daemon_stop_best_effort() {
     let _ = uxc_command().arg("daemon").arg("stop").output();
 }
 
+/// Robust daemon teardown for this test home (see common::stop_test_daemon).
 fn daemon_stop_best_effort_with_home(home: &Path) {
-    let _ = uxc_command_with_home(home)
-        .arg("daemon")
-        .arg("stop")
-        .output();
+    common::stop_test_daemon(home);
 }
 
 fn mcp_http_endpoint(addr: &str) -> String {

--- a/tests/input_coercion_cli_test.rs
+++ b/tests/input_coercion_cli_test.rs
@@ -3,7 +3,11 @@ use mockito::{Matcher, Server};
 use std::fs;
 
 fn uxc() -> Command {
-    Command::new(assert_cmd::cargo::cargo_bin!("uxc"))
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("uxc"));
+    // Bound idle lifetime of any auto-started daemon so a killed test run
+    // cannot leak `uxc daemon _serve` processes (issue #459).
+    cmd.env("UXC_DAEMON_IDLE_TIMEOUT_SECS", "120");
+    cmd
 }
 
 fn openapi_schema() -> String {

--- a/tests/link_cli_test.rs
+++ b/tests/link_cli_test.rs
@@ -5,7 +5,11 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn uxc_command() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_uxc"))
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_uxc"));
+    // Bound idle lifetime of any auto-started daemon so a killed test run
+    // cannot leak `uxc daemon _serve` processes (issue #459).
+    cmd.env("UXC_DAEMON_IDLE_TIMEOUT_SECS", "120");
+    cmd
 }
 
 fn prepend_path(dir: &PathBuf) -> std::ffi::OsString {

--- a/tests/oauth_cli_test.rs
+++ b/tests/oauth_cli_test.rs
@@ -25,6 +25,9 @@ impl AuthFiles {
 
 fn uxc_command(files: &AuthFiles) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_uxc"));
+    // Bound idle lifetime of any auto-started daemon so a killed test run
+    // cannot leak `uxc daemon _serve` processes (issue #459).
+    cmd.env("UXC_DAEMON_IDLE_TIMEOUT_SECS", "120");
     cmd.env("UXC_CREDENTIALS_FILE", &files.credentials_file);
     cmd.env("UXC_AUTH_BINDINGS_FILE", &files.bindings_file);
     cmd.env("UXC_OAUTH_SESSION_DIR", &files.session_dir);

--- a/tests/offline_cache_test.rs
+++ b/tests/offline_cache_test.rs
@@ -5,7 +5,11 @@ use std::time::Duration;
 use serial_test::serial;
 
 fn uxc_command() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_uxc"))
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_uxc"));
+    // Bound idle lifetime of any auto-started daemon so a killed test run
+    // cannot leak `uxc daemon _serve` processes (issue #459).
+    cmd.env("UXC_DAEMON_IDLE_TIMEOUT_SECS", "120");
+    cmd
 }
 
 fn daemon_stop_best_effort() {

--- a/tests/source_cli_test.rs
+++ b/tests/source_cli_test.rs
@@ -8,11 +8,9 @@ use std::time::{Duration, Instant};
 
 use common::{start_test_server, uxc_command_with_home};
 
+/// Robust daemon teardown for this test home (see common::stop_test_daemon).
 fn daemon_stop_best_effort_with_home(home: &Path) {
-    let _ = uxc_command_with_home(home)
-        .arg("daemon")
-        .arg("stop")
-        .output();
+    common::stop_test_daemon(home);
 }
 
 fn daemon_runtime_dir(home: &Path) -> PathBuf {

--- a/tests/stdio_auth_injection_cli_test.rs
+++ b/tests/stdio_auth_injection_cli_test.rs
@@ -27,6 +27,9 @@ impl AuthFiles {
 
 fn uxc_command(files: &AuthFiles) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_uxc"));
+    // Bound idle lifetime of any auto-started daemon so a killed test run
+    // cannot leak `uxc daemon _serve` processes (issue #459).
+    cmd.env("UXC_DAEMON_IDLE_TIMEOUT_SECS", "120");
     cmd.env("UXC_CREDENTIALS_FILE", &files.credentials_file);
     cmd.env("UXC_AUTH_BINDINGS_FILE", &files.bindings_file);
     cmd.env("HOME", files.temp_dir.path());


### PR DESCRIPTION
## What

Fix `uxc daemon _serve` process leaks from integration tests (issue #459):

- **Daemon orphan watchdog** (`src/daemon.rs`): after binding the socket, the daemon records the socket inode and re-checks the path every 2s. If the socket path disappears (state dir / test temp HOME deleted) or the socket is replaced by a newer daemon owner, the daemon logs a warning and exits. Previously such daemons idled forever (~22MB RSS each; 31 leaked on this machine after one day of test runs).
- **Optional idle self-shutdown** via `UXC_DAEMON_IDLE_TIMEOUT_SECS` (same naming pattern as `UXC_DAEMON_MCP_IDLE_TTL_SECS`): when set and no client connections were seen for longer than the window, the daemon shuts down gracefully. This bounds leaks from test runs that are killed mid-run and never execute teardown (RAII/drop never runs, temp dirs persist).
- **Robust test teardown** (`tests/common/mod.rs`): `TestHome::drop` now retries `daemon stop` until `daemon status` is unreachable instead of one silent best-effort attempt. This closes the mid-startup race where a daemon holds neither socket nor owner lock yet, so a single stop no-ops and the daemon outlives its deleted HOME.
- **TTL injection**: all test command helpers (`common` plus the local helpers in offline_cache/link/oauth/stdio_auth_injection/input_coercion tests) set `UXC_DAEMON_IDLE_TIMEOUT_SECS=120`, far above the longest gap between commands within a single test.

## Why

Issue #459: leaked test daemons are unkillable after their temp HOME is deleted (socket + `daemon.lock` with the owner pid are gone), so fixing only the test harness could not cover killed runs. The daemon itself must notice it is orphaned.

## How

- Watchdog task in `run_daemon_server` uses `classify_daemon_socket_watch` (stat result + expected inode → Healthy / Orphaned / TransientError); orphaned → `std::process::exit(0)` since the lock/log files are already gone. Idle timeout → `request_stop()` for the normal graceful shutdown path.
- `DaemonActivity` tracks open connections + last accepted connection; only external client connections count as activity (managed-source polling does not keep a test daemon alive).
- New integration tests read the owner pid from `daemon.lock` and watch the process directly (Linux: `/proc/<pid>/stat` zombie-aware; other unix: `kill -0`).

## Testing

- New: `tests/daemon_orphan_exit_test.rs` — daemon exits after state-dir deletion; daemon self-terminates after a 2s idle TTL. Both pass.
- New unit tests: idle-timeout env parsing, watchdog socket classification, activity/guard accounting.
- Regression: `daemon_cli_test` (13), `daemon_reuse_test` (5), `daemon_logging_test` (23), `daemon_version_mismatch_test` (4), `source_cli_test` (5), `offline_cache_test` (18), `link_cli_test` (14), `oauth_cli_test` (3), `stdio_auth_injection_cli_test` (4), `input_coercion_cli_test` (3) — all green with `--test-threads=1`; zero `uxc daemon _serve` processes left afterwards.
- Killed-run acceptance (issue #459): simulated 3 test homes whose teardown never runs → all daemons self-terminated within the 120s TTL window.

Closes #459