### PR TITLE
feat(email): add attachment daemon RPC

### DIFF
--- a/packages/uxc-daemon-client/src/index.ts
+++ b/packages/uxc-daemon-client/src/index.ts
@@ -206,6 +206,27 @@ export interface EmailBodyResult {
   provenance: EmailBodyProvenance;
 }
 
+export interface EmailAttachmentGetArgs {
+  handle: unknown;
+  outputPath: string;
+  profile?: string;
+  maxBytes?: number;
+}
+
+export interface EmailAttachmentGetResult {
+  provider: string;
+  account?: string | null;
+  mailbox?: string | null;
+  message_id?: string | null;
+  uid?: string | null;
+  attachment_id: string;
+  filename?: string | null;
+  content_type?: string | null;
+  size_bytes: number;
+  sha256: string;
+  saved_path: string;
+}
+
 export interface EmailBodyCapability {
   schema_version: number;
   parser_version: string;
@@ -378,6 +399,7 @@ export class DaemonRpcError extends Error {
     message: string,
     readonly code: number,
     readonly method: string,
+    readonly data?: unknown,
   ) {
     super(message);
     this.name = "DaemonRpcError";
@@ -478,6 +500,20 @@ export class UxcDaemonClient {
   async emailBodyRead(args: EmailBodyReadArgs): Promise<EmailBodyResult> {
     return this.request("email.body.read", {
       input: emailBodyInputParams(args.input),
+    });
+  }
+
+  async emailAttachmentGet(
+    args: EmailAttachmentGetArgs,
+  ): Promise<EmailAttachmentGetResult> {
+    if (args.outputPath.length === 0) {
+      throw new Error("emailAttachmentGet requires outputPath");
+    }
+    return this.request("email.attachment.get", {
+      handle: emailAttachmentHandleParam(args.handle),
+      output: args.outputPath,
+      ...(args.profile === undefined ? {} : { profile: args.profile }),
+      ...(args.maxBytes === undefined ? {} : { max_bytes: args.maxBytes }),
     });
   }
 
@@ -640,6 +676,7 @@ export class UxcDaemonClient {
               parsed.message.error.message,
               parsed.message.error.code,
               method,
+              parsed.message.error.data,
             ),
           );
           return;
@@ -1140,6 +1177,17 @@ function emailBodyInputParams(input: EmailBodyInput): Record<string, unknown> {
   }
 }
 
+function emailAttachmentHandleParam(handle: unknown): string {
+  if (typeof handle === "string") {
+    return handle;
+  }
+  const serialized = JSON.stringify(handle);
+  if (serialized === undefined) {
+    throw new Error("emailAttachmentGet handle must be JSON-serializable");
+  }
+  return serialized;
+}
+
 function bestEffortUserLabel(env: NodeJS.ProcessEnv | undefined): string {
   const raw = env?.USER ?? env?.USERNAME ?? "unknown";
   const filtered = raw.replace(/[^A-Za-z0-9_-]/g, "_");
@@ -1160,6 +1208,7 @@ function tryParseFrame(buffer: Buffer<ArrayBufferLike>): {
     error?: {
       code: number;
       message: string;
+      data?: unknown;
     };
   };
   remaining: Buffer<ArrayBufferLike>;
@@ -1184,6 +1233,7 @@ function tryParseFrame(buffer: Buffer<ArrayBufferLike>): {
     error?: {
       code: number;
       message: string;
+      data?: unknown;
     };
   };
   return {

--- a/packages/uxc-daemon-client/test/client.test.ts
+++ b/packages/uxc-daemon-client/test/client.test.ts
@@ -322,6 +322,60 @@ describe("UxcDaemonClient", () => {
     });
   });
 
+  test("emailAttachmentGet serializes an opaque handle and controlled output path", async () => {
+    const stub = new UxcDaemonClient({ autoStart: false });
+    const calls: Array<{ method: string; params: unknown }> = [];
+    (stub as unknown as { request: (method: string, params?: unknown) => Promise<unknown> }).request = async (
+      method,
+      params,
+    ) => {
+      calls.push({ method, params });
+      return {
+        provider: "imap",
+        attachment_id: "2",
+        size_bytes: 5,
+        sha256: "abc",
+        saved_path: "/tmp/staging/attachment",
+      };
+    };
+    const handle = {
+      type: "email_attachment",
+      provider: "imap",
+      endpoint: "imaps://example.invalid",
+      part: { section: "2" },
+    };
+
+    const response = await stub.emailAttachmentGet({
+      handle,
+      outputPath: "/tmp/staging/attachment",
+      profile: "mail",
+      maxBytes: 1024,
+    });
+
+    expect(response.saved_path).toBe("/tmp/staging/attachment");
+    expect(calls).toEqual([
+      {
+        method: "email.attachment.get",
+        params: {
+          handle: JSON.stringify(handle),
+          output: "/tmp/staging/attachment",
+          profile: "mail",
+          max_bytes: 1024,
+        },
+      },
+    ]);
+  });
+
+  test("emailAttachmentGet requires a controlled output path", async () => {
+    const stub = new UxcDaemonClient({ autoStart: false });
+    await expect(
+      stub.emailAttachmentGet({
+        handle: {},
+        outputPath: "",
+      }),
+    ).rejects.toThrow("emailAttachmentGet requires outputPath");
+  });
+
   test("call executes OpenAPI operations without CLI envelope parsing", async () => {
     const server = createOpenApiServer();
     await server.start();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -78,6 +78,7 @@ use tokio::task::JoinHandle;
 
 const JSONRPC_VERSION: &str = "2.0";
 const EMAIL_BODY_DEADLINE: Duration = Duration::from_secs(30);
+const EMAIL_ATTACHMENT_DEADLINE: Duration = Duration::from_secs(30);
 const EMAIL_BODY_GLOBAL_LIMIT: usize = 4;
 const EMAIL_BODY_QUEUE_LIMIT: usize = 32;
 const EMAIL_BODY_SOURCE_LIMIT: usize = 2;
@@ -4482,6 +4483,37 @@ impl DaemonRuntime {
         .map_err(|_| anyhow!("timeout: email body retrieval exceeded 30 seconds"))?
     }
 
+    async fn get_email_attachment(
+        &self,
+        request: crate::email_attachment_get::EmailAttachmentGetRequest,
+    ) -> Result<crate::email_attachment_get::EmailAttachmentGetResult> {
+        let output = request
+            .output
+            .as_deref()
+            .filter(|output| !output.is_empty())
+            .ok_or_else(|| {
+                StructuredError::new(
+                    "invalid_output",
+                    "daemon attachment retrieval requires an output path",
+                    None,
+                )
+            })?;
+        if !Path::new(output).is_absolute() {
+            return Err(StructuredError::new(
+                "invalid_output",
+                "daemon attachment output path must be absolute",
+                None,
+            )
+            .into());
+        }
+        tokio::time::timeout(
+            EMAIL_ATTACHMENT_DEADLINE,
+            crate::email_attachment_get::get_email_attachment(&request),
+        )
+        .await
+        .map_err(|_| anyhow!("timeout: email attachment retrieval exceeded 30 seconds"))?
+    }
+
     fn initialize_logger() -> Option<DaemonLogger> {
         let dir = daemon_dir();
         match DaemonLogger::new(&dir) {
@@ -7212,6 +7244,23 @@ pub async fn email_body_read_client(
 }
 
 #[cfg(unix)]
+#[allow(dead_code)]
+pub async fn email_attachment_get_client(
+    request: &crate::email_attachment_get::EmailAttachmentGetRequest,
+) -> Result<crate::email_attachment_get::EmailAttachmentGetResult> {
+    let value = client_call("email.attachment.get", Some(serde_json::to_value(request)?)).await?;
+    Ok(serde_json::from_value(value)?)
+}
+
+#[cfg(not(unix))]
+#[allow(dead_code)]
+pub async fn email_attachment_get_client(
+    _request: &crate::email_attachment_get::EmailAttachmentGetRequest,
+) -> Result<crate::email_attachment_get::EmailAttachmentGetResult> {
+    bail!("Daemon email attachment retrieval is only supported on Unix")
+}
+
+#[cfg(unix)]
 pub async fn daemon_sessions_client() -> Result<Vec<DaemonSessionView>> {
     let value = client_call("daemon.sessions", None).await?;
     Ok(serde_json::from_value(value)?)
@@ -7951,6 +8000,41 @@ async fn handle_connection(mut stream: UnixStream, runtime: Arc<DaemonRuntime>) 
                     id: req.id,
                     result: None,
                     error: Some(email_body_read_jsonrpc_error(&err)),
+                },
+            }
+        }
+        "email.attachment.get" => {
+            let Some(params) = req.params else {
+                write_jsonrpc_error(&mut stream, req.id, -32602, "Missing params".to_string())
+                    .await?;
+                return Ok(());
+            };
+            let request: crate::email_attachment_get::EmailAttachmentGetRequest =
+                match serde_json::from_value(params) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        write_jsonrpc_error(
+                            &mut stream,
+                            req.id,
+                            -32602,
+                            format!("Invalid params: {err}"),
+                        )
+                        .await?;
+                        return Ok(());
+                    }
+                };
+            match runtime.get_email_attachment(request).await {
+                Ok(result) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: Some(serde_json::to_value(result)?),
+                    error: None,
+                },
+                Err(err) => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION.to_string(),
+                    id: req.id,
+                    result: None,
+                    error: Some(email_attachment_get_jsonrpc_error(&err)),
                 },
             }
         }
