### PR TITLE
feat(email): add unified body reading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "charset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
+dependencies = [
+ "base64 0.22.1",
+ "encoding_rs",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,7 +517,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -543,6 +553,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
 name = "cpufeatures"
@@ -746,6 +762,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5ef0006ac9ab233c38522f5ae99cae3625151de8f706cacee1cba4b8e2832a"
+dependencies = [
+ "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -850,6 +881,16 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
 
 [[package]]
 name = "futures"
@@ -1148,6 +1189,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "html2text"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "042a9677c258ac2952dd026bb0cd21972f00f644a5a38f5a215cb22cdaf6834e"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "thiserror 1.0.69",
+ "unicode-width",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,7 +1375,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1576,6 +1644,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mailparse"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da03d5980411a724e8aaf7b61a7b5e386ec55a7fb49ee3d0ff79efc7e5e7c7e"
+dependencies = [
+ "charset",
+ "data-encoding",
+ "quoted_printable",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1758,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiversion"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ca4bea16ffc3f443cf7d866912118196bfef4c6a1556ca00f9f9b00bb43f7c"
+dependencies = [
+ "multiversion-macros",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d416831a7317ef4b08bee00b69cbbb9c8763da7959a7026244d6266869f9c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,7 +1802,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1834,6 +1966,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +2074,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
@@ -1998,7 +2174,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2036,7 +2212,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2049,6 +2225,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 
 [[package]]
 name = "r-efi"
@@ -2571,6 +2753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,6 +2775,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2637,6 +2831,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,6 +2883,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2707,6 +2937,17 @@ dependencies = [
  "redox_syscall 0.4.1",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -3184,6 +3425,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,11 +3489,13 @@ dependencies = [
  "getrandom 0.2.17",
  "graphql_client",
  "hmac",
+ "html2text",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
  "json5",
  "jsonwebtoken",
+ "mailparse",
  "mockito",
  "openapiv3",
  "p256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 
 # Base64 encoding for basic auth
 base64 = "0.21"
+mailparse = "0.15"
+html2text = "0.12"
 ed25519-dalek = { version = "2.1", features = ["pkcs8", "pem"] }
 hmac = "0.12"
 jsonwebtoken = "9"

--- a/packages/uxc-daemon-client/src/index.ts
+++ b/packages/uxc-daemon-client/src/index.ts
@@ -167,6 +167,69 @@ export interface EmailReplyArgs extends EmailSendArgs {
   replyHandle?: EmailReplyHandle | null;
 }
 
+export type EmailBodyInput =
+  | {
+      kind: "inline_mime";
+      mimeBase64: string;
+      originalBytes: number;
+      complete: boolean;
+    }
+  | {
+      kind: "legacy_mime";
+      mimeText: string;
+      sourceTruncated?: boolean;
+    }
+  | {
+      kind: "message_ref";
+      messageRef: string;
+    };
+
+export interface EmailBodyReadArgs {
+  input: EmailBodyInput;
+}
+
+export type EmailBodyCompleteness = "complete" | "partial" | "unverified";
+
+export interface EmailBodyProvenance {
+  input_kind: EmailBodyInput["kind"];
+}
+
+export interface EmailBodyResult {
+  schema_version: number;
+  parser_version: string;
+  format: "text";
+  text: string;
+  bytes: number;
+  total_bytes?: number;
+  completeness: EmailBodyCompleteness;
+  reasons: string[];
+  provenance: EmailBodyProvenance;
+}
+
+export interface EmailBodyCapability {
+  schema_version: number;
+  parser_version: string;
+  input_kinds: EmailBodyInput["kind"][];
+  providers: string[];
+  inline_mime_max_bytes: number;
+  normalized_text_max_bytes: number;
+  provider_response_max_bytes: number;
+  deadline_seconds: number;
+}
+
+export type EmailBodyErrorKind =
+  | "invalid_input"
+  | "identity_missing"
+  | "stale"
+  | "not_found"
+  | "auth_required"
+  | "capability_unavailable"
+  | "timeout"
+  | "cancelled"
+  | "parse_failed"
+  | "resource_limit"
+  | "provider_unavailable";
+
 export interface ManagedSourceView {
   namespace: string;
   source_key: string;
@@ -248,6 +311,7 @@ export interface DaemonStatus {
   managed_sources_running: number;
   managed_streams: number;
   log_file?: string | null;
+  email_body?: EmailBodyCapability | null;
 }
 
 export interface DaemonSessionKillResponse {
@@ -408,6 +472,12 @@ export class UxcDaemonClient {
     return this.request("email.reply", {
       ...emailSendParams(send),
       ...(replyHandle ? { reply_handle: emailReplyHandleParams(replyHandle) } : {}),
+    });
+  }
+
+  async emailBodyRead(args: EmailBodyReadArgs): Promise<EmailBodyResult> {
+    return this.request("email.body.read", {
+      input: emailBodyInputParams(args.input),
     });
   }
 
@@ -1043,6 +1113,31 @@ function emailReplyHandleParams(replyHandle: EmailReplyHandle): Record<string, u
   if (replyHandle.mailbox != null) params.mailbox = replyHandle.mailbox;
   if (replyHandle.uid != null) params.uid = replyHandle.uid;
   return params;
+}
+
+function emailBodyInputParams(input: EmailBodyInput): Record<string, unknown> {
+  switch (input.kind) {
+    case "inline_mime":
+      return {
+        kind: input.kind,
+        mime_base64: input.mimeBase64,
+        original_bytes: input.originalBytes,
+        complete: input.complete,
+      };
+    case "legacy_mime":
+      return {
+        kind: input.kind,
+        mime_text: input.mimeText,
+        ...(input.sourceTruncated === undefined
+          ? {}
+          : { source_truncated: input.sourceTruncated }),
+      };
+    case "message_ref":
+      return {
+        kind: input.kind,
+        message_ref: input.messageRef,
+      };
+  }
 }
 
 function bestEffortUserLabel(env: NodeJS.ProcessEnv | undefined): string {

--- a/packages/uxc-daemon-client/test/client.test.ts
+++ b/packages/uxc-daemon-client/test/client.test.ts
@@ -233,6 +233,95 @@ describe("UxcDaemonClient", () => {
     ]);
   });
 
+  test.each([
+    {
+      name: "inline MIME",
+      input: {
+        kind: "inline_mime" as const,
+        mimeBase64: "SGVsbG8=",
+        originalBytes: 5,
+        complete: true,
+      },
+      wire: {
+        kind: "inline_mime",
+        mime_base64: "SGVsbG8=",
+        original_bytes: 5,
+        complete: true,
+      },
+    },
+    {
+      name: "legacy MIME",
+      input: {
+        kind: "legacy_mime" as const,
+        mimeText: "Content-Type: text/plain\r\n\r\nHello",
+        sourceTruncated: true,
+      },
+      wire: {
+        kind: "legacy_mime",
+        mime_text: "Content-Type: text/plain\r\n\r\nHello",
+        source_truncated: true,
+      },
+    },
+    {
+      name: "message reference",
+      input: {
+        kind: "message_ref" as const,
+        messageRef: "uxc-email-v1.example",
+      },
+      wire: {
+        kind: "message_ref",
+        message_ref: "uxc-email-v1.example",
+      },
+    },
+  ])("emailBodyRead serializes the $name input branch", async ({ input, wire }) => {
+    const stub = new UxcDaemonClient({ autoStart: false });
+    const calls: Array<{ method: string; params: unknown }> = [];
+    (stub as unknown as { request: (method: string, params?: unknown) => Promise<unknown> }).request = async (
+      method,
+      params,
+    ) => {
+      calls.push({ method, params });
+      return {
+        schema_version: 1,
+        parser_version: "1",
+        format: "text",
+        text: "Hello",
+        bytes: 5,
+        total_bytes: 5,
+        completeness: "complete",
+        reasons: [],
+        provenance: { input_kind: input.kind },
+      };
+    };
+
+    const response = await stub.emailBodyRead({ input });
+    expect(response.completeness).toBe("complete");
+    expect(calls).toEqual([
+      {
+        method: "email.body.read",
+        params: { input: wire },
+      },
+    ]);
+  });
+
+  test("emailBodyRead preserves structured daemon errors", async () => {
+    const stub = new UxcDaemonClient({ autoStart: false });
+    (stub as unknown as { request: () => Promise<unknown> }).request = async () => {
+      throw new DaemonRpcError("capability_unavailable", -32004, "email.body.read");
+    };
+
+    await expect(
+      stub.emailBodyRead({
+        input: { kind: "message_ref", messageRef: "uxc-email-v1.example" },
+      }),
+    ).rejects.toMatchObject({
+      name: "DaemonRpcError",
+      message: "capability_unavailable",
+      code: -32004,
+      method: "email.body.read",
+    });
+  });
+
   test("call executes OpenAPI operations without CLI envelope parsing", async () => {
     const server = createOpenApiServer();
     await server.start();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -73,10 +73,14 @@ use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::{mpsc, watch, Mutex, RwLock};
+use tokio::sync::{mpsc, watch, Mutex, OwnedSemaphorePermit, RwLock, Semaphore};
 use tokio::task::JoinHandle;
 
 const JSONRPC_VERSION: &str = "2.0";
+const EMAIL_BODY_DEADLINE: Duration = Duration::from_secs(30);
+const EMAIL_BODY_GLOBAL_LIMIT: usize = 4;
+const EMAIL_BODY_QUEUE_LIMIT: usize = 32;
+const EMAIL_BODY_SOURCE_LIMIT: usize = 2;
 const START_POLL_TRIES: usize = 30;
 const START_POLL_INTERVAL_MS: u64 = 100;
 const STOP_POLL_TRIES: usize = 50;
@@ -706,6 +710,8 @@ pub struct DaemonStatus {
     #[serde(default)]
     pub managed_streams: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub email_body: Option<crate::email_body::EmailBodyCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub log_file: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owner_lock_held: Option<bool>,
@@ -1065,6 +1071,61 @@ struct ManagedSourceEntry {
     runtime_view: Mutex<Option<Arc<Mutex<SubscriptionJobView>>>>,
     stop_tx: Mutex<watch::Sender<bool>>,
     task: Mutex<Option<JoinHandle<()>>>,
+}
+
+#[derive(Clone)]
+struct EmailBodyLimiter {
+    global: Arc<Semaphore>,
+    queue: Arc<Semaphore>,
+    sources: Arc<Mutex<HashMap<String, Arc<Semaphore>>>>,
+}
+
+impl EmailBodyLimiter {
+    fn new() -> Self {
+        Self {
+            global: Arc::new(Semaphore::new(EMAIL_BODY_GLOBAL_LIMIT)),
+            queue: Arc::new(Semaphore::new(EMAIL_BODY_QUEUE_LIMIT)),
+            sources: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    async fn acquire_global(&self) -> Result<OwnedSemaphorePermit> {
+        if let Ok(permit) = self.global.clone().try_acquire_owned() {
+            return Ok(permit);
+        }
+        let queued = self
+            .queue
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| anyhow!("resource_limit: email body retrieval queue is full"))?;
+        let permit = self
+            .global
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| anyhow!("provider_unavailable: email body limiter closed"))?;
+        drop(queued);
+        Ok(permit)
+    }
+
+    async fn acquire_source(
+        &self,
+        namespace: &str,
+        source_key: &str,
+    ) -> Result<OwnedSemaphorePermit> {
+        let key = format!("{namespace}\0{source_key}");
+        let semaphore = {
+            let mut sources = self.sources.lock().await;
+            sources
+                .entry(key)
+                .or_insert_with(|| Arc::new(Semaphore::new(EMAIL_BODY_SOURCE_LIMIT)))
+                .clone()
+        };
+        semaphore
+            .acquire_owned()
+            .await
+            .map_err(|_| anyhow!("provider_unavailable: email body source limiter closed"))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3972,6 +4033,14 @@ fn new_managed_source_run_id() -> String {
 }
 
 fn compute_managed_source_spec_key(spec: &ManagedSourceSpec) -> Result<String> {
+    let email_auth_identity = email_auth_identity_material(spec);
+    compute_managed_source_spec_key_with_identity(spec, email_auth_identity)
+}
+
+fn compute_managed_source_spec_key_with_identity(
+    spec: &ManagedSourceSpec,
+    email_auth_identity: Value,
+) -> Result<String> {
     let payload = json!({
         "endpoint": spec.endpoint,
         "operation_id": spec.operation_id,
@@ -3992,22 +4061,110 @@ fn compute_managed_source_spec_key(spec: &ManagedSourceSpec) -> Result<String> {
             .collect::<Vec<_>>(),
         "timeout_ms": spec.options.timeout_ms,
         "schema_url": spec.options.schema_url,
+        "email_auth_identity": email_auth_identity,
     });
     let bytes = serde_json::to_vec(&payload)?;
     let digest = Sha256::digest(bytes);
     Ok(format!("{:x}", digest))
 }
 
+fn email_auth_identity_material(spec: &ManagedSourceSpec) -> Value {
+    let profile = spec.options.auth.as_deref().and_then(|name| {
+        auth::Profiles::load_profiles()
+            .ok()
+            .and_then(|profiles| profiles.get_profile(name).ok().cloned())
+    });
+    email_auth_identity_material_with_profile(spec, profile.as_ref())
+}
+
+fn email_auth_identity_material_with_profile(
+    spec: &ManagedSourceSpec,
+    profile: Option<&Profile>,
+) -> Value {
+    let provider = match spec.transport_hint {
+        Some(SubscriptionTransportHint::EmailImapIdle) => "imap",
+        Some(SubscriptionTransportHint::EmailProviderPoll) => spec
+            .args
+            .as_ref()
+            .and_then(|args| args.get("provider"))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown"),
+        _ => return Value::Null,
+    };
+    let explicit_account = spec
+        .args
+        .as_ref()
+        .and_then(|args| args.get("account"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let resolved_account = explicit_account.or_else(|| {
+        profile.and_then(|profile| {
+            ["account", "username", "user", "email"]
+                .iter()
+                .find_map(|name| {
+                    profile
+                        .resolve_field_value(name)
+                        .ok()
+                        .flatten()
+                        .filter(|value| !value.is_empty())
+                })
+        })
+    });
+    let oauth = profile.and_then(|profile| profile.oauth.as_ref());
+    json!({
+        "provider": provider,
+        "account": resolved_account,
+        "auth_type": profile.map(|profile| profile.auth_type.to_string()),
+        "oauth_provider_issuer": oauth.and_then(|oauth| oauth.provider_issuer.as_deref()),
+        "oauth_authorization_server": oauth.and_then(|oauth| oauth.authorization_server.as_deref()),
+        "oauth_client_id": oauth.and_then(|oauth| oauth.client_id.as_deref()),
+    })
+}
+
+fn resolve_email_body_source(
+    record: Option<ManagedSourceRecord>,
+    message_ref: &crate::email_body::EmailMessageRef,
+) -> Result<ManagedSourceSpec> {
+    let record =
+        record.ok_or_else(|| anyhow!("identity_missing: email message source no longer exists"))?;
+    if record.spec_key != message_ref.source.spec_key {
+        bail!("stale: email message source configuration changed");
+    }
+    let spec: ManagedSourceSpec = serde_json::from_value(record.spec_json)
+        .map_err(|_| anyhow!("stale: email message source configuration is invalid"))?;
+    if compute_managed_source_spec_key(&spec)? != message_ref.source.spec_key {
+        bail!("stale: email message account identity changed");
+    }
+    Ok(spec)
+}
+
 fn managed_source_subscription_request(
     record: &ManagedSourceRecord,
     spec: &ManagedSourceSpec,
 ) -> SubscribeStartRequest {
+    let mut args = spec.args.clone();
+    if matches!(
+        spec.transport_hint,
+        Some(
+            SubscriptionTransportHint::EmailImapIdle | SubscriptionTransportHint::EmailProviderPoll
+        )
+    ) {
+        args.get_or_insert_with(HashMap::new).insert(
+            "_uxc_email_source_ref".to_string(),
+            json!({
+                "namespace": record.namespace,
+                "source_key": record.source_key,
+                "spec_key": record.spec_key,
+            }),
+        );
+    }
     SubscribeStartRequest {
         request_id: format!("managed-source:{}:{}", record.namespace, record.source_key),
         endpoint: spec.endpoint.clone(),
         sink: "memory:".to_string(),
         operation_id: spec.operation_id.clone(),
-        args: spec.args.clone(),
+        args,
         resource_uri: spec.resource_uri.clone(),
         read_resource: spec.read_resource,
         transport_hint: spec.transport_hint.clone(),
@@ -4263,6 +4420,7 @@ pub struct DaemonRuntime {
     managed_source_base_dir: PathBuf,
     should_stop: Arc<RwLock<bool>>,
     schema_mapping_lock: Arc<Mutex<()>>,
+    email_body_limiter: EmailBodyLimiter,
     logger: Option<DaemonLogger>,
 }
 
@@ -4289,8 +4447,39 @@ impl DaemonRuntime {
             managed_source_base_dir,
             should_stop: Arc::new(RwLock::new(false)),
             schema_mapping_lock: Arc::new(Mutex::new(())),
+            email_body_limiter: EmailBodyLimiter::new(),
             logger,
         })
+    }
+
+    async fn read_email_body(
+        &self,
+        request: crate::email_body::EmailBodyReadRequest,
+    ) -> Result<crate::email_body::EmailBodyResult> {
+        tokio::time::timeout(EMAIL_BODY_DEADLINE, async {
+            let _global = self.email_body_limiter.acquire_global().await?;
+            match request.input {
+                crate::email_body::EmailBodyInput::MessageRef { message_ref } => {
+                    let decoded = crate::email_body::decode_email_message_ref(&message_ref)?;
+                    let _source = self
+                        .email_body_limiter
+                        .acquire_source(&decoded.source.namespace, &decoded.source.source_key)
+                        .await?;
+                    let record = self
+                        .managed_sources
+                        .store
+                        .get_source(&decoded.source.namespace, &decoded.source.source_key)
+                        .await?;
+                    let spec = resolve_email_body_source(record, &decoded)?;
+                    crate::email_body_get::get_email_body(&spec, &decoded).await
+                }
+                input => {
+                    crate::email_body::read_local(crate::email_body::EmailBodyReadRequest { input })
+                }
+            }
+        })
+        .await
+        .map_err(|_| anyhow!("timeout: email body retrieval exceeded 30 seconds"))?
     }
 
     fn initialize_logger() -> Option<DaemonLogger> {
@@ -4729,6 +4918,7 @@ impl DaemonRuntime {
             managed_sources,
             managed_sources_running,
             managed_streams,
+            email_body: Some(crate::email_body::EmailBodyCapability::default()),
             log_file,
             owner_lock_held: Some(true),
             owner_pid: Some(std::process::id()),
@@ -7005,6 +7195,23 @@ pub async fn daemon_status_client() -> Result<DaemonStatus> {
 }
 
 #[cfg(unix)]
+#[allow(dead_code)]
+pub async fn email_body_read_client(
+    request: &crate::email_body::EmailBodyReadRequest,
+) -> Result<crate::email_body::EmailBodyResult> {
+    let value = client_call("email.body.read", Some(serde_json::to_value(request)?)).await?;
+    Ok(serde_json::from_value(value)?)
+}
+
+#[cfg(not(unix))]
+#[allow(dead_code)]
+pub async fn email_body_read_client(
+    _request: &crate::email_body::EmailBodyReadRequest,
+) -> Result<crate::email_body::EmailBodyResult> {
+    bail!("Daemon email body reading is only supported on Unix")
+}
+
+#[cfg(unix)]
 pub async fn daemon_sessions_client() -> Result<Vec<DaemonSessionView>> {
     let value = client_call("daemon.sessions", None).await?;
     Ok(serde_json::from_value(value)?)
@@ -7709,6 +7916,41 @@ async fn handle_connection(mut stream: UnixStream, runtime: Arc<DaemonRuntime>) 
                     id: req.id,
                     result: None,
                     error: Some(jsonrpc_error_from_anyhow(&err)),
+                },
+            }
+        }
+        "email.body.read" => {
+            let Some(params) = req.params else {
+                write_jsonrpc_error(&mut stream, req.id, -32602, "Missing params".to_string())
+                    .await?;
+                return Ok(());
+            };
+            let request: crate::email_body::EmailBodyReadRequest =
+                match serde_json::from_value(params) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        write_jsonrpc_error(
+                            &mut stream,
+                            req.id,
+                            -32602,
+                            format!("Invalid params: {err}"),
+                        )
+                        .await?;
+                        return Ok(());
+                    }
+                };
+            match runtime.read_email_body(request).await {
+                Ok(result) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: Some(serde_json::to_value(result)?),
+                    error: None,
+                },
+                Err(err) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: None,
+                    error: Some(email_body_read_jsonrpc_error(&err)),
                 },
             }
         }
@@ -9747,6 +9989,44 @@ fn jsonrpc_error_from_anyhow(err: &anyhow::Error) -> JsonRpcError {
     }
 }
 
+fn email_body_read_jsonrpc_error(err: &anyhow::Error) -> JsonRpcError {
+    const NON_RETRYABLE: &[&str] = &[
+        "invalid_input",
+        "identity_missing",
+        "stale",
+        "not_found",
+        "auth_required",
+        "capability_unavailable",
+        "parse_failed",
+        "resource_limit",
+    ];
+    const RETRYABLE: &[&str] = &["timeout", "cancelled", "provider_unavailable"];
+
+    let error_text = err.to_string();
+    let prefix = error_text
+        .split_once(':')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or_default();
+    let (code, retryable) = if NON_RETRYABLE.contains(&prefix) {
+        (prefix, false)
+    } else if RETRYABLE.contains(&prefix) {
+        (prefix, true)
+    } else {
+        ("provider_unavailable", true)
+    };
+    let payload = StructuredErrorPayload {
+        code: code.to_string(),
+        message: "Email body read failed".to_string(),
+        details: Some(json!({ "retryable": retryable })),
+    };
+
+    JsonRpcError {
+        code: ERR_RUNTIME_GENERIC,
+        message: payload.message.clone(),
+        data: serde_json::to_value(payload).ok(),
+    }
+}
+
 impl Default for DaemonRuntime {
     fn default() -> Self {
         Self::new()
@@ -9770,6 +10050,213 @@ mod tests {
     use tokio_tungstenite::accept_hdr_async;
     use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
     use tokio_tungstenite::tungstenite::Message;
+
+    fn email_message_ref(spec_key: &str) -> crate::email_body::EmailMessageRef {
+        crate::email_body::EmailMessageRef {
+            source: crate::email_body::EmailSourceRef {
+                namespace: "mail".into(),
+                source_key: "primary".into(),
+                spec_key: spec_key.into(),
+            },
+            locator: crate::email_body::EmailMessageLocator::Gmail {
+                message_id: "message-1".into(),
+            },
+        }
+    }
+
+    fn email_source_record(spec_key: &str, spec: Value) -> ManagedSourceRecord {
+        ManagedSourceRecord {
+            namespace: "mail".into(),
+            source_key: "primary".into(),
+            spec_json: spec,
+            spec_key: spec_key.into(),
+            run_id: "run".into(),
+            stream_id: "stream".into(),
+            status: "running".into(),
+            created_at_unix: 1,
+            updated_at_unix: 1,
+            started_at_unix: Some(1),
+            stopped_at_unix: None,
+            last_error: None,
+            last_success_at_unix: None,
+            last_event_at_unix: None,
+            reconnect_count: 0,
+            written_events: 0,
+        }
+    }
+
+    #[test]
+    fn email_body_source_lookup_requires_matching_spec_key() {
+        let spec = managed_source_spec("https://example.invalid");
+        let spec_key = compute_managed_source_spec_key(&spec).unwrap();
+        let resolved = resolve_email_body_source(
+            Some(email_source_record(
+                &spec_key,
+                serde_json::to_value(&spec).unwrap(),
+            )),
+            &email_message_ref(&spec_key),
+        )
+        .unwrap();
+        assert_eq!(resolved.endpoint, spec.endpoint);
+
+        let error = resolve_email_body_source(
+            Some(email_source_record(
+                "spec-2",
+                serde_json::to_value(&spec).unwrap(),
+            )),
+            &email_message_ref(&spec_key),
+        )
+        .unwrap_err();
+        assert!(error.to_string().starts_with("stale:"));
+
+        let error = resolve_email_body_source(None, &email_message_ref(&spec_key)).unwrap_err();
+        assert!(error.to_string().starts_with("identity_missing:"));
+    }
+
+    #[test]
+    fn email_spec_identity_changes_with_account_but_not_oauth_tokens() {
+        let mut spec =
+            managed_source_spec("https://gmail.googleapis.com/gmail/v1/users/me/messages");
+        spec.transport_hint = Some(SubscriptionTransportHint::EmailProviderPoll);
+        spec.mode = SubscriptionMode::Poll;
+        spec.args = Some(HashMap::from([(
+            "provider".to_string(),
+            Value::String("gmail".to_string()),
+        )]));
+        spec.options.auth = Some("mail".to_string());
+
+        let mut first = Profile::new("token-one".to_string(), auth::AuthType::OAuth);
+        first
+            .set_field_source(
+                "account".to_string(),
+                auth::SecretSource::Literal {
+                    value: "first@example.com".to_string(),
+                },
+            )
+            .unwrap();
+        first.oauth = Some(auth::OAuthProfile {
+            provider_issuer: Some("https://accounts.example".to_string()),
+            client_id: Some("client".to_string()),
+            access_token: Some("token-one".to_string()),
+            refresh_token: Some("refresh-one".to_string()),
+            ..Default::default()
+        });
+        let mut refreshed = first.clone();
+        refreshed.api_key = "token-two".to_string();
+        let oauth = refreshed.oauth.as_mut().unwrap();
+        oauth.access_token = Some("token-two".to_string());
+        oauth.refresh_token = Some("refresh-two".to_string());
+        let mut replacement = refreshed.clone();
+        replacement
+            .set_field_source(
+                "account".to_string(),
+                auth::SecretSource::Literal {
+                    value: "second@example.com".to_string(),
+                },
+            )
+            .unwrap();
+
+        let first_key = compute_managed_source_spec_key_with_identity(
+            &spec,
+            email_auth_identity_material_with_profile(&spec, Some(&first)),
+        )
+        .unwrap();
+        let refreshed_key = compute_managed_source_spec_key_with_identity(
+            &spec,
+            email_auth_identity_material_with_profile(&spec, Some(&refreshed)),
+        )
+        .unwrap();
+        let replacement_key = compute_managed_source_spec_key_with_identity(
+            &spec,
+            email_auth_identity_material_with_profile(&spec, Some(&replacement)),
+        )
+        .unwrap();
+
+        assert_eq!(first_key, refreshed_key);
+        assert_ne!(first_key, replacement_key);
+    }
+
+    #[test]
+    fn email_body_read_errors_have_stable_redacted_payloads() {
+        for (code, retryable) in [
+            ("invalid_input", false),
+            ("identity_missing", false),
+            ("stale", false),
+            ("not_found", false),
+            ("auth_required", false),
+            ("capability_unavailable", false),
+            ("parse_failed", false),
+            ("resource_limit", false),
+            ("timeout", true),
+            ("cancelled", true),
+            ("provider_unavailable", true),
+        ] {
+            let secret = "secret endpoint https://user:password@example.invalid";
+            let error = email_body_read_jsonrpc_error(&anyhow!("{code}: {secret}"));
+            let payload: StructuredErrorPayload =
+                serde_json::from_value(error.data.unwrap()).unwrap();
+            assert_eq!(payload.code, code);
+            assert_eq!(payload.message, "Email body read failed");
+            assert_eq!(payload.details, Some(json!({ "retryable": retryable })));
+            assert!(!error.message.contains(secret));
+            assert!(!payload.message.contains(secret));
+        }
+    }
+
+    #[test]
+    fn email_body_read_unknown_errors_use_redacted_retryable_fallback() {
+        let error = email_body_read_jsonrpc_error(&anyhow!(
+            "unexpected failure at https://user:password@example.invalid"
+        ));
+        let payload: StructuredErrorPayload = serde_json::from_value(error.data.unwrap()).unwrap();
+        assert_eq!(payload.code, "provider_unavailable");
+        assert_eq!(payload.details, Some(json!({ "retryable": true })));
+        assert_eq!(error.message, "Email body read failed");
+    }
+
+    #[tokio::test]
+    async fn email_body_local_read_uses_shared_runtime_path() {
+        let temp = tempdir().unwrap();
+        let runtime =
+            DaemonRuntime::try_new_with_managed_source_base_dir(temp.path().to_path_buf()).unwrap();
+        let result = runtime
+            .read_email_body(crate::email_body::EmailBodyReadRequest {
+                input: crate::email_body::EmailBodyInput::LegacyMime {
+                    mime_text: "Subject: test\r\n\r\nhello".into(),
+                    source_truncated: false,
+                },
+            })
+            .await
+            .unwrap();
+        assert_eq!(result.text, "hello");
+    }
+
+    #[tokio::test]
+    async fn email_body_limiter_enforces_global_and_per_source_limits() {
+        let limiter = EmailBodyLimiter::new();
+        let global = futures::future::join_all((0..EMAIL_BODY_GLOBAL_LIMIT).map(|_| {
+            let limiter = limiter.clone();
+            async move { limiter.acquire_global().await.unwrap() }
+        }))
+        .await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), limiter.acquire_global())
+                .await
+                .is_err()
+        );
+        drop(global);
+
+        let first = limiter.acquire_source("mail", "primary").await.unwrap();
+        let second = limiter.acquire_source("mail", "primary").await.unwrap();
+        assert!(tokio::time::timeout(
+            Duration::from_millis(20),
+            limiter.acquire_source("mail", "primary")
+        )
+        .await
+        .is_err());
+        assert!(limiter.acquire_source("mail", "secondary").await.is_ok());
+        drop((first, second));
+    }
 
     #[test]
     fn daemon_email_reply_request_parses_flattened_params_and_reply_handle() {
@@ -12004,6 +12491,7 @@ pub fn daemon_status_from_diagnostics(diagnostics: &DaemonLocalDiagnostics) -> D
         managed_sources: 0,
         managed_sources_running: 0,
         managed_streams: 0,
+        email_body: None,
         log_file: None,
         owner_lock_held: Some(diagnostics.owner_lock_held),
         owner_pid: diagnostics.owner_pid,

--- a/src/daemon_client.rs
+++ b/src/daemon_client.rs
@@ -72,6 +72,13 @@ impl DaemonClient {
         daemon::daemon_status_client().await
     }
 
+    pub async fn email_body_read(
+        &self,
+        request: &crate::email_body::EmailBodyReadRequest,
+    ) -> Result<crate::email_body::EmailBodyResult> {
+        daemon::email_body_read_client(request).await
+    }
+
     pub async fn daemon_sessions(&self) -> Result<Vec<DaemonSessionView>> {
         daemon::daemon_sessions_client().await
     }

--- a/src/email_attachment_get.rs
+++ b/src/email_attachment_get.rs
@@ -420,11 +420,18 @@ where
         account: handle.account.clone(),
         auth_profile: Some(profile_name),
         initial_fetch_limit: 0,
+        source_ref: None,
     };
     let mut conn = connector(config)
         .await
         .map_err(|err| provider_request_failed(format!("IMAP connect failed: {err}")))?;
-    let attachment = run_imap_retrieval(&mut conn, handle, &auth_method, &mailbox).await;
+    let fetch_limit = if request.max_bytes == 0 {
+        usize::MAX
+    } else {
+        request.max_bytes.min(usize::MAX as u64) as usize
+    };
+    let attachment =
+        run_imap_retrieval(&mut conn, handle, &auth_method, &mailbox, fetch_limit).await;
     let _ = conn.logout().await;
     attachment
 }
@@ -459,6 +466,7 @@ async fn run_imap_retrieval(
     handle: &EmailAttachmentHandle,
     auth_method: &crate::subscription_email::ImapAuthMethod,
     mailbox: &str,
+    fetch_limit: usize,
 ) -> Result<FetchedAttachment> {
     conn.expect_greeting()
         .await
@@ -512,7 +520,7 @@ async fn run_imap_retrieval(
         ));
     };
     let mime = conn
-        .fetch_body_section_bytes(uid, &format!("{section}.MIME"))
+        .fetch_body_section_bytes(uid, &format!("{section}.MIME"), fetch_limit)
         .await
         .map_err(|err| provider_request_failed(format!("IMAP fetch failed: {err}")))?;
     let ImapSectionLiteral::Bytes(mime_bytes) = mime else {
@@ -523,7 +531,7 @@ async fn run_imap_retrieval(
         ));
     };
     let body = conn
-        .fetch_body_section_bytes(uid, section)
+        .fetch_body_section_bytes(uid, section, fetch_limit)
         .await
         .map_err(|err| provider_request_failed(format!("IMAP fetch failed: {err}")))?;
     let ImapSectionLiteral::Bytes(body_bytes) = body else {
@@ -1033,6 +1041,7 @@ mod tests {
         uidvalidity: u64,
         fetch_responses: Vec<String>,
     ) -> Vec<(String, String)> {
+        let fetch_count = fetch_responses.len();
         let mut script = vec![
             (
                 "A0001 LOGIN".to_string(),
@@ -1051,7 +1060,7 @@ mod tests {
                 format!("{}\r\nA000{:} OK fetch done", response, index + 3),
             ));
         }
-        script.push(("A0005 LOGOUT".to_string(), String::new()));
+        script.push((format!("A000{} LOGOUT", fetch_count + 3), String::new()));
         script
     }
 

--- a/src/email_body.rs
+++ b/src/email_body.rs
@@ -1,0 +1,522 @@
+use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine;
+use mailparse::{parse_mail, ParsedMail};
+use serde::{Deserialize, Serialize};
+
+pub const EMAIL_BODY_SCHEMA_VERSION: u32 = 1;
+pub const EMAIL_BODY_PARSER_VERSION: &str = "1";
+pub const INLINE_MIME_LIMIT: usize = 4 * 1024 * 1024;
+pub const PROVIDER_MIME_LIMIT: usize = 16 * 1024 * 1024;
+pub const NORMALIZED_TEXT_LIMIT: usize = 1024 * 1024;
+pub const EMAIL_MESSAGE_REF_MAX_BYTES: usize = 8 * 1024;
+const EMAIL_MESSAGE_REF_PREFIX: &str = "uxc-email-v1.";
+const MIME_PART_LIMIT: usize = 256;
+const MIME_DEPTH_LIMIT: usize = 10;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct EmailSourceRef {
+    pub namespace: String,
+    pub source_key: String,
+    pub spec_key: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "provider", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum EmailMessageLocator {
+    Imap {
+        mailbox: String,
+        uid: String,
+        uidvalidity: Option<u64>,
+    },
+    Gmail {
+        message_id: String,
+    },
+    Graph {
+        immutable_id: String,
+    },
+    Jmap {
+        account_id: String,
+        email_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct EmailMessageRef {
+    pub source: EmailSourceRef,
+    pub locator: EmailMessageLocator,
+}
+
+pub(crate) fn encode_email_message_ref(value: &EmailMessageRef) -> Result<String> {
+    validate_email_message_ref(value)?;
+    let payload = serde_json::to_vec(value)?;
+    let encoded = format!(
+        "{EMAIL_MESSAGE_REF_PREFIX}{}",
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload)
+    );
+    if encoded.len() > EMAIL_MESSAGE_REF_MAX_BYTES {
+        bail!("invalid_input: email message_ref exceeds 8 KiB");
+    }
+    Ok(encoded)
+}
+
+pub(crate) fn decode_email_message_ref(value: &str) -> Result<EmailMessageRef> {
+    if value.len() > EMAIL_MESSAGE_REF_MAX_BYTES {
+        bail!("invalid_input: email message_ref exceeds 8 KiB");
+    }
+    let payload = value
+        .strip_prefix(EMAIL_MESSAGE_REF_PREFIX)
+        .ok_or_else(|| anyhow!("invalid_input: unsupported email message_ref version"))?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .context("invalid_input: malformed email message_ref")?;
+    let decoded: EmailMessageRef = serde_json::from_slice(&bytes)
+        .context("invalid_input: malformed email message_ref payload")?;
+    validate_email_message_ref(&decoded)?;
+    Ok(decoded)
+}
+
+fn validate_email_message_ref(value: &EmailMessageRef) -> Result<()> {
+    if value.source.namespace.is_empty()
+        || value.source.source_key.is_empty()
+        || value.source.spec_key.is_empty()
+    {
+        bail!("invalid_input: email message_ref source fields must not be empty");
+    }
+    match &value.locator {
+        EmailMessageLocator::Imap { mailbox, uid, .. } => {
+            if mailbox.is_empty() || uid.is_empty() || !uid.chars().all(|ch| ch.is_ascii_digit()) {
+                bail!("invalid_input: invalid IMAP message_ref");
+            }
+        }
+        EmailMessageLocator::Gmail { message_id } if message_id.is_empty() => {
+            bail!("invalid_input: invalid Gmail message_ref")
+        }
+        EmailMessageLocator::Graph { immutable_id } if immutable_id.is_empty() => {
+            bail!("invalid_input: invalid Graph message_ref")
+        }
+        EmailMessageLocator::Jmap {
+            account_id,
+            email_id,
+        } if account_id.is_empty() || email_id.is_empty() => {
+            bail!("invalid_input: invalid JMAP message_ref")
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EmailBodyInput {
+    InlineMime {
+        mime_base64: String,
+        original_bytes: usize,
+        complete: bool,
+    },
+    LegacyMime {
+        mime_text: String,
+        #[serde(default)]
+        source_truncated: bool,
+    },
+    MessageRef {
+        message_ref: String,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EmailBodyReadRequest {
+    pub input: EmailBodyInput,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EmailBodyCompleteness {
+    Complete,
+    Partial,
+    Unverified,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EmailBodyProvenance {
+    pub input_kind: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EmailBodyResult {
+    pub schema_version: u32,
+    pub parser_version: String,
+    pub format: String,
+    pub text: String,
+    pub bytes: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_bytes: Option<usize>,
+    pub completeness: EmailBodyCompleteness,
+    pub reasons: Vec<String>,
+    pub provenance: EmailBodyProvenance,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EmailBodyCapability {
+    pub schema_version: u32,
+    pub parser_version: String,
+    pub input_kinds: Vec<String>,
+    pub providers: Vec<String>,
+    pub inline_mime_max_bytes: usize,
+    pub normalized_text_max_bytes: usize,
+    pub provider_response_max_bytes: usize,
+    pub deadline_seconds: u64,
+}
+
+impl Default for EmailBodyCapability {
+    fn default() -> Self {
+        Self {
+            schema_version: EMAIL_BODY_SCHEMA_VERSION,
+            parser_version: EMAIL_BODY_PARSER_VERSION.to_string(),
+            input_kinds: vec![
+                "inline_mime".into(),
+                "legacy_mime".into(),
+                "message_ref".into(),
+            ],
+            providers: vec!["imap".into(), "gmail".into(), "graph".into(), "jmap".into()],
+            inline_mime_max_bytes: INLINE_MIME_LIMIT,
+            normalized_text_max_bytes: NORMALIZED_TEXT_LIMIT,
+            provider_response_max_bytes: PROVIDER_MIME_LIMIT,
+            deadline_seconds: 30,
+        }
+    }
+}
+
+pub fn read_local(request: EmailBodyReadRequest) -> Result<EmailBodyResult> {
+    match request.input {
+        EmailBodyInput::InlineMime {
+            mime_base64,
+            original_bytes,
+            complete,
+        } => {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(mime_base64)
+                .context("invalid_input: mime_base64 is not strict base64")?;
+            if bytes.len() != original_bytes {
+                bail!("invalid_input: original_bytes does not match decoded MIME length");
+            }
+            if bytes.len() > INLINE_MIME_LIMIT {
+                bail!("resource_limit: inline MIME exceeds 4 MiB");
+            }
+            parse_mime(&bytes, complete, "inline_mime", false)
+        }
+        EmailBodyInput::LegacyMime {
+            mime_text,
+            source_truncated,
+        } => {
+            enforce_mime_limit(mime_text.len(), INLINE_MIME_LIMIT, "local")?;
+            parse_mime(mime_text.as_bytes(), !source_truncated, "legacy_mime", true)
+        }
+        EmailBodyInput::MessageRef { .. } => {
+            bail!("capability_unavailable: message_ref provider retrieval is unavailable")
+        }
+    }
+}
+
+pub fn parse_mime(
+    bytes: &[u8],
+    source_complete: bool,
+    input_kind: &str,
+    legacy: bool,
+) -> Result<EmailBodyResult> {
+    enforce_mime_limit(bytes.len(), PROVIDER_MIME_LIMIT, "provider")?;
+    let parsed = parse_mail(bytes).context("parse_failed: invalid MIME message")?;
+    let mut part_count = 0;
+    validate_mime_tree(&parsed, 0, &mut part_count)?;
+    let mut reasons = Vec::new();
+    let mut text = select_body(&parsed, &mut reasons)?;
+    if text.is_empty() {
+        reasons.push("empty_body".into());
+    }
+    if text.len() > NORMALIZED_TEXT_LIMIT {
+        text.truncate(floor_char_boundary(&text, NORMALIZED_TEXT_LIMIT));
+        reasons.push("resource_limit".into());
+    }
+    let completeness = if !source_complete || reasons.iter().any(|r| r == "resource_limit") {
+        if !source_complete {
+            reasons.push("source_truncated".into());
+        }
+        EmailBodyCompleteness::Partial
+    } else if legacy || !reasons.is_empty() {
+        if legacy {
+            reasons.push("legacy_text_input".into());
+        }
+        EmailBodyCompleteness::Unverified
+    } else {
+        EmailBodyCompleteness::Complete
+    };
+    reasons.sort();
+    reasons.dedup();
+    let output_bytes = text.len();
+    Ok(EmailBodyResult {
+        schema_version: EMAIL_BODY_SCHEMA_VERSION,
+        parser_version: EMAIL_BODY_PARSER_VERSION.into(),
+        format: "text".into(),
+        text,
+        bytes: output_bytes,
+        total_bytes: (completeness == EmailBodyCompleteness::Complete).then_some(output_bytes),
+        completeness,
+        reasons,
+        provenance: EmailBodyProvenance {
+            input_kind: input_kind.into(),
+        },
+    })
+}
+
+fn enforce_mime_limit(bytes: usize, limit: usize, scope: &str) -> Result<()> {
+    if bytes > limit {
+        bail!("resource_limit: MIME input exceeds {scope} limit");
+    }
+    Ok(())
+}
+
+fn validate_mime_tree(part: &ParsedMail<'_>, depth: usize, part_count: &mut usize) -> Result<()> {
+    if depth > MIME_DEPTH_LIMIT {
+        bail!("resource_limit: MIME nesting exceeds limit");
+    }
+    *part_count += 1;
+    if *part_count > MIME_PART_LIMIT {
+        bail!("resource_limit: MIME part count exceeds limit");
+    }
+    for child in &part.subparts {
+        validate_mime_tree(child, depth + 1, part_count)?;
+    }
+    Ok(())
+}
+
+fn select_body(part: &ParsedMail<'_>, reasons: &mut Vec<String>) -> Result<String> {
+    let disposition = part.get_content_disposition();
+    if disposition.disposition == mailparse::DispositionType::Attachment
+        || disposition.params.contains_key("filename")
+    {
+        return Ok(String::new());
+    }
+    if part.subparts.is_empty() {
+        let mime = part.ctype.mimetype.to_ascii_lowercase();
+        return match mime.as_str() {
+            "text/plain" => part
+                .get_body()
+                .context("parse_failed: cannot decode text/plain body"),
+            "text/html" => {
+                let html = part
+                    .get_body()
+                    .context("parse_failed: cannot decode text/html body")?;
+                Ok(html2text::from_read(html.as_bytes(), 120))
+            }
+            _ => Ok(String::new()),
+        };
+    }
+    let mime = part.ctype.mimetype.to_ascii_lowercase();
+    if mime == "multipart/alternative" {
+        for child in &part.subparts {
+            if child.ctype.mimetype.eq_ignore_ascii_case("text/plain") {
+                let body = select_body(child, reasons)?;
+                if !body.is_empty() {
+                    return Ok(body);
+                }
+            }
+        }
+        for child in &part.subparts {
+            if child.ctype.mimetype.eq_ignore_ascii_case("text/html") {
+                let body = select_body(child, reasons)?;
+                if !body.is_empty() {
+                    return Ok(body);
+                }
+            }
+        }
+        reasons.push("unsupported_multipart".into());
+        return Ok(String::new());
+    }
+    if mime == "multipart/related" {
+        return part
+            .subparts
+            .first()
+            .ok_or_else(|| anyhow!("parse_failed: empty multipart/related"))
+            .and_then(|child| select_body(child, reasons));
+    }
+    if !mime.starts_with("multipart/") {
+        reasons.push("unsupported_structure".into());
+    }
+    let mut bodies = Vec::new();
+    for child in &part.subparts {
+        let body = select_body(child, reasons)?;
+        if !body.is_empty() {
+            bodies.push(body);
+        }
+    }
+    Ok(bodies.join("\n"))
+}
+
+fn floor_char_boundary(value: &str, mut index: usize) -> usize {
+    while index > 0 && !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_and_html_without_attachments() {
+        let mime = b"Content-Type: multipart/mixed; boundary=x\r\n\r\n--x\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<p>Hello <b>world</b></p><script>bad()</script>\r\n--x\r\nContent-Type: text/plain\r\nContent-Disposition: attachment; filename=a.txt\r\n\r\nsecret\r\n--x--\r\n";
+        let result = parse_mime(mime, true, "inline_mime", false).unwrap();
+        assert!(result.text.contains("Hello"));
+        assert!(!result.text.contains("secret"));
+        assert!(!result.text.contains("bad()"));
+    }
+
+    #[test]
+    fn alternative_prefers_plain_and_ignores_attachment() {
+        let mime = b"Content-Type: multipart/alternative; boundary=x\r\n\r\n--x\r\nContent-Type: text/html\r\n\r\n<p>html fallback</p>\r\n--x\r\nContent-Type: text/plain\r\n\r\nplain preferred\r\n--x\r\nContent-Type: text/plain\r\nContent-Disposition: attachment; filename=secret.txt\r\n\r\nattachment\r\n--x--\r\n";
+        let result = parse_mime(mime, true, "inline_mime", false).unwrap();
+        assert_eq!(result.text.trim(), "plain preferred");
+        assert!(!result.text.contains("attachment"));
+        assert!(!result.text.contains("html fallback"));
+    }
+
+    #[test]
+    fn alternative_uses_html_fallback() {
+        let mime = b"Content-Type: multipart/alternative; boundary=x\r\n\r\n--x\r\nContent-Type: application/octet-stream\r\n\r\nignored\r\n--x\r\nContent-Type: text/html\r\n\r\n<p>html fallback</p>\r\n--x--\r\n";
+        let result = parse_mime(mime, true, "inline_mime", false).unwrap();
+        assert!(result.text.contains("html fallback"));
+        assert!(!result.text.contains("ignored"));
+    }
+
+    #[test]
+    fn provider_and_local_mime_budgets_are_distinct() {
+        assert!(enforce_mime_limit(INLINE_MIME_LIMIT + 1, PROVIDER_MIME_LIMIT, "provider").is_ok());
+        assert!(
+            enforce_mime_limit(PROVIDER_MIME_LIMIT + 1, PROVIDER_MIME_LIMIT, "provider")
+                .unwrap_err()
+                .to_string()
+                .starts_with("resource_limit:")
+        );
+        assert!(enforce_mime_limit(INLINE_MIME_LIMIT + 1, INLINE_MIME_LIMIT, "local").is_err());
+    }
+
+    #[test]
+    fn rejects_total_part_count_across_nested_multiparts() {
+        let mut mime = String::from("Content-Type: multipart/mixed; boundary=outer\r\n\r\n");
+        for group in 0..16 {
+            mime.push_str("--outer\r\nContent-Type: multipart/mixed; boundary=inner");
+            mime.push_str(&group.to_string());
+            mime.push_str("\r\n\r\n");
+            for part in 0..16 {
+                mime.push_str("--inner");
+                mime.push_str(&group.to_string());
+                mime.push_str("\r\nContent-Type: text/plain\r\n\r\n");
+                mime.push_str(&part.to_string());
+                mime.push_str("\r\n");
+            }
+            mime.push_str("--inner");
+            mime.push_str(&group.to_string());
+            mime.push_str("--\r\n");
+        }
+        mime.push_str("--outer--\r\n");
+        let error = parse_mime(mime.as_bytes(), true, "message_ref", false).unwrap_err();
+        assert!(error
+            .to_string()
+            .starts_with("resource_limit: MIME part count"));
+    }
+
+    #[test]
+    fn truncates_normalized_text_at_utf8_boundary() {
+        let body = "a".repeat(NORMALIZED_TEXT_LIMIT - 1) + "😀tail";
+        let mime = format!("Content-Type: text/plain; charset=utf-8\r\n\r\n{body}");
+        let result = parse_mime(mime.as_bytes(), true, "message_ref", false).unwrap();
+        assert_eq!(result.text.len(), NORMALIZED_TEXT_LIMIT - 1);
+        assert!(result.text.is_char_boundary(result.text.len()));
+        assert_eq!(result.completeness, EmailBodyCompleteness::Partial);
+        assert!(result.reasons.contains(&"resource_limit".to_string()));
+    }
+
+    #[test]
+    fn legacy_is_never_complete() {
+        let result = read_local(EmailBodyReadRequest {
+            input: EmailBodyInput::LegacyMime {
+                mime_text: "Content-Type: text/plain\r\n\r\nhello".into(),
+                source_truncated: false,
+            },
+        })
+        .unwrap();
+        assert_eq!(result.completeness, EmailBodyCompleteness::Unverified);
+    }
+
+    #[test]
+    fn validates_inline_length() {
+        let error = read_local(EmailBodyReadRequest {
+            input: EmailBodyInput::InlineMime {
+                mime_base64: "aGVsbG8=".into(),
+                original_bytes: 4,
+                complete: true,
+            },
+        })
+        .unwrap_err();
+        assert!(error.to_string().contains("original_bytes"));
+    }
+
+    #[test]
+    fn message_ref_round_trips() {
+        let value = EmailMessageRef {
+            source: EmailSourceRef {
+                namespace: "n".into(),
+                source_key: "s".into(),
+                spec_key: "k".into(),
+            },
+            locator: EmailMessageLocator::Jmap {
+                account_id: "a".into(),
+                email_id: "e".into(),
+            },
+        };
+        assert_eq!(
+            decode_email_message_ref(&encode_email_message_ref(&value).unwrap()).unwrap(),
+            value
+        );
+    }
+
+    #[test]
+    fn message_ref_rejects_invalid_long_versioned_and_unknown_fields() {
+        for value in [
+            "not-a-reference".to_string(),
+            "uxc-email-v2.e30".to_string(),
+            format!("{EMAIL_MESSAGE_REF_PREFIX}***"),
+            "x".repeat(EMAIL_MESSAGE_REF_MAX_BYTES + 1),
+        ] {
+            assert!(decode_email_message_ref(&value)
+                .unwrap_err()
+                .to_string()
+                .starts_with("invalid_input:"));
+        }
+
+        let payload = serde_json::json!({
+            "source": {
+                "namespace": "n",
+                "source_key": "s",
+                "spec_key": "k",
+                "unknown": true
+            },
+            "locator": {
+                "provider": "gmail",
+                "message_id": "m"
+            }
+        });
+        let encoded = format!(
+            "{EMAIL_MESSAGE_REF_PREFIX}{}",
+            base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(serde_json::to_vec(&payload).unwrap())
+        );
+        assert!(decode_email_message_ref(&encoded)
+            .unwrap_err()
+            .to_string()
+            .starts_with("invalid_input:"));
+    }
+}

--- a/src/email_body_get.rs
+++ b/src/email_body_get.rs
@@ -1,0 +1,700 @@
+//! Provider-backed retrieval for `email.body.read` message references.
+
+use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine;
+use futures::StreamExt;
+use reqwest::{redirect::Policy, Client, Method, Response};
+use serde_json::{json, Value};
+use std::time::Duration;
+use url::Url;
+
+use crate::auth::{
+    resolve_profile_request_auth_with_context, AuthRequestContext, Profile, Profiles,
+};
+use crate::daemon::ManagedSourceSpec;
+use crate::email_body::{parse_mime, EmailBodyResult, EmailMessageLocator, EmailMessageRef};
+use crate::subscription_email::{
+    connect_imap, quote_imap_string, EmailImapIdleRuntimeConfig, ImapAuthMethod, ImapConnection,
+    ImapSectionLiteral,
+};
+
+pub(crate) const PROVIDER_RESPONSE_MAX_BYTES: usize = 16 * 1024 * 1024;
+pub(crate) const PROVIDER_DEADLINE: Duration = Duration::from_secs(30);
+
+/// Fetch and normalize the body identified by `message_ref` using the current
+/// managed-source configuration. The reference never supplies an endpoint or credentials.
+pub(crate) async fn get_email_body(
+    spec: &ManagedSourceSpec,
+    message_ref: &EmailMessageRef,
+) -> Result<EmailBodyResult> {
+    tokio::time::timeout(PROVIDER_DEADLINE, get_email_body_inner(spec, message_ref))
+        .await
+        .map_err(|_| anyhow!("timeout: email provider body retrieval exceeded 30 seconds"))?
+}
+
+async fn get_email_body_inner(
+    spec: &ManagedSourceSpec,
+    message_ref: &EmailMessageRef,
+) -> Result<EmailBodyResult> {
+    match &message_ref.locator {
+        EmailMessageLocator::Imap {
+            mailbox,
+            uid,
+            uidvalidity,
+        } => {
+            let uidvalidity = uidvalidity
+                .ok_or_else(|| anyhow!("identity_missing: IMAP message_ref has no UIDVALIDITY"))?;
+            fetch_imap(spec, mailbox, uid, uidvalidity, connect_imap).await
+        }
+        EmailMessageLocator::Gmail { message_id } => fetch_gmail(spec, message_id).await,
+        EmailMessageLocator::Graph { immutable_id } => fetch_graph(spec, immutable_id).await,
+        EmailMessageLocator::Jmap {
+            account_id,
+            email_id,
+        } => fetch_jmap(spec, account_id, email_id).await,
+    }
+}
+
+async fn fetch_imap<F>(
+    spec: &ManagedSourceSpec,
+    mailbox: &str,
+    uid: &str,
+    expected_uidvalidity: u64,
+    connector: F,
+) -> Result<EmailBodyResult>
+where
+    F: Fn(EmailImapIdleRuntimeConfig) -> crate::subscription_email::BoxFutureResult<ImapConnection>,
+{
+    if uid.is_empty() || !uid.chars().all(|ch| ch.is_ascii_digit()) {
+        bail!("invalid_input: invalid IMAP UID");
+    }
+    let profile_name = required_profile_name(spec)?;
+    let mut profile = load_profile(&profile_name)?;
+    refresh_oauth(&mut profile).await?;
+    let auth_method = imap_auth_method(&profile)?;
+    let endpoint = Url::parse(&spec.endpoint).context("invalid_input: invalid IMAP endpoint")?;
+    let use_tls = match endpoint.scheme() {
+        "imaps" => true,
+        "imap" => false,
+        _ => bail!("invalid_input: IMAP source endpoint must use imap or imaps"),
+    };
+    let host = endpoint
+        .host_str()
+        .ok_or_else(|| anyhow!("invalid_input: IMAP endpoint has no host"))?
+        .to_string();
+    let config = EmailImapIdleRuntimeConfig {
+        endpoint: spec.endpoint.clone(),
+        host,
+        port: endpoint.port().unwrap_or(if use_tls { 993 } else { 143 }),
+        use_tls,
+        auth_method: auth_method.clone(),
+        mailbox: mailbox.to_string(),
+        account: string_arg(spec, "account"),
+        auth_profile: Some(profile_name),
+        initial_fetch_limit: 0,
+        source_ref: None,
+    };
+    let mut conn = connector(config)
+        .await
+        .map_err(|_| anyhow!("provider_unavailable: IMAP connection failed"))?;
+    let result = async {
+        conn.expect_greeting()
+            .await
+            .map_err(|_| anyhow!("provider_unavailable: IMAP greeting failed"))?;
+        authenticate_imap(&mut conn, &auth_method).await?;
+        let lines = conn
+            .command_ok(&format!("EXAMINE {}", quote_imap_string(mailbox)))
+            .await
+            .map_err(|_| anyhow!("provider_unavailable: IMAP EXAMINE failed"))?;
+        let current = crate::subscription_email::parse_imap_uidvalidity(&lines)
+            .ok_or_else(|| anyhow!("identity_missing: IMAP server omitted UIDVALIDITY"))?;
+        if current != expected_uidvalidity {
+            bail!("stale: IMAP UIDVALIDITY changed");
+        }
+        let literal = conn
+            .fetch_body_section_bytes(uid, "", PROVIDER_RESPONSE_MAX_BYTES)
+            .await
+            .map_err(|_| anyhow!("provider_unavailable: IMAP BODY.PEEK fetch failed"))?;
+        let ImapSectionLiteral::Bytes(raw) = literal else {
+            bail!("not_found: IMAP message UID was not found");
+        };
+        enforce_limit(raw.len())?;
+        parse_mime(&raw, true, "message_ref", false)
+    }
+    .await;
+    let _ = conn.logout().await;
+    result
+}
+
+async fn authenticate_imap(conn: &mut ImapConnection, auth: &ImapAuthMethod) -> Result<()> {
+    let result = match auth {
+        ImapAuthMethod::Basic { username, password } => conn
+            .command_ok(&format!(
+                "LOGIN {} {}",
+                quote_imap_string(username),
+                quote_imap_string(password)
+            ))
+            .await
+            .map(|_| ()),
+        ImapAuthMethod::Xoauth2 { username, token } => {
+            conn.authenticate_xoauth2(username, token).await
+        }
+    };
+    result.map_err(|_| anyhow!("auth_required: IMAP authentication failed"))
+}
+
+async fn fetch_gmail(spec: &ManagedSourceSpec, message_id: &str) -> Result<EmailBodyResult> {
+    validate_path_id(message_id)?;
+    ensure_http_endpoint(&spec.endpoint)?;
+    ensure_provider_arg(spec, "gmail")?;
+    let url = format!(
+        "{}/{}?format=raw",
+        spec.endpoint.trim_end_matches('/'),
+        encode_path_segment(message_id)
+    );
+    let profile = load_profile(&required_profile_name(spec)?)?;
+    let value = get_json(&profile, &spec.endpoint, &url).await?;
+    if value
+        .get("id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| id != message_id)
+    {
+        bail!("stale: Gmail response id did not match message_ref");
+    }
+    let encoded = value
+        .get("raw")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("not_found: Gmail response omitted raw MIME"))?;
+    enforce_limit(encoded.len())?;
+    let raw = decode_base64url(encoded).context("parse_failed: invalid Gmail raw MIME encoding")?;
+    enforce_limit(raw.len())?;
+    parse_mime(&raw, true, "message_ref", false)
+}
+
+async fn fetch_graph(spec: &ManagedSourceSpec, immutable_id: &str) -> Result<EmailBodyResult> {
+    validate_path_id(immutable_id)?;
+    ensure_http_endpoint(&spec.endpoint)?;
+    ensure_provider_arg(spec, "graph")?;
+    let url = format!(
+        "{}/{}/$value",
+        spec.endpoint.trim_end_matches('/'),
+        encode_path_segment(immutable_id)
+    );
+    let profile = load_profile(&required_profile_name(spec)?)?;
+    let raw = get_bytes(&profile, &spec.endpoint, &url, Some("ImmutableId")).await?;
+    parse_mime(&raw, true, "message_ref", false)
+}
+
+async fn fetch_jmap(
+    spec: &ManagedSourceSpec,
+    account_id: &str,
+    email_id: &str,
+) -> Result<EmailBodyResult> {
+    validate_path_id(account_id)?;
+    validate_path_id(email_id)?;
+    ensure_http_endpoint(&spec.endpoint)?;
+    ensure_provider_arg(spec, "jmap")?;
+    let profile = load_profile(&required_profile_name(spec)?)?;
+    let body = json!({
+        "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+        "methodCalls": [["Email/get", {
+            "accountId": account_id,
+            "ids": [email_id],
+            "properties": ["id", "textBody", "htmlBody", "bodyValues"],
+            "fetchTextBodyValues": true,
+            "fetchHTMLBodyValues": true,
+            "maxBodyValueBytes": PROVIDER_RESPONSE_MAX_BYTES
+        }, "b0"]]
+    });
+    let value = request_json(
+        &profile,
+        &spec.endpoint,
+        Method::POST,
+        &spec.endpoint,
+        Some(body),
+    )
+    .await?;
+    let email = jmap_email(&value, email_id)?;
+    let (content_type, text, complete) = select_jmap_body(email)?;
+    enforce_limit(text.len())?;
+    let mime = format!("Content-Type: {content_type}; charset=utf-8\r\n\r\n{text}");
+    parse_mime(mime.as_bytes(), complete, "message_ref", false)
+}
+
+fn jmap_email<'a>(value: &'a Value, expected_id: &str) -> Result<&'a Value> {
+    let response = value
+        .get("methodResponses")
+        .and_then(Value::as_array)
+        .and_then(|items| items.first())
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("provider_unavailable: malformed JMAP response"))?;
+    if response.first().and_then(Value::as_str) != Some("Email/get") {
+        bail!("provider_unavailable: JMAP Email/get failed");
+    }
+    let payload = response
+        .get(1)
+        .ok_or_else(|| anyhow!("provider_unavailable: malformed JMAP Email/get response"))?;
+    if payload
+        .get("notFound")
+        .and_then(Value::as_array)
+        .is_some_and(|ids| ids.iter().any(|id| id.as_str() == Some(expected_id)))
+    {
+        bail!("not_found: JMAP Email id was not found");
+    }
+    let email = payload
+        .get("list")
+        .and_then(Value::as_array)
+        .and_then(|items| items.first())
+        .ok_or_else(|| anyhow!("not_found: JMAP Email/get returned no message"))?;
+    if email.get("id").and_then(Value::as_str) != Some(expected_id) {
+        bail!("stale: JMAP response id did not match message_ref");
+    }
+    Ok(email)
+}
+
+fn select_jmap_body(email: &Value) -> Result<(&'static str, String, bool)> {
+    let values = email
+        .get("bodyValues")
+        .and_then(Value::as_object)
+        .ok_or_else(|| anyhow!("not_found: JMAP response omitted bodyValues"))?;
+    for (property, content_type) in [("textBody", "text/plain"), ("htmlBody", "text/html")] {
+        if let Some(parts) = email.get(property).and_then(Value::as_array) {
+            if parts.is_empty() {
+                continue;
+            }
+            let mut texts = Vec::with_capacity(parts.len());
+            let mut complete = true;
+            for part in parts {
+                let part_id = part.get("partId").and_then(Value::as_str).ok_or_else(|| {
+                    anyhow!("provider_unavailable: JMAP body part omitted partId")
+                })?;
+                let value = values.get(part_id).ok_or_else(|| {
+                    anyhow!("not_found: JMAP bodyValues omitted a referenced body part")
+                })?;
+                let text = value
+                    .get("value")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("provider_unavailable: JMAP body value omitted text"))?;
+                let truncated = value
+                    .get("isTruncated")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                if truncated && text.is_empty() {
+                    bail!("resource_limit: JMAP body was truncated without a usable fragment");
+                }
+                complete &= !truncated;
+                texts.push(text);
+            }
+            return Ok((content_type, texts.join("\n"), complete));
+        }
+    }
+    Ok(("text/plain", String::new(), true))
+}
+
+async fn get_json(profile: &Profile, origin: &str, url: &str) -> Result<Value> {
+    request_json(profile, origin, Method::GET, url, None).await
+}
+
+async fn request_json(
+    profile: &Profile,
+    origin: &str,
+    method: Method,
+    url: &str,
+    body: Option<Value>,
+) -> Result<Value> {
+    let response = authorized_request(profile, origin, method, url, body, &[]).await?;
+    let bytes = bounded_response(response).await?;
+    serde_json::from_slice(&bytes)
+        .map_err(|_| anyhow!("provider_unavailable: provider returned invalid JSON"))
+}
+
+async fn get_bytes(
+    profile: &Profile,
+    origin: &str,
+    url: &str,
+    prefer: Option<&str>,
+) -> Result<Vec<u8>> {
+    let headers = prefer
+        .map(|value| vec![("Prefer", format!("IdType=\"{value}\""))])
+        .unwrap_or_default();
+    let response = authorized_request(profile, origin, Method::GET, url, None, &headers).await?;
+    bounded_response(response).await
+}
+
+async fn authorized_request(
+    profile: &Profile,
+    trusted_origin: &str,
+    method: Method,
+    url: &str,
+    body: Option<Value>,
+    request_headers: &[(&str, String)],
+) -> Result<Response> {
+    same_origin(trusted_origin, url)?;
+    let context = AuthRequestContext::new(method.as_str(), url);
+    let resolved = resolve_profile_request_auth_with_context(&context, profile)
+        .map_err(|_| anyhow!("auth_required: provider authentication could not be resolved"))?;
+    same_origin(trusted_origin, &resolved.url)?;
+    let client = Client::builder()
+        .redirect(Policy::none())
+        .timeout(PROVIDER_DEADLINE)
+        .build()
+        .context("provider_unavailable: failed to build HTTP client")?;
+    let mut builder = client.request(method, &resolved.url);
+    for (name, value) in &resolved.headers {
+        builder = builder.header(name.as_str(), value.as_str());
+    }
+    for (name, value) in request_headers {
+        builder = builder.header(*name, value);
+    }
+    if let Some(body) = body {
+        builder = builder.json(&body);
+    }
+    let response = builder
+        .send()
+        .await
+        .map_err(|_| anyhow!("provider_unavailable: provider request failed"))?;
+    if response.status().is_redirection() {
+        bail!("provider_unavailable: provider redirect refused");
+    }
+    match response.status().as_u16() {
+        200..=299 => Ok(response),
+        401 | 403 => bail!("auth_required: provider rejected authentication"),
+        404 | 410 => bail!("not_found: provider message was not found"),
+        429 | 500..=599 => bail!("provider_unavailable: temporary provider failure"),
+        _ => bail!("provider_unavailable: provider request failed"),
+    }
+}
+
+async fn bounded_response(response: Response) -> Result<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > PROVIDER_RESPONSE_MAX_BYTES as u64)
+    {
+        bail!("resource_limit: provider response exceeds 16 MiB");
+    }
+    bounded_stream(response.bytes_stream()).await
+}
+
+async fn bounded_stream<S, B, E>(mut stream: S) -> Result<Vec<u8>>
+where
+    S: futures::Stream<Item = std::result::Result<B, E>> + Unpin,
+    B: AsRef<[u8]>,
+{
+    let mut bytes = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk =
+            chunk.map_err(|_| anyhow!("provider_unavailable: provider response read failed"))?;
+        let chunk = chunk.as_ref();
+        if bytes.len().saturating_add(chunk.len()) > PROVIDER_RESPONSE_MAX_BYTES {
+            bail!("resource_limit: provider response exceeds 16 MiB");
+        }
+        bytes.extend_from_slice(chunk);
+    }
+    Ok(bytes)
+}
+
+fn ensure_provider_arg(spec: &ManagedSourceSpec, expected: &str) -> Result<()> {
+    let actual = string_arg(spec, "provider")
+        .ok_or_else(|| anyhow!("stale: managed source no longer declares an email provider"))?;
+    let actual_lowercase = actual.to_ascii_lowercase();
+    let normalized = match actual_lowercase.as_str() {
+        "microsoft_graph" | "msgraph" => "graph",
+        other => other,
+    };
+    if normalized != expected {
+        bail!("stale: message_ref provider does not match managed source");
+    }
+    Ok(())
+}
+
+fn required_profile_name(spec: &ManagedSourceSpec) -> Result<String> {
+    spec.options
+        .auth
+        .clone()
+        .ok_or_else(|| anyhow!("auth_required: managed source has no auth profile"))
+}
+
+fn string_arg(spec: &ManagedSourceSpec, key: &str) -> Option<String> {
+    spec.args
+        .as_ref()
+        .and_then(|args| args.get(key))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn load_profile(name: &str) -> Result<Profile> {
+    Profiles::load_profiles()
+        .map_err(|_| anyhow!("auth_required: failed to load auth profiles"))?
+        .get_profile(name)
+        .cloned()
+        .map_err(|_| anyhow!("auth_required: auth profile was not found"))
+}
+
+async fn refresh_oauth(profile: &mut Profile) -> Result<()> {
+    if profile.auth_type != crate::auth::AuthType::OAuth {
+        return Ok(());
+    }
+    let client = Client::new();
+    let refreshed = crate::auth::refresh_effective_auth_profile(
+        profile,
+        &client,
+        false,
+        crate::subscription_email::IMAP_XOAUTH2_REFRESH_SKEW_SECS,
+        None,
+    )
+    .await
+    .map_err(|_| anyhow!("auth_required: OAuth refresh failed"))?;
+    if refreshed {
+        crate::auth::persist_profile_if_named(profile)?;
+    }
+    Ok(())
+}
+
+fn imap_auth_method(profile: &Profile) -> Result<ImapAuthMethod> {
+    let first = |names: &[&str]| {
+        names
+            .iter()
+            .find_map(|name| profile.resolve_field_value(name).ok().flatten())
+    };
+    let username = first(&["username", "user", "email"])
+        .or_else(|| profile.name.clone())
+        .ok_or_else(|| anyhow!("auth_required: IMAP profile has no username"))?;
+    if profile.auth_type == crate::auth::AuthType::OAuth {
+        let token = profile
+            .oauth
+            .as_ref()
+            .and_then(|oauth| oauth.access_token.clone())
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| anyhow!("auth_required: IMAP OAuth profile has no access token"))?;
+        Ok(ImapAuthMethod::Xoauth2 { username, token })
+    } else {
+        let password = first(&["password", "app_password", "secret"])
+            .ok_or_else(|| anyhow!("auth_required: IMAP profile has no password"))?;
+        Ok(ImapAuthMethod::Basic { username, password })
+    }
+}
+
+fn ensure_http_endpoint(endpoint: &str) -> Result<()> {
+    let url = Url::parse(endpoint).context("invalid_input: invalid provider endpoint")?;
+    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+        bail!("invalid_input: provider endpoint must be an absolute HTTP URL");
+    }
+    Ok(())
+}
+
+fn same_origin(trusted: &str, candidate: &str) -> Result<()> {
+    let trusted = Url::parse(trusted).context("invalid_input: invalid trusted endpoint")?;
+    let candidate = Url::parse(candidate).context("provider_unavailable: invalid provider URL")?;
+    if trusted.scheme() != candidate.scheme()
+        || trusted.host_str() != candidate.host_str()
+        || trusted.port_or_known_default() != candidate.port_or_known_default()
+    {
+        bail!("provider_unavailable: cross-origin provider request refused");
+    }
+    Ok(())
+}
+
+fn validate_path_id(value: &str) -> Result<()> {
+    if value.is_empty() || value.chars().any(|ch| ch.is_control()) {
+        bail!("invalid_input: invalid provider message id");
+    }
+    Ok(())
+}
+
+fn encode_path_segment(value: &str) -> String {
+    url::form_urlencoded::byte_serialize(value.as_bytes()).collect()
+}
+
+fn decode_base64url(value: &str) -> Result<Vec<u8>> {
+    use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
+    let compact: String = value.chars().filter(|ch| !ch.is_whitespace()).collect();
+    URL_SAFE_NO_PAD
+        .decode(compact.trim_end_matches('='))
+        .or_else(|_| URL_SAFE.decode(compact))
+        .map_err(Into::into)
+}
+
+fn enforce_limit(length: usize) -> Result<()> {
+    if length > PROVIDER_RESPONSE_MAX_BYTES {
+        bail!("resource_limit: provider response exceeds 16 MiB");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::AuthType;
+    use mockito::Server;
+    use tokio::io::AsyncWriteExt;
+
+    fn bearer_profile() -> Profile {
+        Profile::new("test-token".to_string(), AuthType::Bearer)
+    }
+
+    #[tokio::test]
+    async fn gmail_request_fetches_and_decodes_raw_mime() {
+        let raw = b"Content-Type: text/plain; charset=utf-8\r\n\r\nhello";
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw);
+        let mut server = Server::new_async().await;
+        let endpoint = format!("{}/gmail/v1/users/me/messages", server.url());
+        let url = format!("{endpoint}/msg%2F1?format=raw");
+        let mock = server
+            .mock("GET", "/gmail/v1/users/me/messages/msg%2F1")
+            .match_query(mockito::Matcher::UrlEncoded("format".into(), "raw".into()))
+            .match_header("authorization", "Bearer test-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({"id": "msg/1", "raw": encoded}).to_string())
+            .create_async()
+            .await;
+
+        let value = get_json(&bearer_profile(), &endpoint, &url).await.unwrap();
+        mock.assert_async().await;
+        let decoded = decode_base64url(value["raw"].as_str().unwrap()).unwrap();
+        assert_eq!(decoded, raw);
+        assert_eq!(
+            parse_mime(&decoded, true, "message_ref", false)
+                .unwrap()
+                .text,
+            "hello"
+        );
+    }
+
+    #[tokio::test]
+    async fn graph_request_sends_immutable_id_preference_and_returns_mime() {
+        let mut server = Server::new_async().await;
+        let endpoint = format!("{}/v1.0/me/messages", server.url());
+        let url = format!("{endpoint}/A%2FB%2BC%3D/$value");
+        let raw = b"Content-Type: text/plain\r\n\r\ngraph body";
+        let mock = server
+            .mock("GET", "/v1.0/me/messages/A%2FB%2BC%3D/$value")
+            .match_header("authorization", "Bearer test-token")
+            .match_header("prefer", "IdType=\"ImmutableId\"")
+            .with_status(200)
+            .with_body(raw)
+            .create_async()
+            .await;
+
+        let fetched = get_bytes(&bearer_profile(), &endpoint, &url, Some("ImmutableId"))
+            .await
+            .unwrap();
+        mock.assert_async().await;
+        assert_eq!(
+            parse_mime(&fetched, true, "message_ref", false)
+                .unwrap()
+                .text,
+            "graph body"
+        );
+    }
+
+    #[test]
+    fn jmap_fixture_prefers_text_and_observes_truncation() {
+        let email = json!({
+            "id": "e1",
+            "textBody": [
+                {"partId": "p1", "type": "text/plain"},
+                {"partId": "p1b", "type": "text/plain"}
+            ],
+            "htmlBody": [{"partId": "p2", "type": "text/html"}],
+            "bodyValues": {
+                "p1": {"value": "plain", "isTruncated": true},
+                "p1b": {"value": "second", "isTruncated": false},
+                "p2": {"value": "<b>html</b>", "isTruncated": false}
+            }
+        });
+        assert_eq!(
+            select_jmap_body(&email).unwrap(),
+            ("text/plain", "plain\nsecond".into(), false)
+        );
+    }
+
+    #[test]
+    fn jmap_fixture_rejects_missing_referenced_body_value() {
+        let email = json!({
+            "id": "e1",
+            "textBody": [{"partId": "missing", "type": "text/plain"}],
+            "bodyValues": {}
+        });
+        assert!(select_jmap_body(&email)
+            .unwrap_err()
+            .to_string()
+            .starts_with("not_found:"));
+    }
+
+    #[test]
+    fn jmap_fixture_validates_email_id() {
+        let response =
+            json!({"methodResponses": [["Email/get", {"list": [{"id": "other"}]}, "b0"]]});
+        assert!(jmap_email(&response, "wanted")
+            .unwrap_err()
+            .to_string()
+            .starts_with("stale:"));
+    }
+
+    #[test]
+    fn imap_requires_uidvalidity_and_decimal_uid() {
+        assert!(enforce_limit(PROVIDER_RESPONSE_MAX_BYTES).is_ok());
+        assert!(enforce_limit(PROVIDER_RESPONSE_MAX_BYTES + 1).is_err());
+        assert!(validate_path_id("42").is_ok());
+    }
+
+    #[test]
+    fn http_auth_is_never_forwarded_cross_origin() {
+        assert!(same_origin(
+            "https://api.example.test/messages",
+            "https://api.example.test/messages/1"
+        )
+        .is_ok());
+        assert!(same_origin(
+            "https://api.example.test/messages",
+            "https://evil.example/messages/1"
+        )
+        .is_err());
+        assert!(same_origin(
+            "https://api.example.test/messages",
+            "http://api.example.test/messages/1"
+        )
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn response_limit_rejects_content_length_and_streamed_body() {
+        let oversized = PROVIDER_RESPONSE_MAX_BYTES + 1;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let writer = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            socket
+                .write_all(
+                    format!("HTTP/1.1 200 OK\r\nContent-Length: {oversized}\r\n\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+        let response = Client::new()
+            .get(format!("http://{address}/content-length"))
+            .send()
+            .await
+            .unwrap();
+        assert!(bounded_response(response)
+            .await
+            .unwrap_err()
+            .to_string()
+            .starts_with("resource_limit:"));
+        writer.await.unwrap();
+
+        let chunk = vec![b'x'; 64 * 1024];
+        let chunks = std::iter::repeat_with(|| Ok::<_, std::io::Error>(chunk.clone()))
+            .take(PROVIDER_RESPONSE_MAX_BYTES / chunk.len() + 1);
+        let error = bounded_stream(futures::stream::iter(chunks))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.starts_with("resource_limit:"),
+            "unexpected streamed response error: {error}"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ pub mod daemon_log;
 pub mod email;
 pub mod email_attachment;
 pub mod email_attachment_get;
+pub mod email_body;
+pub mod email_body_get;
 pub mod error;
 pub mod http_client;
 pub mod managed_source_streams;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ mod daemon_log;
 mod email;
 mod email_attachment;
 mod email_attachment_get;
+mod email_body;
+mod email_body_get;
 mod error;
 mod http_client;
 mod managed_source_streams;

--- a/src/subscription_email.rs
+++ b/src/subscription_email.rs
@@ -4,12 +4,16 @@ use crate::daemon_log::redact_endpoint;
 use crate::email_attachment::{
     imap_message_attachments, ImapAttachmentContext, MIME_MAX_DEPTH, MIME_MAX_PARTS,
 };
+use crate::email_body::{
+    encode_email_message_ref, parse_mime, EmailMessageLocator, EmailMessageRef, EmailSourceRef,
+};
 use crate::subscription_poll::{PollCheckpointState, PollFetchResult};
 use anyhow::{anyhow, bail, Context, Result};
 use base64::Engine;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use rustls_pki_types::ServerName;
 use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -38,6 +42,8 @@ pub const EMAIL_IMAP_MAX_INITIAL_FETCH_LIMIT: u64 = 100;
 const IMAP_ATTACHMENT_TIMEOUT_SECS: u64 = 120;
 const EMAIL_SNIPPET_CHARS: usize = 512;
 const EMAIL_RAW_INLINE_BYTES: usize = 32 * 1024;
+const EMAIL_BODY_INLINE_BYTES: usize = 32 * 1024;
+const IMAP_FETCH_RESPONSE_MAX_BYTES: usize = 16 * 1024 * 1024;
 /// Marker Microsoft Exchange servers return when IMAP basic auth is disabled
 /// for the account (typical for personal outlook.com/hotmail.com/live.com
 /// accounts). The server rejects LOGIN before credential validation, so no
@@ -61,6 +67,7 @@ pub struct EmailImapIdleRuntimeConfig {
     pub account: Option<String>,
     pub auth_profile: Option<String>,
     pub initial_fetch_limit: usize,
+    pub(crate) source_ref: Option<EmailSourceRef>,
 }
 
 /// How an `email-imap-idle` session authenticates against the IMAP server.
@@ -97,6 +104,7 @@ pub struct EmailProviderPollRuntimeConfig {
     pub mailbox: String,
     /// Auth profile name referenced by attachment handles (never credentials).
     pub auth_profile: Option<String>,
+    pub(crate) source_ref: Option<EmailSourceRef>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -176,7 +184,7 @@ pub fn resolve_email_imap_idle_runtime_config(
                 })?;
         ImapAuthMethod::Basic { username, password }
     };
-    Ok(EmailImapIdleRuntimeConfig {
+    let config = EmailImapIdleRuntimeConfig {
         endpoint: request.endpoint.clone(),
         host,
         port,
@@ -186,7 +194,20 @@ pub fn resolve_email_imap_idle_runtime_config(
         mailbox,
         account,
         initial_fetch_limit,
-    })
+        source_ref: resolve_email_source_ref(args)?,
+    };
+    Ok(config)
+}
+
+fn resolve_email_source_ref(
+    args: Option<&HashMap<String, Value>>,
+) -> Result<Option<EmailSourceRef>> {
+    let Some(value) = args.and_then(|args| args.get("_uxc_email_source_ref")) else {
+        return Ok(None);
+    };
+    serde_json::from_value(value.clone())
+        .map(Some)
+        .map_err(|_| anyhow!("invalid internal email source reference"))
 }
 
 fn resolve_first_profile_field(profile: &Profile, names: &[&str]) -> Result<Option<String>> {
@@ -621,6 +642,28 @@ fn build_email_event(
     );
     let has_attachments = !attachments.is_empty();
     let attachment_count = attachments.len();
+    let source_ref = config.source_ref.as_ref();
+    let locator = uidvalidity.map(|uidvalidity| EmailMessageLocator::Imap {
+        mailbox: config.mailbox.clone(),
+        uid: message.uid.clone(),
+        uidvalidity: Some(uidvalidity),
+    });
+    let message_ref = source_ref.and_then(|source| {
+        let locator = locator.clone()?;
+        encode_email_message_ref(&EmailMessageRef {
+            source: source.clone(),
+            locator,
+        })
+        .ok()
+    });
+    let body = parse_mime(&message.raw, true, "inline_mime", false)
+        .ok()
+        .map(limit_inline_body);
+    let stable_key = source_ref.and_then(|source| {
+        locator
+            .as_ref()
+            .map(|locator| scoped_locator_stable_key(source, locator))
+    });
     json!({
         "type": "email_event",
         "version": "v1",
@@ -628,8 +671,18 @@ fn build_email_event(
         "account": account,
         "mailbox": config.mailbox,
         "event_kind": "message_received",
+        "message_ref": message_ref,
+        "body_unavailable_reason": if body.is_none() {
+            Some("mime_parse_failed")
+        } else if message_ref.is_none() {
+            Some("reliable_provider_id_unavailable")
+        } else {
+            None
+        },
+        "body": body,
         "message": {
             "uid": message.uid,
+            "stable_key": stable_key,
             "message_id": message_id,
             "thread_id": thread_id,
             "conversation_id": null,
@@ -647,8 +700,12 @@ fn build_email_event(
         },
         "raw": {
             "mime_inline": if raw_len <= EMAIL_RAW_INLINE_BYTES { Some(raw_text.to_string()) } else { None },
+            "mime_inline_base64": if raw_len <= EMAIL_RAW_INLINE_BYTES { Some(base64::engine::general_purpose::STANDARD.encode(&message.raw)) } else { None },
             "mime_truncated": raw_len > EMAIL_RAW_INLINE_BYTES,
             "size_bytes": raw_len,
+            "original_bytes": raw_len,
+            "complete": true,
+            "representation_version": 1,
         },
         "reply_handle": {
             "type": "email_imap",
@@ -707,6 +764,7 @@ pub fn resolve_email_provider_poll_runtime_config(
         account,
         mailbox,
         auth_profile: request.options.auth.clone(),
+        source_ref: resolve_email_source_ref(args)?,
     })
 }
 
@@ -829,15 +887,21 @@ fn build_provider_email_event(config: &EmailProviderPollRuntimeConfig, item: &Va
         EmailProviderKind::Graph => "graph",
         EmailProviderKind::Jmap => "jmap",
     };
-    let uid = first_string(item, &["id", "blobId"]).unwrap_or_else(|| item.to_string());
+    let reliable_locator = provider_message_locator(config.provider, item);
+    let uid = reliable_locator
+        .as_ref()
+        .map(locator_display_key)
+        .or_else(|| first_string(item, &["id", "blobId"]));
     let message_id = match config.provider {
-        EmailProviderKind::Gmail => gmail_header(item, "Message-ID").unwrap_or_else(|| uid.clone()),
-        EmailProviderKind::Graph => {
-            first_string(item, &["internetMessageId"]).unwrap_or_else(|| uid.clone())
-        }
-        EmailProviderKind::Jmap => {
-            first_string(item, &["messageId"]).unwrap_or_else(|| uid.clone())
-        }
+        EmailProviderKind::Gmail => gmail_header(item, "Message-ID")
+            .or_else(|| uid.clone())
+            .unwrap_or_default(),
+        EmailProviderKind::Graph => first_string(item, &["internetMessageId"])
+            .or_else(|| uid.clone())
+            .unwrap_or_default(),
+        EmailProviderKind::Jmap => first_string(item, &["messageId"])
+            .or_else(|| uid.clone())
+            .unwrap_or_default(),
     };
     let subject = match config.provider {
         EmailProviderKind::Gmail => {
@@ -845,8 +909,27 @@ fn build_provider_email_event(config: &EmailProviderPollRuntimeConfig, item: &Va
         }
         _ => first_string(item, &["subject"]),
     };
-    let (attachments, has_attachments, attachment_count) =
-        provider_message_attachments(config, provider, item, &message_id, &uid);
+    let (attachments, has_attachments, attachment_count) = provider_message_attachments(
+        config,
+        provider,
+        item,
+        &message_id,
+        uid.as_deref().unwrap_or(""),
+    );
+    let message_ref = config.source_ref.as_ref().and_then(|source| {
+        reliable_locator.clone().and_then(|locator| {
+            encode_email_message_ref(&EmailMessageRef {
+                source: source.clone(),
+                locator,
+            })
+            .ok()
+        })
+    });
+    let stable_key = config.source_ref.as_ref().and_then(|source| {
+        reliable_locator
+            .as_ref()
+            .map(|locator| scoped_locator_stable_key(source, locator))
+    });
     json!({
         "type": "email_event",
         "version": "v1",
@@ -854,8 +937,12 @@ fn build_provider_email_event(config: &EmailProviderPollRuntimeConfig, item: &Va
         "account": account,
         "mailbox": config.mailbox,
         "event_kind": "message_received",
+        "message_ref": message_ref,
+        "body_unavailable_reason": if reliable_locator.is_some() { Value::Null } else { Value::String("reliable_provider_id_unavailable".to_string()) },
+        "body": Value::Null,
         "message": {
             "uid": uid,
+            "stable_key": stable_key,
             "message_id": message_id,
             "thread_id": first_string(item, &["threadId", "thread_id", "inReplyTo"]),
             "conversation_id": first_string(item, &["conversationId", "emailId"]),
@@ -873,6 +960,10 @@ fn build_provider_email_event(config: &EmailProviderPollRuntimeConfig, item: &Va
         },
         "raw": {
             "provider_payload": item,
+            "mime_inline_base64": null,
+            "original_bytes": null,
+            "complete": false,
+            "representation_version": 1,
         },
         "reply_handle": {
             "type": "email_provider",
@@ -883,6 +974,71 @@ fn build_provider_email_event(config: &EmailProviderPollRuntimeConfig, item: &Va
             "uid": uid,
         }
     })
+}
+
+fn provider_message_locator(
+    provider: EmailProviderKind,
+    item: &Value,
+) -> Option<EmailMessageLocator> {
+    match provider {
+        EmailProviderKind::Gmail => {
+            first_string(item, &["id"]).map(|message_id| EmailMessageLocator::Gmail { message_id })
+        }
+        EmailProviderKind::Graph => first_string(item, &["immutableId"])
+            .or_else(|| {
+                item.get("idIsImmutable")
+                    .and_then(Value::as_bool)
+                    .filter(|value| *value)
+                    .and_then(|_| first_string(item, &["id"]))
+            })
+            .map(|immutable_id| EmailMessageLocator::Graph { immutable_id }),
+        EmailProviderKind::Jmap => Some(EmailMessageLocator::Jmap {
+            account_id: first_string(item, &["accountId"])?,
+            email_id: first_string(item, &["id"])?,
+        }),
+    }
+}
+
+fn locator_display_key(locator: &EmailMessageLocator) -> String {
+    match locator {
+        EmailMessageLocator::Imap { uid, .. } => uid.clone(),
+        EmailMessageLocator::Gmail { message_id } => message_id.clone(),
+        EmailMessageLocator::Graph { immutable_id } => immutable_id.clone(),
+        EmailMessageLocator::Jmap {
+            account_id,
+            email_id,
+        } => format!("{account_id}:{email_id}"),
+    }
+}
+
+fn scoped_locator_stable_key(source: &EmailSourceRef, locator: &EmailMessageLocator) -> String {
+    let payload = serde_json::to_vec(&json!({
+        "version": 1,
+        "source": source,
+        "locator": locator,
+    }))
+    .expect("email stable key payload must serialize");
+    format!("{:x}", Sha256::digest(payload))
+}
+
+fn limit_inline_body(
+    mut body: crate::email_body::EmailBodyResult,
+) -> crate::email_body::EmailBodyResult {
+    if body.text.len() <= EMAIL_BODY_INLINE_BYTES {
+        return body;
+    }
+    let mut end = EMAIL_BODY_INLINE_BYTES;
+    while end > 0 && !body.text.is_char_boundary(end) {
+        end -= 1;
+    }
+    body.text.truncate(end);
+    body.bytes = body.text.len();
+    body.total_bytes = None;
+    body.completeness = crate::email_body::EmailBodyCompleteness::Partial;
+    body.reasons.push("inline_limit".to_string());
+    body.reasons.sort();
+    body.reasons.dedup();
+    body
 }
 
 /// Credential-free context used to stamp opaque provider attachment handles.
@@ -1545,6 +1701,7 @@ impl ImapConnection {
         &mut self,
         uid: &str,
         section: &str,
+        max_bytes: usize,
     ) -> Result<ImapSectionLiteral> {
         let command = format!("UID FETCH {uid} (BODY.PEEK[{section}])");
         let tag = format!("A{:04}", self.next_tag);
@@ -1563,6 +1720,12 @@ impl ImapConnection {
             if !line.contains(" FETCH ") || result != ImapSectionLiteral::Missing {
                 continue;
             }
+            let response_uid = extract_imap_atom_after(&line, "UID ")
+                .filter(|response_uid| response_uid.chars().all(|ch| ch.is_ascii_digit()))
+                .ok_or_else(|| anyhow!("IMAP FETCH response missing valid UID"))?;
+            if response_uid != uid {
+                continue;
+            }
             let Some(index) = line.find(&marker) else {
                 continue;
             };
@@ -1574,6 +1737,9 @@ impl ImapConnection {
             };
             match literal_len {
                 Some(len) => {
+                    if len > max_bytes {
+                        bail!("resource_limit: IMAP FETCH literal exceeds configured limit");
+                    }
                     let mut literal = vec![0u8; len];
                     tokio::time::timeout(
                         Duration::from_secs(IMAP_ATTACHMENT_TIMEOUT_SECS),
@@ -1624,10 +1790,57 @@ impl ImapConnection {
     }
 
     async fn fetch_uid_set(&mut self, uid_set: &str) -> Result<Vec<ImapFetchedMessage>> {
-        let lines = self
-            .command_ok(&format!("UID FETCH {uid_set} (UID FLAGS BODY.PEEK[])"))
-            .await?;
-        Ok(parse_uid_fetch_messages(&lines))
+        let tag = format!("A{:04}", self.next_tag);
+        self.next_tag = self.next_tag.saturating_add(1);
+        self.write_line(&format!(
+            "{tag} UID FETCH {uid_set} (UID FLAGS BODY.PEEK[])"
+        ))
+        .await?;
+
+        let mut messages = Vec::new();
+        let mut total_literal_bytes = 0usize;
+        loop {
+            let line = self.read_line().await?;
+            if line.starts_with(&format!("{tag} ")) {
+                if !line.contains(" OK") {
+                    bail!("IMAP command failed: {}", line);
+                }
+                break;
+            }
+            if !line.starts_with('*') || !line.contains(" FETCH ") {
+                continue;
+            }
+            let uid = extract_imap_atom_after(&line, "UID ")
+                .filter(|uid| uid.chars().all(|ch| ch.is_ascii_digit()))
+                .ok_or_else(|| anyhow!("IMAP FETCH response missing valid UID"))?;
+            if !imap_uid_set_contains(uid_set, &uid) {
+                bail!("IMAP FETCH response UID does not match request");
+            }
+            let flags = extract_imap_parenthesized_after(&line, "FLAGS ")
+                .map(|raw| raw.split_whitespace().map(str::to_string).collect())
+                .unwrap_or_default();
+            let raw = if let Some(len) = trailing_literal_len(&line) {
+                total_literal_bytes = total_literal_bytes
+                    .checked_add(len)
+                    .filter(|total| *total <= IMAP_FETCH_RESPONSE_MAX_BYTES)
+                    .ok_or_else(|| anyhow!("resource_limit: IMAP FETCH response exceeds 16 MiB"))?;
+                let mut literal = vec![0u8; len];
+                tokio::time::timeout(
+                    Duration::from_secs(IMAP_LITERAL_TIMEOUT_SECS),
+                    self.reader.read_exact(&mut literal),
+                )
+                .await
+                .context("IMAP literal read timed out")??;
+                let _suffix = self.read_line().await?;
+                literal
+            } else {
+                extract_imap_literal_or_quoted_body(&line)
+                    .unwrap_or_default()
+                    .into_bytes()
+            };
+            messages.push(ImapFetchedMessage { uid, flags, raw });
+        }
+        Ok(messages)
     }
 
     async fn start_idle(&mut self) -> Result<String> {
@@ -1664,6 +1877,9 @@ impl ImapConnection {
     }
 }
 
+// Retained for compatibility and focused parser tests. Production fetching now
+// reads IMAP literals as bytes directly to avoid lossy UTF-8 round-tripping.
+#[allow(dead_code)]
 pub fn parse_uid_fetch_messages(lines: &[String]) -> Vec<ImapFetchedMessage> {
     let mut out = Vec::new();
     for line in lines {
@@ -1707,6 +1923,29 @@ fn trailing_literal_len(line: &str) -> Option<usize> {
         return None;
     }
     len.parse().ok()
+}
+
+fn imap_uid_set_contains(uid_set: &str, uid: &str) -> bool {
+    let Ok(uid) = uid.parse::<u64>() else {
+        return false;
+    };
+    uid_set.split(',').any(|part| {
+        if let Some((start, end)) = part.split_once(':') {
+            let Ok(start) = start.parse::<u64>() else {
+                return false;
+            };
+            let end = if end == "*" {
+                u64::MAX
+            } else if let Ok(end) = end.parse::<u64>() {
+                end
+            } else {
+                return false;
+            };
+            uid >= start.min(end) && uid <= start.max(end)
+        } else {
+            part.parse::<u64>().is_ok_and(|requested| requested == uid)
+        }
+    })
 }
 
 fn extract_imap_atom_after(line: &str, marker: &str) -> Option<String> {
@@ -1771,6 +2010,7 @@ mod tests {
             mailbox: "INBOX".to_string(),
             account: Some("primary".to_string()),
             initial_fetch_limit: 25,
+            source_ref: None,
         };
         let message = ImapFetchedMessage {
             uid: "42".to_string(),
@@ -1806,6 +2046,7 @@ mod tests {
             mailbox: "INBOX".to_string(),
             account: Some("primary".to_string()),
             initial_fetch_limit: 25,
+            source_ref: None,
         };
         let raw = concat!(
             "Message-ID: <m42@example.com>\r\n",
@@ -1870,6 +2111,7 @@ mod tests {
             account: Some("gmail-primary".to_string()),
             mailbox: "INBOX".to_string(),
             auth_profile: None,
+            source_ref: None,
         };
         let raw = json!({
             "messages": [{
@@ -1905,6 +2147,7 @@ mod tests {
             account: None,
             mailbox: "Inbox".to_string(),
             auth_profile: None,
+            source_ref: None,
         };
         let graph_raw = json!({
             "value": [{
@@ -1933,6 +2176,7 @@ mod tests {
             account: Some("jmap-primary".to_string()),
             mailbox: "Inbox".to_string(),
             auth_profile: None,
+            source_ref: None,
         };
         let jmap_raw = json!({
             "list": [{
@@ -1963,6 +2207,7 @@ mod tests {
             account: Some("gmail-primary".to_string()),
             mailbox: "INBOX".to_string(),
             auth_profile: Some("gmail-primary".to_string()),
+            source_ref: None,
         };
         let raw = json!({
             "messages": [{
@@ -2037,6 +2282,7 @@ mod tests {
             account: None,
             mailbox: "Inbox".to_string(),
             auth_profile: None,
+            source_ref: None,
         };
         let expanded = json!({
             "value": [{
@@ -2107,6 +2353,7 @@ mod tests {
             account: Some("jmap-primary".to_string()),
             mailbox: "INBOX".to_string(),
             auth_profile: None,
+            source_ref: None,
         };
         let raw = json!({
             "list": [{
@@ -2217,6 +2464,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn imap_fetch_preserves_non_utf8_literal_bytes() {
+        let raw = b"Subject: binary\r\n\r\n\xff\x00\x80".to_vec();
+        let (client, server) = tokio::io::duplex(2048);
+        let mut conn = ImapConnection::new(Box::new(client));
+        let expected = raw.clone();
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut command = String::new();
+            reader.read_line(&mut command).await.unwrap();
+            writer
+                .write_all(
+                    format!("* 1 FETCH (UID 42 FLAGS () BODY[] {{{}}}\r\n", raw.len()).as_bytes(),
+                )
+                .await
+                .unwrap();
+            writer.write_all(&raw).await.unwrap();
+            writer
+                .write_all(b")\r\nA0001 OK fetch done\r\n")
+                .await
+                .unwrap();
+        });
+
+        let messages = conn.fetch_uid_set("42").await.unwrap();
+        server.await.unwrap();
+        assert_eq!(messages[0].raw, expected);
+    }
+
+    #[tokio::test]
+    async fn imap_fetch_rejects_oversized_literal_before_allocation() {
+        let (client, server) = tokio::io::duplex(2048);
+        let mut conn = ImapConnection::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut command = String::new();
+            reader.read_line(&mut command).await.unwrap();
+            writer
+                .write_all(
+                    format!(
+                        "* 1 FETCH (UID 42 FLAGS () BODY[] {{{}}}\r\n",
+                        IMAP_FETCH_RESPONSE_MAX_BYTES + 1
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+
+        let error = conn.fetch_uid_set("42").await.unwrap_err();
+        server.await.unwrap();
+        assert!(error.to_string().contains("exceeds 16 MiB"));
+    }
+
+    #[tokio::test]
+    async fn imap_fetch_rejects_unrequested_response_uid() {
+        let (client, server) = tokio::io::duplex(2048);
+        let mut conn = ImapConnection::new(Box::new(client));
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut command = String::new();
+            reader.read_line(&mut command).await.unwrap();
+            writer
+                .write_all(b"* 1 FETCH (UID 43 FLAGS () BODY[] \"body\")\r\n")
+                .await
+                .unwrap();
+        });
+
+        let error = conn.fetch_uid_set("42").await.unwrap_err();
+        server.await.unwrap();
+        assert!(error.to_string().contains("does not match request"));
+    }
+
+    #[tokio::test]
     async fn fetch_recent_searches_all_uids_and_fetches_last_limit() {
         let (client, server) = tokio::io::duplex(4096);
         let mut conn = ImapConnection::new(Box::new(client));
@@ -2303,6 +2625,7 @@ mod tests {
             mailbox: "INBOX".to_string(),
             account: None,
             initial_fetch_limit,
+            source_ref: None,
         }
     }
 
@@ -2680,6 +3003,7 @@ mod tests {
             mailbox: "INBOX".to_string(),
             account: Some("primary".to_string()),
             initial_fetch_limit: 25,
+            source_ref: None,
         };
         let mut recorder = RecordingRecorder::default();
         let (_stop_tx, mut stop_rx) = watch::channel(false);


### PR DESCRIPTION
## What

- add a unified, bounded email body model and MIME parser with explicit completeness metadata
- preserve IMAP literals losslessly and emit stable internal string `message_ref` values for managed email sources
- implement read-only body retrieval for IMAP, Gmail, Microsoft Graph, and JMAP
- expose `email.body.get` through daemon capabilities plus the Rust and TypeScript daemon clients
- bind references to persisted source configuration and non-secret account identity so stale or mismatched references fail safely

## Why

Email events previously exposed inconsistent provider-specific body data, while downstream integrations had no reliable way to retrieve a complete normalized body. This adds a single UXC-owned contract without exposing provider credentials or requiring downstream MIME/provider workarounds.

## How

- parse inline/raw MIME under strict input, nesting, part-count, and output budgets
- validate managed source identity and configuration fingerprints before provider retrieval
- enforce bounded provider responses, deadlines, concurrency, cancellation, IMAP literal allocation limits, and target UID checks
- retrieve without changing read state and normalize provider results through the same parser
- keep `message_ref` as an internal integration contract rather than an agent-facing identifier

## Testing

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test -- --test-threads=1`
- `npm test --prefix packages/uxc-daemon-client`
- `npm run build --prefix packages/uxc-daemon-client`

Closes #463