### PR TITLE
docs: sync daemon, email, schema-mapping, and telegram skill references

### DIFF
--- a/docs/site/daemon/api.md
+++ b/docs/site/daemon/api.md
@@ -16,6 +16,10 @@ UXC exposes a stable local daemon control plane over a Unix socket using
 - `stream.read`
 - `stream.info`
 - `stream.trim`
+- `email.send`
+- `email.reply`
+- `email.body.read`
+- `email.attachment.get`
 
 ## Transport
 
@@ -45,6 +49,37 @@ Typical request shape:
   "limit": 100
 }
 ```
+
+## Email RPCs
+
+Email operations share the same JSON-RPC surface. `email.send`, `email.reply`,
+and `email.attachment.get` mirror the `uxc email` CLI commands.
+`email.body.read` is daemon-only: local app integrations use it to extract
+normalized message text.
+
+- `email.send` sends a new message over SMTP. Params mirror the CLI flags:
+  `smtp_url`, `from`, `to`/`cc`/`bcc`, `subject`, `text`/`html`, plus an
+  optional `auth` profile and a caller-supplied `message_id` for outbound
+  idempotency.
+- `email.reply` flattens the same send params and accepts the `reply_handle`
+  JSON carried by an `email_event` envelope.
+- `email.body.read` takes one `input`:
+  - `inline_mime`: `mime_base64` payload with `original_bytes` and `complete`
+  - `legacy_mime`: inline `mime_text` with optional `source_truncated`
+  - `message_ref`: opaque provider message reference
+
+  Results return normalized plain text with a `completeness` value
+  (`complete`, `partial`, or `unverified`) and parser provenance. Size limits
+  and the read deadline are advertised in `daemon.status` under `email_body`.
+- `email.attachment.get` downloads an attachment referenced by an
+  `email_attachment` handle. Params: `handle` (raw handle JSON or `@file`),
+  optional `profile` override, optional `output` path (defaults to the
+  attachment cache), and `max_bytes` (`0` disables the limit). Results include
+  `saved_path`, `size_bytes`, and `sha256`.
+
+The TypeScript client exposes these as `emailSend`, `emailReply`,
+`emailBodyRead`, and `emailAttachmentGet`; see
+[Generated TypeScript Clients](../ecosystem/typescript-client.md).
 
 ## TypeScript Client
 

--- a/docs/site/daemon/index.md
+++ b/docs/site/daemon/index.md
@@ -34,6 +34,12 @@ which does not inherit env vars exported in the invoking shell; see
 [Secret Sources](../auth/secret-sources.md) for the boundary and recommended
 alternatives.
 
+The daemon self-terminates when it detects that its state directory or socket
+has disappeared (for example, after a state cleanup), so stale daemons do not
+linger on reused sockets. Set `UXC_DAEMON_IDLE_TIMEOUT_SECS` to a positive
+number of seconds to shut the daemon down after that much idle time; this is
+mainly useful for short-lived test harnesses that may skip teardown.
+
 <!-- INDEX:START -->
 
 - [Daemon API](./api.md)

--- a/docs/site/ecosystem/typescript-client.md
+++ b/docs/site/ecosystem/typescript-client.md
@@ -42,6 +42,42 @@ const source = await runtime.generateTypeScriptClient({
 The generated client targets the UXC daemon/runtime surface rather than a
 protocol-native direct client.
 
+## Daemon Email RPC Helpers
+
+The package also ships typed helpers for the daemon email RPCs:
+
+```ts
+import { UxcDaemonClient } from "@holon-run/uxc-daemon-client";
+
+const runtime = new UxcDaemonClient();
+
+const body = await runtime.emailBodyRead({
+  input: { kind: "inline_mime", mimeBase64, originalBytes, complete: true },
+});
+// body.text holds normalized plain text; body.completeness reports
+// "complete" | "partial" | "unverified".
+
+const attachment = await runtime.emailAttachmentGet({
+  handle,
+  outputPath: "/tmp/report.pdf",
+});
+
+await runtime.emailSend({
+  smtpUrl: "smtp://smtp.example.com:587",
+  from: "bot@example.com",
+  to: ["user@example.com"],
+  subject: "Hello",
+  text: "Hi",
+});
+```
+
+- `emailBodyRead` normalizes MIME or provider payloads into plain text.
+- `emailAttachmentGet` requires a controlled absolute output path and rejects
+  attachments larger than `maxBytes` when set.
+- `emailReply` sends an SMTP reply using an `email_event` reply handle.
+
+See [Daemon API](../daemon/api.md) for the RPC-level contract.
+
 ## Current V1 Boundaries
 
 The first emitter generation keeps a narrow scope:

--- a/docs/site/reference/schema-mapping.md
+++ b/docs/site/reference/schema-mapping.md
@@ -35,6 +35,20 @@ Typical fields:
 - `priority`
 - `enabled`
 
+## Builtin Mappings
+
+UXC ships builtin host-to-schema mappings that apply when neither the CLI
+override nor a user mapping matches:
+
+| Host | Schema |
+| --- | --- |
+| `api.github.com` | `github/rest-api-description` `api.github.com.json` |
+| `api.telegram.org` | curated Telegram Bot API schema from this repository's `telegram-openapi-skill` |
+
+For example, `uxc https://api.telegram.org -h` resolves the curated Telegram
+schema automatically; no `--schema-url` override is required. A user mapping
+for the same host overrides the builtin rule (see Matching Rules below).
+
 ## Matching Rules
 
 - host matching is exact and case-insensitive