@@ -10027,6 +10111,48 @@ fn email_body_read_jsonrpc_error(err: &anyhow::Error) -> JsonRpcError {
     }
 }
 
+fn email_attachment_get_jsonrpc_error(err: &anyhow::Error) -> JsonRpcError {
+    const NON_RETRYABLE: &[&str] = &[
+        "invalid_attachment_handle",
+        "invalid_output",
+        "auth_profile_missing",
+        "auth_failed",
+        "attachment_not_found",
+        "message_not_found",
+        "uid_invalid",
+        "size_limit_exceeded",
+    ];
+    const RETRYABLE: &[&str] = &["provider_request_failed", "timeout"];
+
+    let structured = structured_error_from_anyhow(err);
+    let structured_code = structured.as_ref().map(|payload| payload.code.as_str());
+    let error_text = err.to_string();
+    let prefix = error_text.split_once(':').map(|(prefix, _)| prefix);
+    let candidate = structured_code.or(prefix);
+    let (code, retryable) = if let Some(code) = candidate {
+        if NON_RETRYABLE.contains(&code) {
+            (code, false)
+        } else if RETRYABLE.contains(&code) {
+            (code, true)
+        } else {
+            ("provider_request_failed", true)
+        }
+    } else {
+        ("provider_request_failed", true)
+    };
+    let payload = StructuredErrorPayload {
+        code: code.to_string(),
+        message: "Email attachment retrieval failed".to_string(),
+        details: Some(json!({ "retryable": retryable })),
+    };
+
+    JsonRpcError {
+        code: ERR_RUNTIME_GENERIC,
+        message: payload.message.clone(),
+        data: serde_json::to_value(payload).ok(),
+    }
+}
+
 impl Default for DaemonRuntime {
     fn default() -> Self {
         Self::new()
@@ -10212,6 +10338,52 @@ mod tests {
         assert_eq!(payload.code, "provider_unavailable");
         assert_eq!(payload.details, Some(json!({ "retryable": true })));
         assert_eq!(error.message, "Email body read failed");
+    }
+
+    #[test]
+    fn email_attachment_get_errors_have_stable_redacted_payloads() {
+        for (code, retryable) in [
+            ("invalid_attachment_handle", false),
+            ("invalid_output", false),
+            ("auth_profile_missing", false),
+            ("auth_failed", false),
+            ("attachment_not_found", false),
+            ("message_not_found", false),
+            ("uid_invalid", false),
+            ("size_limit_exceeded", false),
+            ("provider_request_failed", true),
+            ("timeout", true),
+        ] {
+            let secret = "secret endpoint https://user:password@example.invalid";
+            let error = email_attachment_get_jsonrpc_error(&anyhow!("{code}: {secret}"));
+            let payload: StructuredErrorPayload =
+                serde_json::from_value(error.data.unwrap()).unwrap();
+            assert_eq!(payload.code, code);
+            assert_eq!(payload.message, "Email attachment retrieval failed");
+            assert_eq!(payload.details, Some(json!({ "retryable": retryable })));
+            assert!(!error.message.contains(secret));
+            assert!(!payload.message.contains(secret));
+        }
+    }
+
+    #[tokio::test]
+    async fn email_attachment_get_requires_an_absolute_output_path() {
+        let temp = tempdir().unwrap();
+        let runtime =
+            DaemonRuntime::try_new_with_managed_source_base_dir(temp.path().to_path_buf()).unwrap();
+        for output in [None, Some("relative/path".to_string())] {
+            let err = runtime
+                .get_email_attachment(crate::email_attachment_get::EmailAttachmentGetRequest {
+                    handle: "{}".to_string(),
+                    profile: None,
+                    output,
+                    max_bytes: crate::email_attachment_get::DEFAULT_MAX_ATTACHMENT_BYTES,
+                })
+                .await
+                .unwrap_err();
+            let payload = structured_error_from_anyhow(&err).unwrap();
+            assert_eq!(payload.code, "invalid_output");
+        }
     }
 
     #[tokio::test]

--- a/src/email_attachment_get.rs
+++ b/src/email_attachment_get.rs
@@ -11,7 +11,7 @@
 
 use anyhow::{Context, Result};
 use base64::Engine;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
@@ -34,16 +34,23 @@ const ATTACHMENT_CACHE_DIR: &str = "email-attachments";
 const JMAP_MAIL_CAPABILITY: &str = "urn:ietf:params:jmap:mail";
 
 /// CLI request for lazy attachment retrieval.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmailAttachmentGetRequest {
     /// Raw JSON handle (or `@path` to read the handle from a file).
     pub handle: String,
     /// Auth profile override; takes precedence over the handle reference.
+    #[serde(default)]
     pub profile: Option<String>,
     /// Explicit output path; defaults to a cache path.
+    #[serde(default)]
     pub output: Option<String>,
     /// Reject attachments larger than this many bytes; 0 disables the limit.
+    #[serde(default = "default_max_attachment_bytes")]
     pub max_bytes: u64,
+}
+
+const fn default_max_attachment_bytes() -> u64 {
+    DEFAULT_MAX_ATTACHMENT_BYTES
 }
 
 /// Parsed and validated `email_attachment` handle.
@@ -101,7 +108,7 @@ impl AttachmentPart {
 }
 
 /// Successful retrieval result (mirrors the JSON envelope data payload).
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EmailAttachmentGetResult {
     pub provider: String,
     pub account: Option<String>,


### PR DESCRIPTION
## What

- add an `email.attachment.get` daemon RPC that reuses the existing attachment retrieval core
- require an explicit absolute output path and keep provider attachment handles opaque
- expose the RPC through `@holon-run/uxc-daemon-client`
- return stable, redacted attachment error codes from the daemon boundary

## Why

AgentInbox #239 needs to materialize email attachments on demand without shelling out to the UXC CLI or exposing provider-specific retrieval details. This RPC provides the prerequisite managed boundary for that work.

Related: https://github.com/holon-run/agentinbox/issues/239

## How

- derive serde contracts from the existing attachment request/result types
- route daemon requests through `get_email_attachment()` with the standard operation timeout
- validate output paths before retrieval
- add typed TypeScript request/result/error handling and protocol tests

## Testing

- `cargo test email_attachment_get -- --test-threads=1` (14 passed)
- `npm --workspace packages/uxc-daemon-client run build`
- `npm --workspace packages/uxc-daemon-client test` (26 passed)
- `cargo clippy --lib --bins -- -D warnings`
- `cargo test -- --test-threads=1`
- `cargo fmt -- --check`

`cargo clippy --all-targets -- -D warnings` remains blocked by pre-existing test-only warnings also present on `origin/main` (primarily needless borrows in protocol contract tests plus existing mock/dead-code warnings). No warning originates from this PR's changed files.