--- a/skills/telegram-openapi-skill/SKILL.md
+++ b/skills/telegram-openapi-skill/SKILL.md
@@ -64,7 +64,10 @@ uxc auth binding match https://api.telegram.org/getMe
 1. Use the fixed link command by default:
    - `command -v telegram-openapi-cli`
    - If missing, create it:
-     `uxc link telegram-openapi-cli https://api.telegram.org --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/telegram-openapi-skill/references/telegram-bot.openapi.json`
+     `uxc link telegram-openapi-cli https://api.telegram.org`
+     UXC resolves the curated Telegram Bot API schema through its builtin host
+     mapping. Pass `--schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/telegram-openapi-skill/references/telegram-bot.openapi.json`
+     only when pinning a specific schema revision.
    - `telegram-openapi-cli -h`
 
 2. Inspect operation schema first:

--- a/skills/telegram-openapi-skill/SKILL.md
+++ b/skills/telegram-openapi-skill/SKILL.md
@@ -66,8 +66,9 @@ uxc auth binding match https://api.telegram.org/getMe
    - If missing, create it:
      `uxc link telegram-openapi-cli https://api.telegram.org`
      UXC resolves the curated Telegram Bot API schema through its builtin host
-     mapping. Pass `--schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/telegram-openapi-skill/references/telegram-bot.openapi.json`
-     only when pinning a specific schema revision.
+    mapping. To pin an explicit schema revision instead of the builtin mapping,
+    create the link with:
+    `uxc link telegram-openapi-cli https://api.telegram.org --schema-url https://raw.githubusercontent.com/holon-run/uxc/main/skills/telegram-openapi-skill/references/telegram-bot.openapi.json`
    - `telegram-openapi-cli -h`
 
 2. Inspect operation schema first:


### PR DESCRIPTION
## What

Catch up documentation and skill material with the changes merged since v0.20.0:

- **daemon/api.md**: add `email.send`, `email.reply`, `email.body.read`, `email.attachment.get` to the Current Methods list (stale since #443) and document their request shapes, including the three `email.body.read` input kinds and the `daemon.status` `email_body` capability block.
- **daemon/index.md**: document daemon orphan self-termination (state dir/socket disappearance) and the optional `UXC_DAEMON_IDLE_TIMEOUT_SECS` idle shutdown (#462).
- **reference/schema-mapping.md**: enumerate builtin mappings, including the new `api.telegram.org` rule (#461).
- **ecosystem/typescript-client.md**: document the daemon email RPC helpers (`emailSend`, `emailReply`, `emailBodyRead`, `emailAttachmentGet`) added in #443/#464/#465.
- **skills/telegram-openapi-skill/SKILL.md**: link command now relies on the builtin host mapping; `--schema-url` kept as an explicit override for pinning a schema revision (#461).

## Why

The recent series of updates (#461, #462, #464, #465) shipped code and tests but did not sync user-facing docs or the telegram skill, leaving daemon RPC references, lifecycle env vars, and the builtin mapping list stale.

## How

Markdown-only changes plus one skill instruction update; no code changes.

## Testing

- `mdorigin build index --root docs/site` passes (9 index files regenerated, no content drift).
- `docs:build` full run is blocked locally by a pre-existing glibc limitation (indexbind prebuilt requires GLIBC 2.39); CI docs build covers it.

Follow-ups #461 #462 #464 #465